### PR TITLE
feat: Add maintenance dashboard for cleanup

### DIFF
--- a/packages/api/src/app.module.ts
+++ b/packages/api/src/app.module.ts
@@ -10,6 +10,7 @@ import { Device } from './devices/devices.entity'
 import { DevicesModule } from './devices/devices.module'
 import { LogEntry } from './logs/logs.entity'
 import { LogsModule } from './logs/logs.module'
+import { MaintenanceModule } from './maintenance/maintenance.module'
 import { MashupConfiguration } from './mashup/entities/mashup-configuration.entity'
 import { MashupSlot } from './mashup/entities/mashup-slot.entity'
 import { MashupModule } from './mashup/mashup.module'
@@ -63,6 +64,7 @@ const conf = config()
     DevicesModule,
     PluginsModule,
     MashupModule,
+    MaintenanceModule,
   ],
 })
 export class AppModule {}

--- a/packages/api/src/maintenance/__test__/maintenance.controller.spec.ts
+++ b/packages/api/src/maintenance/__test__/maintenance.controller.spec.ts
@@ -1,0 +1,142 @@
+import type { CleanupResult, MaintenanceIssues, MaintenanceService } from '../maintenance.service'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { MaintenanceController } from '../maintenance.controller'
+
+describe('maintenanceController', () => {
+  let controller: MaintenanceController
+  let service: MaintenanceService
+
+  beforeEach(() => {
+    service = {
+      scan: vi.fn(),
+      cleanup: vi.fn(),
+      getStats: vi.fn(),
+    } as any
+
+    controller = new MaintenanceController(service)
+  })
+
+  describe('scan', () => {
+    it('calls service.scan and returns issues', async () => {
+      const mockIssues: MaintenanceIssues = {
+        orphanedScreenFiles: [],
+        orphanedDeviceDirs: [],
+        brokenScreens: [],
+        tempFiles: [],
+        oldUploads: [],
+        totalSize: 0,
+        scannedAt: new Date().toISOString(),
+      }
+
+      vi.mocked(service.scan).mockResolvedValue(mockIssues)
+
+      const result = await controller.scan()
+
+      expect(service.scan).toHaveBeenCalled()
+      expect(result).toBe(mockIssues)
+    })
+  })
+
+  describe('cleanup', () => {
+    it('calls service.cleanup with provided parameters', async () => {
+      const mockResult: CleanupResult = {
+        filesDeleted: 5,
+        dirsDeleted: 2,
+        screensDeleted: 1,
+        bytesFreed: 10240,
+        errors: [],
+      }
+
+      vi.mocked(service.cleanup).mockResolvedValue(mockResult)
+
+      const dto = {
+        orphanedFiles: ['/path/to/file.png'],
+        orphanedDirs: ['/path/to/dir'],
+        brokenScreens: ['screen-1'],
+        tempFiles: ['/path/to/temp'],
+        oldUploads: ['/path/to/upload.zip'],
+        dryRun: false,
+      }
+
+      const result = await controller.cleanup(dto)
+
+      expect(service.cleanup).toHaveBeenCalledWith(
+        dto.orphanedFiles,
+        dto.orphanedDirs,
+        dto.brokenScreens,
+        dto.tempFiles,
+        dto.oldUploads,
+        dto.dryRun,
+      )
+      expect(result).toBe(mockResult)
+    })
+
+    it('defaults to empty arrays and false for missing parameters', async () => {
+      const mockResult: CleanupResult = {
+        filesDeleted: 0,
+        dirsDeleted: 0,
+        screensDeleted: 0,
+        bytesFreed: 0,
+        errors: [],
+      }
+
+      vi.mocked(service.cleanup).mockResolvedValue(mockResult)
+
+      const dto = {}
+
+      await controller.cleanup(dto)
+
+      expect(service.cleanup).toHaveBeenCalledWith(
+        [],
+        [],
+        [],
+        [],
+        [],
+        false,
+      )
+    })
+
+    it('passes dryRun parameter correctly', async () => {
+      const mockResult: CleanupResult = {
+        filesDeleted: 0,
+        dirsDeleted: 0,
+        screensDeleted: 0,
+        bytesFreed: 0,
+        errors: [],
+      }
+
+      vi.mocked(service.cleanup).mockResolvedValue(mockResult)
+
+      const dto = {
+        dryRun: true,
+      }
+
+      await controller.cleanup(dto)
+
+      expect(service.cleanup).toHaveBeenCalledWith(
+        [],
+        [],
+        [],
+        [],
+        [],
+        true,
+      )
+    })
+  })
+
+  describe('getStats', () => {
+    it('calls service.getStats and returns stats', async () => {
+      const mockStats = {
+        fileCount: 42,
+        totalSize: 1024000,
+      }
+
+      vi.mocked(service.getStats).mockResolvedValue(mockStats)
+
+      const result = await controller.getStats()
+
+      expect(service.getStats).toHaveBeenCalled()
+      expect(result).toBe(mockStats)
+    })
+  })
+})

--- a/packages/api/src/maintenance/__test__/maintenance.service.spec.ts
+++ b/packages/api/src/maintenance/__test__/maintenance.service.spec.ts
@@ -1,0 +1,423 @@
+import type { Device } from '../../devices/devices.entity'
+import type { Screen } from '../../screens/screens.entity'
+import * as fs from 'node:fs'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { MaintenanceService } from '../maintenance.service'
+
+vi.mock('../../utils/pathHelper', () => ({
+  resolveAppPath: vi.fn((...parts: string[]) => `/mock/${parts.join('/')}`),
+}))
+
+function createMockRepo() {
+  return {
+    find: vi.fn(),
+    findOne: vi.fn(),
+    findOneBy: vi.fn(),
+    create: vi.fn(),
+    save: vi.fn(),
+    update: vi.fn(),
+    remove: vi.fn(),
+    delete: vi.fn(),
+  }
+}
+
+describe('maintenanceService', () => {
+  let service: MaintenanceService
+  let deviceRepo: ReturnType<typeof createMockRepo>
+  let screenRepo: ReturnType<typeof createMockRepo>
+
+  beforeEach(() => {
+    deviceRepo = createMockRepo()
+    screenRepo = createMockRepo()
+    service = new MaintenanceService(
+      deviceRepo as any,
+      screenRepo as any,
+    )
+    vi.resetAllMocks()
+  })
+
+  describe('scan', () => {
+    it('returns empty issues when no devices exist', async () => {
+      deviceRepo.find.mockResolvedValue([])
+      screenRepo.find.mockResolvedValue([])
+      vi.spyOn(fs.promises, 'stat').mockRejectedValue(new Error('ENOENT'))
+
+      const result = await service.scan()
+
+      expect(result.orphanedScreenFiles).toEqual([])
+      expect(result.orphanedDeviceDirs).toEqual([])
+      expect(result.brokenScreens).toEqual([])
+      expect(result.tempFiles).toEqual([])
+      expect(result.oldUploads).toEqual([])
+      expect(result.totalSize).toBe(0)
+    })
+
+    it('detects orphaned screen files', async () => {
+      const device = { id: 'device-1' } as Device
+      deviceRepo.find.mockResolvedValue([device])
+      screenRepo.find.mockResolvedValue([])
+
+      vi.spyOn(fs.promises, 'stat').mockImplementation(async (path: any) => {
+        if (path === '/mock/public/screens/devices')
+          return { isDirectory: () => true } as any
+        if (path === '/mock/public/screens/devices/device-1')
+          return { isDirectory: () => true } as any
+        if (path === '/mock/public/screens/devices/device-1/orphaned-123.png')
+          return { isDirectory: () => false, size: 1024, mtimeMs: Date.now() } as any
+        throw new Error('ENOENT')
+      })
+
+      vi.spyOn(fs.promises, 'readdir').mockImplementation(async (path: any) => {
+        if (path === '/mock/public/screens/devices')
+          return ['device-1'] as any
+        if (path === '/mock/public/screens/devices/device-1')
+          return ['orphaned-123.png'] as any
+        return [] as any
+      })
+
+      const result = await service.scan()
+
+      expect(result.orphanedScreenFiles).toHaveLength(1)
+      expect(result.orphanedScreenFiles[0]).toMatchObject({
+        deviceId: 'device-1',
+        screenId: 'orphaned-123',
+        size: 1024,
+      })
+    })
+
+    it('detects orphaned device directories', async () => {
+      deviceRepo.find.mockResolvedValue([])
+      screenRepo.find.mockResolvedValue([])
+
+      vi.spyOn(fs.promises, 'stat').mockImplementation(async (path: any) => {
+        if (path === '/mock/public/screens/devices')
+          return { isDirectory: () => true } as any
+        if (path === '/mock/public/screens/devices/orphaned-device')
+          return { isDirectory: () => true } as any
+        if (path === '/mock/public/screens/devices/orphaned-device/screen.png')
+          return { isDirectory: () => false, size: 2048, mtimeMs: Date.now() } as any
+        throw new Error('ENOENT')
+      })
+
+      vi.spyOn(fs.promises, 'readdir').mockImplementation(async (path: any, _options?: any) => {
+        if (path === '/mock/public/screens/devices')
+          return ['orphaned-device'] as any
+        if (path === '/mock/public/screens/devices/orphaned-device')
+          return [{ name: 'screen.png', isDirectory: () => false }] as any
+        return [] as any
+      })
+
+      const result = await service.scan()
+
+      expect(result.orphanedDeviceDirs).toHaveLength(1)
+      expect(result.orphanedDeviceDirs[0]).toMatchObject({
+        deviceId: 'orphaned-device',
+        fileCount: 1,
+        size: 2048,
+      })
+    })
+
+    it('detects broken screens', async () => {
+      const device = { id: 'device-1' } as Device
+      const screen = {
+        id: 'screen-1',
+        device,
+        filename: 'missing.png',
+        type: 'file',
+      } as Screen
+
+      deviceRepo.find.mockResolvedValue([device])
+      screenRepo.find.mockResolvedValue([screen])
+
+      vi.spyOn(fs.promises, 'stat').mockImplementation(async (path: any) => {
+        if (path === '/mock/public/screens/devices')
+          return { isDirectory: () => true } as any
+        if (path === '/mock/public/screens/devices/device-1')
+          return { isDirectory: () => true } as any
+        throw new Error('ENOENT')
+      })
+
+      vi.spyOn(fs.promises, 'readdir').mockImplementation(async (path: any) => {
+        if (path === '/mock/public/screens/devices')
+          return ['device-1'] as any
+        return [] as any
+      })
+
+      vi.spyOn(fs.promises, 'access').mockRejectedValue(new Error('ENOENT'))
+
+      const result = await service.scan()
+
+      expect(result.brokenScreens).toHaveLength(1)
+      expect(result.brokenScreens[0]).toMatchObject({
+        screenId: 'screen-1',
+        deviceId: 'device-1',
+        filename: 'missing.png',
+        type: 'file',
+      })
+    })
+
+    it('detects temp files older than threshold', async () => {
+      const device = { id: 'device-1' } as Device
+      deviceRepo.find.mockResolvedValue([device])
+      screenRepo.find.mockResolvedValue([])
+
+      const oldDate = Date.now() - (25 * 60 * 60 * 1000)
+
+      vi.spyOn(fs.promises, 'stat').mockImplementation(async (path: any) => {
+        if (path === '/mock/public/screens/devices')
+          return { isDirectory: () => true } as any
+        if (path === '/mock/public/screens/devices/device-1')
+          return { isDirectory: () => true } as any
+        if (path === '/mock/public/screens/devices/device-1/tmp-source')
+          return { isDirectory: () => false, size: 512, mtimeMs: oldDate } as any
+        throw new Error('ENOENT')
+      })
+
+      vi.spyOn(fs.promises, 'readdir').mockImplementation(async (path: any) => {
+        if (path === '/mock/public/screens/devices')
+          return ['device-1'] as any
+        if (path === '/mock/public/screens/devices/device-1')
+          return ['tmp-source'] as any
+        return [] as any
+      })
+
+      const result = await service.scan()
+
+      expect(result.tempFiles).toHaveLength(1)
+      expect(result.tempFiles[0]).toMatchObject({
+        path: '/mock/public/screens/devices/device-1/tmp-source',
+        size: 512,
+      })
+      expect(result.tempFiles[0].age).toBeGreaterThan(24)
+    })
+
+    it('ignores mirror.png files', async () => {
+      const device = { id: 'device-1' } as Device
+      deviceRepo.find.mockResolvedValue([device])
+      screenRepo.find.mockResolvedValue([])
+
+      vi.spyOn(fs.promises, 'stat').mockImplementation(async (path: any) => {
+        if (path === '/mock/public/screens/devices')
+          return { isDirectory: () => true } as any
+        if (path === '/mock/public/screens/devices/device-1')
+          return { isDirectory: () => true } as any
+        if (path === '/mock/public/screens/devices/device-1/mirror.png')
+          return { isDirectory: () => false, size: 1024, mtimeMs: Date.now() } as any
+        throw new Error('ENOENT')
+      })
+
+      vi.spyOn(fs.promises, 'readdir').mockImplementation(async (path: any) => {
+        if (path === '/mock/public/screens/devices')
+          return ['device-1'] as any
+        if (path === '/mock/public/screens/devices/device-1')
+          return ['mirror.png'] as any
+        return [] as any
+      })
+
+      const result = await service.scan()
+
+      expect(result.orphanedScreenFiles).toHaveLength(0)
+    })
+
+    it('skips plugin and mashup screens when checking for broken screens', async () => {
+      const device = { id: 'device-1' } as Device
+      const pluginScreen = {
+        id: 'screen-1',
+        device,
+        type: 'plugin',
+      } as Screen
+      const mashupScreen = {
+        id: 'screen-2',
+        device,
+        type: 'mashup',
+      } as Screen
+
+      deviceRepo.find.mockResolvedValue([device])
+      screenRepo.find.mockResolvedValue([pluginScreen, mashupScreen])
+
+      vi.spyOn(fs.promises, 'stat').mockImplementation(async (path: any) => {
+        if (path === '/mock/public/screens/devices')
+          return { isDirectory: () => true } as any
+        if (path === '/mock/public/screens/devices/device-1')
+          return { isDirectory: () => true } as any
+        throw new Error('ENOENT')
+      })
+
+      vi.spyOn(fs.promises, 'readdir').mockImplementation(async (path: any) => {
+        if (path === '/mock/public/screens/devices')
+          return ['device-1'] as any
+        return [] as any
+      })
+
+      const result = await service.scan()
+
+      expect(result.brokenScreens).toHaveLength(0)
+    })
+  })
+
+  describe('cleanup', () => {
+    it('deletes orphaned files in non-dry-run mode', async () => {
+      const unlinkMock = vi.spyOn(fs.promises, 'unlink').mockResolvedValue(undefined)
+      vi.spyOn(fs.promises, 'stat').mockResolvedValue({ size: 1024 } as any)
+
+      const result = await service.cleanup(
+        ['/mock/public/screens/devices/device-1/orphaned.png'],
+        [],
+        [],
+        [],
+        [],
+        false,
+      )
+
+      expect(unlinkMock).toHaveBeenCalledWith('/mock/public/screens/devices/device-1/orphaned.png')
+      expect(result.filesDeleted).toBe(1)
+      expect(result.bytesFreed).toBe(1024)
+    })
+
+    it('does not delete files in dry-run mode', async () => {
+      const unlinkMock = vi.spyOn(fs.promises, 'unlink').mockResolvedValue(undefined)
+      vi.spyOn(fs.promises, 'stat').mockResolvedValue({ size: 1024 } as any)
+
+      const result = await service.cleanup(
+        ['/mock/public/screens/devices/device-1/orphaned.png'],
+        [],
+        [],
+        [],
+        [],
+        true,
+      )
+
+      expect(unlinkMock).not.toHaveBeenCalled()
+      expect(result.filesDeleted).toBe(1)
+      expect(result.bytesFreed).toBe(1024)
+    })
+
+    it('protects system files from deletion', async () => {
+      const unlinkMock = vi.spyOn(fs.promises, 'unlink').mockResolvedValue(undefined)
+      vi.spyOn(fs.promises, 'stat').mockResolvedValue({ size: 1024 } as any)
+
+      const result = await service.cleanup(
+        ['/mock/public/screens/devices/noScreen.png'],
+        [],
+        [],
+        [],
+        [],
+        false,
+      )
+
+      expect(unlinkMock).not.toHaveBeenCalled()
+      expect(result.filesDeleted).toBe(0)
+      expect(result.errors).toHaveLength(1)
+      expect(result.errors[0]).toContain('Protected system file')
+    })
+
+    it('validates paths before deletion', async () => {
+      const unlinkMock = vi.spyOn(fs.promises, 'unlink').mockResolvedValue(undefined)
+
+      const result = await service.cleanup(
+        ['../../../etc/passwd'],
+        [],
+        [],
+        [],
+        [],
+        false,
+      )
+
+      expect(unlinkMock).not.toHaveBeenCalled()
+      expect(result.filesDeleted).toBe(0)
+      expect(result.errors).toHaveLength(1)
+      expect(result.errors[0]).toContain('Unsafe path')
+    })
+
+    it('deletes orphaned directories recursively', async () => {
+      const rmMock = vi.spyOn(fs.promises, 'rm').mockResolvedValue(undefined)
+      vi.spyOn(fs.promises, 'readdir').mockResolvedValue([{ name: 'file.png', isDirectory: () => false }] as any)
+      vi.spyOn(fs.promises, 'stat').mockResolvedValue({ size: 2048 } as any)
+
+      const result = await service.cleanup(
+        [],
+        ['/mock/public/screens/devices/orphaned-device'],
+        [],
+        [],
+        [],
+        false,
+      )
+
+      expect(rmMock).toHaveBeenCalledWith('/mock/public/screens/devices/orphaned-device', { recursive: true, force: true })
+      expect(result.dirsDeleted).toBe(1)
+      expect(result.bytesFreed).toBe(2048)
+    })
+
+    it('deletes broken screens from database', async () => {
+      const result = await service.cleanup(
+        [],
+        [],
+        ['screen-1', 'screen-2'],
+        [],
+        [],
+        false,
+      )
+
+      expect(screenRepo.delete).toHaveBeenCalledWith('screen-1')
+      expect(screenRepo.delete).toHaveBeenCalledWith('screen-2')
+      expect(result.screensDeleted).toBe(2)
+    })
+
+    it('handles deletion errors gracefully', async () => {
+      vi.spyOn(fs.promises, 'unlink').mockRejectedValue(new Error('Permission denied'))
+      vi.spyOn(fs.promises, 'stat').mockResolvedValue({ size: 1024 } as any)
+
+      const result = await service.cleanup(
+        ['/mock/public/screens/devices/device-1/orphaned.png'],
+        [],
+        [],
+        [],
+        [],
+        false,
+      )
+
+      expect(result.filesDeleted).toBe(0)
+      expect(result.errors).toHaveLength(1)
+      expect(result.errors[0]).toContain('Permission denied')
+    })
+  })
+
+  describe('getStats', () => {
+    it('returns stats for devices directory', async () => {
+      vi.spyOn(fs.promises, 'stat').mockImplementation(async (path: any) => {
+        if (path === '/mock/public/screens/devices')
+          return { isDirectory: () => true } as any
+        return { isDirectory: () => false, size: 1024 } as any
+      })
+
+      vi.spyOn(fs.promises, 'readdir').mockImplementation(async (path: any, _options?: any) => {
+        if (path === '/mock/public/screens/devices') {
+          return [
+            { name: 'device-1', isDirectory: () => true },
+          ] as any
+        }
+        if (path === '/mock/public/screens/devices/device-1') {
+          return [
+            { name: 'screen-1.png', isDirectory: () => false },
+            { name: 'screen-2.png', isDirectory: () => false },
+          ] as any
+        }
+        return [] as any
+      })
+
+      const result = await service.getStats()
+
+      expect(result.fileCount).toBe(2)
+      expect(result.totalSize).toBe(2048)
+    })
+
+    it('returns zero stats when directory does not exist', async () => {
+      vi.spyOn(fs.promises, 'stat').mockRejectedValue(new Error('ENOENT'))
+
+      const result = await service.getStats()
+
+      expect(result.fileCount).toBe(0)
+      expect(result.totalSize).toBe(0)
+    })
+  })
+})

--- a/packages/api/src/maintenance/dto/cleanup.dto.ts
+++ b/packages/api/src/maintenance/dto/cleanup.dto.ts
@@ -1,0 +1,27 @@
+import { IsArray, IsBoolean, IsOptional } from 'class-validator'
+
+export class CleanupDto {
+  @IsArray()
+  @IsOptional()
+  orphanedFiles?: string[]
+
+  @IsArray()
+  @IsOptional()
+  orphanedDirs?: string[]
+
+  @IsArray()
+  @IsOptional()
+  brokenScreens?: string[]
+
+  @IsArray()
+  @IsOptional()
+  tempFiles?: string[]
+
+  @IsArray()
+  @IsOptional()
+  oldUploads?: string[]
+
+  @IsBoolean()
+  @IsOptional()
+  dryRun?: boolean
+}

--- a/packages/api/src/maintenance/maintenance.controller.ts
+++ b/packages/api/src/maintenance/maintenance.controller.ts
@@ -1,0 +1,36 @@
+import { Body, Controller, Get, Logger, Post, UsePipes, ValidationPipe } from '@nestjs/common'
+import { CleanupDto } from './dto/cleanup.dto'
+import { CleanupResult, MaintenanceIssues, MaintenanceService } from './maintenance.service'
+
+@Controller('maintenance')
+export class MaintenanceController {
+  private readonly logger = new Logger(MaintenanceController.name)
+
+  constructor(private readonly maintenanceService: MaintenanceService) {}
+
+  @Get('scan')
+  async scan(): Promise<MaintenanceIssues> {
+    this.logger.log('Scan requested')
+    return this.maintenanceService.scan()
+  }
+
+  @Post('cleanup')
+  @UsePipes(new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true }))
+  async cleanup(@Body() cleanupDto: CleanupDto): Promise<CleanupResult> {
+    this.logger.log('Cleanup requested')
+    return this.maintenanceService.cleanup(
+      cleanupDto.orphanedFiles || [],
+      cleanupDto.orphanedDirs || [],
+      cleanupDto.brokenScreens || [],
+      cleanupDto.tempFiles || [],
+      cleanupDto.oldUploads || [],
+      cleanupDto.dryRun || false,
+    )
+  }
+
+  @Get('stats')
+  async getStats(): Promise<{ fileCount: number, totalSize: number }> {
+    this.logger.log('Stats requested')
+    return this.maintenanceService.getStats()
+  }
+}

--- a/packages/api/src/maintenance/maintenance.module.ts
+++ b/packages/api/src/maintenance/maintenance.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common'
+import { TypeOrmModule } from '@nestjs/typeorm'
+import { Device } from '../devices/devices.entity'
+import { Screen } from '../screens/screens.entity'
+import { MaintenanceController } from './maintenance.controller'
+import { MaintenanceService } from './maintenance.service'
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Device, Screen])],
+  controllers: [MaintenanceController],
+  providers: [MaintenanceService],
+})
+export class MaintenanceModule {}

--- a/packages/api/src/maintenance/maintenance.service.ts
+++ b/packages/api/src/maintenance/maintenance.service.ts
@@ -1,0 +1,375 @@
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { Injectable, Logger } from '@nestjs/common'
+import { InjectRepository } from '@nestjs/typeorm'
+import { Repository } from 'typeorm'
+import { Device } from '../devices/devices.entity'
+import { Screen } from '../screens/screens.entity'
+import { resolveAppPath } from '../utils/pathHelper'
+
+export interface OrphanedScreenFile {
+  deviceId: string
+  screenId: string
+  path: string
+  size: number
+}
+
+export interface OrphanedDeviceDir {
+  deviceId: string
+  path: string
+  fileCount: number
+  size: number
+}
+
+export interface BrokenScreen {
+  screenId: string
+  deviceId: string
+  filename: string
+  type: string
+}
+
+export interface TempFile {
+  path: string
+  age: number
+  size: number
+}
+
+export interface MaintenanceIssues {
+  orphanedScreenFiles: OrphanedScreenFile[]
+  orphanedDeviceDirs: OrphanedDeviceDir[]
+  brokenScreens: BrokenScreen[]
+  tempFiles: TempFile[]
+  oldUploads: TempFile[]
+  totalSize: number
+  scannedAt: string
+}
+
+export interface CleanupResult {
+  filesDeleted: number
+  dirsDeleted: number
+  screensDeleted: number
+  bytesFreed: number
+  errors: string[]
+}
+
+const SYSTEM_FILES = new Set([
+  'noScreen.png',
+  'error.png',
+  'welcome.png',
+  'colormap-2bit.png',
+])
+
+const TEMP_FILE_THRESHOLD_HOURS = 24
+
+@Injectable()
+export class MaintenanceService {
+  private readonly logger = new Logger(MaintenanceService.name)
+
+  constructor(
+    @InjectRepository(Device)
+    private deviceRepository: Repository<Device>,
+    @InjectRepository(Screen)
+    private screenRepository: Repository<Screen>,
+  ) {}
+
+  async scan(): Promise<MaintenanceIssues> {
+    this.logger.log('Starting maintenance scan')
+
+    const orphanedScreenFiles: OrphanedScreenFile[] = []
+    const orphanedDeviceDirs: OrphanedDeviceDir[] = []
+    const brokenScreens: BrokenScreen[] = []
+    const tempFiles: TempFile[] = []
+    const oldUploads: TempFile[] = []
+
+    const devices = await this.deviceRepository.find()
+    const screens = await this.screenRepository.find({ relations: ['device'] })
+
+    const devicesPath = resolveAppPath('public', 'screens', 'devices')
+
+    if (await this.directoryExists(devicesPath)) {
+      const deviceDirs = await fs.promises.readdir(devicesPath)
+
+      for (const deviceDir of deviceDirs) {
+        const devicePath = path.join(devicesPath, deviceDir)
+        const stat = await fs.promises.stat(devicePath)
+
+        if (!stat.isDirectory())
+          continue
+
+        const device = devices.find(d => d.id === deviceDir)
+
+        if (!device) {
+          const { fileCount, size } = await this.getDirectoryStats(devicePath)
+          orphanedDeviceDirs.push({
+            deviceId: deviceDir,
+            path: devicePath,
+            fileCount,
+            size,
+          })
+          continue
+        }
+
+        const files = await fs.promises.readdir(devicePath)
+
+        for (const file of files) {
+          const filePath = path.join(devicePath, file)
+          const fileStat = await fs.promises.stat(filePath)
+
+          if (fileStat.isDirectory())
+            continue
+
+          if (file === 'mirror.png')
+            continue
+
+          if (this.isTempFile(file)) {
+            const ageHours = (Date.now() - fileStat.mtimeMs) / (1000 * 60 * 60)
+            if (ageHours > TEMP_FILE_THRESHOLD_HOURS) {
+              tempFiles.push({
+                path: filePath,
+                age: ageHours,
+                size: fileStat.size,
+              })
+            }
+            continue
+          }
+
+          const screenId = file.replace('.png', '')
+          const screen = screens.find(s => s.id === screenId && s.device.id === deviceDir)
+
+          if (!screen && file.endsWith('.png')) {
+            orphanedScreenFiles.push({
+              deviceId: deviceDir,
+              screenId,
+              path: filePath,
+              size: fileStat.size,
+            })
+          }
+        }
+      }
+    }
+
+    for (const screen of screens) {
+      const expectedPath = resolveAppPath('public', 'screens', 'devices', screen.device.id, `${screen.id}.png`)
+
+      if (screen.type !== 'plugin' && screen.type !== 'mashup' && !screen.externalLink && !(await this.fileExists(expectedPath))) {
+        brokenScreens.push({
+          screenId: screen.id,
+          deviceId: screen.device.id,
+          filename: screen.filename || 'unknown',
+          type: screen.type,
+        })
+      }
+    }
+
+    const uploadsPath = resolveAppPath('uploads')
+    if (await this.directoryExists(uploadsPath)) {
+      const uploadFiles = await fs.promises.readdir(uploadsPath)
+
+      for (const file of uploadFiles) {
+        const filePath = path.join(uploadsPath, file)
+        const stat = await fs.promises.stat(filePath)
+
+        if (stat.isDirectory())
+          continue
+
+        const ageHours = (Date.now() - stat.mtimeMs) / (1000 * 60 * 60)
+        if (ageHours > TEMP_FILE_THRESHOLD_HOURS) {
+          oldUploads.push({
+            path: filePath,
+            age: ageHours,
+            size: stat.size,
+          })
+        }
+      }
+    }
+
+    const totalSize = [
+      ...orphanedScreenFiles.map(f => f.size),
+      ...orphanedDeviceDirs.map(d => d.size),
+      ...tempFiles.map(f => f.size),
+      ...oldUploads.map(f => f.size),
+    ].reduce((sum, size) => sum + size, 0)
+
+    this.logger.log(`Scan complete. Found ${orphanedScreenFiles.length} orphaned files, ${orphanedDeviceDirs.length} orphaned dirs, ${brokenScreens.length} broken screens`)
+
+    return {
+      orphanedScreenFiles,
+      orphanedDeviceDirs,
+      brokenScreens,
+      tempFiles,
+      oldUploads,
+      totalSize,
+      scannedAt: new Date().toISOString(),
+    }
+  }
+
+  async cleanup(
+    orphanedFiles: string[],
+    orphanedDirs: string[],
+    brokenScreens: string[],
+    tempFiles: string[],
+    oldUploads: string[],
+    dryRun: boolean = false,
+  ): Promise<CleanupResult> {
+    this.logger.log(`Starting cleanup (dryRun: ${dryRun})`)
+
+    const result: CleanupResult = {
+      filesDeleted: 0,
+      dirsDeleted: 0,
+      screensDeleted: 0,
+      bytesFreed: 0,
+      errors: [],
+    }
+
+    for (const filePath of orphanedFiles) {
+      if (!this.isPathSafe(filePath)) {
+        result.errors.push(`Unsafe path: ${filePath}`)
+        continue
+      }
+
+      const filename = path.basename(filePath)
+      if (SYSTEM_FILES.has(filename)) {
+        result.errors.push(`Protected system file: ${filename}`)
+        continue
+      }
+
+      try {
+        const stat = await fs.promises.stat(filePath)
+        if (!dryRun) {
+          await fs.promises.unlink(filePath)
+          this.logger.log(`Deleted orphaned file: ${filePath}`)
+        }
+        result.filesDeleted++
+        result.bytesFreed += stat.size
+      }
+      catch (err) {
+        result.errors.push(`Failed to delete ${filePath}: ${err.message}`)
+      }
+    }
+
+    for (const filePath of [...tempFiles, ...oldUploads]) {
+      if (!this.isPathSafe(filePath)) {
+        result.errors.push(`Unsafe path: ${filePath}`)
+        continue
+      }
+
+      try {
+        const stat = await fs.promises.stat(filePath)
+        if (!dryRun) {
+          await fs.promises.unlink(filePath)
+          this.logger.log(`Deleted temp file: ${filePath}`)
+        }
+        result.filesDeleted++
+        result.bytesFreed += stat.size
+      }
+      catch (err) {
+        result.errors.push(`Failed to delete ${filePath}: ${err.message}`)
+      }
+    }
+
+    for (const dirPath of orphanedDirs) {
+      if (!this.isPathSafe(dirPath)) {
+        result.errors.push(`Unsafe path: ${dirPath}`)
+        continue
+      }
+
+      try {
+        const { size } = await this.getDirectoryStats(dirPath)
+        if (!dryRun) {
+          await fs.promises.rm(dirPath, { recursive: true, force: true })
+          this.logger.log(`Deleted orphaned directory: ${dirPath}`)
+        }
+        result.dirsDeleted++
+        result.bytesFreed += size
+      }
+      catch (err) {
+        result.errors.push(`Failed to delete ${dirPath}: ${err.message}`)
+      }
+    }
+
+    for (const screenId of brokenScreens) {
+      try {
+        if (!dryRun) {
+          await this.screenRepository.delete(screenId)
+          this.logger.log(`Deleted broken screen: ${screenId}`)
+        }
+        result.screensDeleted++
+      }
+      catch (err) {
+        result.errors.push(`Failed to delete screen ${screenId}: ${err.message}`)
+      }
+    }
+
+    this.logger.log(`Cleanup complete. Deleted ${result.filesDeleted} files, ${result.dirsDeleted} dirs, ${result.screensDeleted} screens. Freed ${result.bytesFreed} bytes`)
+
+    return result
+  }
+
+  async getStats(): Promise<{ fileCount: number, totalSize: number }> {
+    const devicesPath = resolveAppPath('public', 'screens', 'devices')
+
+    if (!(await this.directoryExists(devicesPath))) {
+      return { fileCount: 0, totalSize: 0 }
+    }
+
+    const { fileCount, size } = await this.getDirectoryStats(devicesPath)
+
+    return { fileCount, totalSize: size }
+  }
+
+  private async fileExists(path: string): Promise<boolean> {
+    try {
+      await fs.promises.access(path, fs.constants.F_OK)
+      return true
+    }
+    catch {
+      return false
+    }
+  }
+
+  private async directoryExists(path: string): Promise<boolean> {
+    try {
+      const stat = await fs.promises.stat(path)
+      return stat.isDirectory()
+    }
+    catch {
+      return false
+    }
+  }
+
+  private async getDirectoryStats(dirPath: string): Promise<{ fileCount: number, size: number }> {
+    let fileCount = 0
+    let size = 0
+
+    const entries = await fs.promises.readdir(dirPath, { withFileTypes: true })
+
+    for (const entry of entries) {
+      const fullPath = path.join(dirPath, entry.name)
+
+      if (entry.isDirectory()) {
+        const subStats = await this.getDirectoryStats(fullPath)
+        fileCount += subStats.fileCount
+        size += subStats.size
+      }
+      else {
+        const stat = await fs.promises.stat(fullPath)
+        fileCount++
+        size += stat.size
+      }
+    }
+
+    return { fileCount, size }
+  }
+
+  private isTempFile(filename: string): boolean {
+    return filename === 'tmp-source'
+      || filename.endsWith('-source')
+      || filename.startsWith('tmp-')
+  }
+
+  private isPathSafe(filePath: string): boolean {
+    const normalized = path.normalize(filePath)
+    return !normalized.includes('..')
+      && (normalized.includes('public/screens/devices') || normalized.includes('uploads'))
+  }
+}

--- a/packages/ui/src/stores/__tests__/maintenance.spec.ts
+++ b/packages/ui/src/stores/__tests__/maintenance.spec.ts
@@ -1,0 +1,291 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useMaintenanceStore } from '../maintenance'
+
+globalThis.fetch = vi.fn()
+
+describe('maintenanceStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  describe('scanSystem', () => {
+    it('fetches scan results successfully', async () => {
+      const mockIssues = {
+        orphanedScreenFiles: [{ deviceId: 'dev-1', screenId: 'screen-1', path: '/path/to/file.png', size: 1024 }],
+        orphanedDeviceDirs: [{ deviceId: 'dev-2', path: '/path/to/dir', fileCount: 5, size: 5120 }],
+        brokenScreens: [{ screenId: 'screen-2', deviceId: 'dev-1', filename: 'broken.png', type: 'file' }],
+        tempFiles: [{ path: '/path/to/temp', age: 25, size: 512 }],
+        oldUploads: [{ path: '/path/to/upload.zip', age: 48, size: 2048 }],
+        totalSize: 8704,
+        scannedAt: '2026-04-24T12:00:00Z',
+      }
+
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockIssues,
+      } as Response)
+
+      const store = useMaintenanceStore()
+      await store.scanSystem()
+
+      expect(fetch).toHaveBeenCalledWith('/api/maintenance/scan')
+      expect(store.issues).toEqual(mockIssues)
+      expect(store.loading).toBe(false)
+      expect(store.error).toBeNull()
+    })
+
+    it('sets loading state during scan', async () => {
+      vi.mocked(fetch).mockImplementationOnce(() =>
+        new Promise(resolve =>
+          setTimeout(
+            () =>
+              resolve({
+                ok: true,
+                json: async () => ({
+                  orphanedScreenFiles: [],
+                  orphanedDeviceDirs: [],
+                  brokenScreens: [],
+                  tempFiles: [],
+                  oldUploads: [],
+                  totalSize: 0,
+                  scannedAt: '2026-04-24T12:00:00Z',
+                }),
+              } as Response),
+            100,
+          ),
+        ),
+      )
+
+      const store = useMaintenanceStore()
+      const scanPromise = store.scanSystem()
+
+      expect(store.loading).toBe(true)
+
+      await scanPromise
+
+      expect(store.loading).toBe(false)
+    })
+
+    it('handles scan errors', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: false,
+        statusText: 'Internal Server Error',
+      } as Response)
+
+      const store = useMaintenanceStore()
+
+      await expect(store.scanSystem()).rejects.toThrow('Scan failed: Internal Server Error')
+
+      expect(store.error).toBe('Scan failed: Internal Server Error')
+      expect(store.loading).toBe(false)
+    })
+
+    it('handles network errors', async () => {
+      vi.mocked(fetch).mockRejectedValueOnce(new Error('Network error'))
+
+      const store = useMaintenanceStore()
+
+      await expect(store.scanSystem()).rejects.toThrow('Network error')
+
+      expect(store.error).toBe('Network error')
+      expect(store.loading).toBe(false)
+    })
+  })
+
+  describe('cleanupIssues', () => {
+    it('sends cleanup request with all parameters', async () => {
+      const mockResult = {
+        filesDeleted: 5,
+        dirsDeleted: 2,
+        screensDeleted: 1,
+        bytesFreed: 10240,
+        errors: [],
+      }
+
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResult,
+      } as Response)
+
+      const store = useMaintenanceStore()
+      const result = await store.cleanupIssues(
+        ['/path/to/file1.png', '/path/to/file2.png'],
+        ['/path/to/dir1'],
+        ['screen-1'],
+        ['/path/to/temp'],
+        ['/path/to/upload.zip'],
+        false,
+      )
+
+      expect(fetch).toHaveBeenCalledWith('/api/maintenance/cleanup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          orphanedFiles: ['/path/to/file1.png', '/path/to/file2.png'],
+          orphanedDirs: ['/path/to/dir1'],
+          brokenScreens: ['screen-1'],
+          tempFiles: ['/path/to/temp'],
+          oldUploads: ['/path/to/upload.zip'],
+          dryRun: false,
+        }),
+      })
+
+      expect(result).toEqual(mockResult)
+      expect(store.loading).toBe(false)
+      expect(store.error).toBeNull()
+    })
+
+    it('defaults to empty arrays and dry-run false', async () => {
+      const mockResult = {
+        filesDeleted: 0,
+        dirsDeleted: 0,
+        screensDeleted: 0,
+        bytesFreed: 0,
+        errors: [],
+      }
+
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResult,
+      } as Response)
+
+      const store = useMaintenanceStore()
+      await store.cleanupIssues()
+
+      expect(fetch).toHaveBeenCalledWith('/api/maintenance/cleanup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          orphanedFiles: [],
+          orphanedDirs: [],
+          brokenScreens: [],
+          tempFiles: [],
+          oldUploads: [],
+          dryRun: false,
+        }),
+      })
+    })
+
+    it('sends dry-run parameter', async () => {
+      const mockResult = {
+        filesDeleted: 5,
+        dirsDeleted: 0,
+        screensDeleted: 0,
+        bytesFreed: 5120,
+        errors: [],
+      }
+
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResult,
+      } as Response)
+
+      const store = useMaintenanceStore()
+      await store.cleanupIssues(['/file.png'], [], [], [], [], true)
+
+      const callArgs = vi.mocked(fetch).mock.calls[0]
+      const body = JSON.parse(callArgs[1]!.body as string)
+
+      expect(body.dryRun).toBe(true)
+    })
+
+    it('handles cleanup errors', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: false,
+        statusText: 'Forbidden',
+      } as Response)
+
+      const store = useMaintenanceStore()
+
+      await expect(store.cleanupIssues([], [], [], [], [], false)).rejects.toThrow('Cleanup failed: Forbidden')
+
+      expect(store.error).toBe('Cleanup failed: Forbidden')
+      expect(store.loading).toBe(false)
+    })
+
+    it('handles network errors during cleanup', async () => {
+      vi.mocked(fetch).mockRejectedValueOnce(new Error('Connection refused'))
+
+      const store = useMaintenanceStore()
+
+      await expect(store.cleanupIssues([], [], [], [], [], false)).rejects.toThrow('Connection refused')
+
+      expect(store.error).toBe('Connection refused')
+      expect(store.loading).toBe(false)
+    })
+  })
+
+  describe('getStats', () => {
+    it('fetches stats successfully', async () => {
+      const mockStats = {
+        fileCount: 42,
+        totalSize: 1024000,
+      }
+
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockStats,
+      } as Response)
+
+      const store = useMaintenanceStore()
+      const result = await store.getStats()
+
+      expect(fetch).toHaveBeenCalledWith('/api/maintenance/stats')
+      expect(result).toEqual(mockStats)
+    })
+
+    it('handles stats fetch errors', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: false,
+        statusText: 'Service Unavailable',
+      } as Response)
+
+      const store = useMaintenanceStore()
+
+      await expect(store.getStats()).rejects.toThrow('Stats fetch failed: Service Unavailable')
+
+      expect(store.error).toBe('Stats fetch failed: Service Unavailable')
+    })
+
+    it('handles network errors during stats fetch', async () => {
+      vi.mocked(fetch).mockRejectedValueOnce(new Error('Timeout'))
+
+      const store = useMaintenanceStore()
+
+      await expect(store.getStats()).rejects.toThrow('Timeout')
+
+      expect(store.error).toBe('Timeout')
+    })
+  })
+
+  describe('clearIssues', () => {
+    it('clears issues and error', async () => {
+      const mockIssues = {
+        orphanedScreenFiles: [],
+        orphanedDeviceDirs: [],
+        brokenScreens: [],
+        tempFiles: [],
+        oldUploads: [],
+        totalSize: 0,
+        scannedAt: '2026-04-24T12:00:00Z',
+      }
+
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockIssues,
+      } as Response)
+
+      const store = useMaintenanceStore()
+      await store.scanSystem()
+
+      expect(store.issues).toEqual(mockIssues)
+
+      store.clearIssues()
+
+      expect(store.issues).toBeNull()
+      expect(store.error).toBeNull()
+    })
+  })
+})

--- a/packages/ui/src/stores/maintenance.ts
+++ b/packages/ui/src/stores/maintenance.ts
@@ -1,55 +1,6 @@
+import type { CleanupResult, MaintenanceIssues, MaintenanceStats } from '../types'
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
-
-export interface OrphanedScreenFile {
-  deviceId: string
-  screenId: string
-  path: string
-  size: number
-}
-
-export interface OrphanedDeviceDir {
-  deviceId: string
-  path: string
-  fileCount: number
-  size: number
-}
-
-export interface BrokenScreen {
-  screenId: string
-  deviceId: string
-  filename: string
-  type: string
-}
-
-export interface TempFile {
-  path: string
-  age: number
-  size: number
-}
-
-export interface MaintenanceIssues {
-  orphanedScreenFiles: OrphanedScreenFile[]
-  orphanedDeviceDirs: OrphanedDeviceDir[]
-  brokenScreens: BrokenScreen[]
-  tempFiles: TempFile[]
-  oldUploads: TempFile[]
-  totalSize: number
-  scannedAt: string
-}
-
-export interface CleanupResult {
-  filesDeleted: number
-  dirsDeleted: number
-  screensDeleted: number
-  bytesFreed: number
-  errors: string[]
-}
-
-export interface MaintenanceStats {
-  fileCount: number
-  totalSize: number
-}
 
 export const useMaintenanceStore = defineStore('maintenance', () => {
   const issues = ref<MaintenanceIssues | null>(null)

--- a/packages/ui/src/stores/maintenance.ts
+++ b/packages/ui/src/stores/maintenance.ts
@@ -1,0 +1,140 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+export interface OrphanedScreenFile {
+  deviceId: string
+  screenId: string
+  path: string
+  size: number
+}
+
+export interface OrphanedDeviceDir {
+  deviceId: string
+  path: string
+  fileCount: number
+  size: number
+}
+
+export interface BrokenScreen {
+  screenId: string
+  deviceId: string
+  filename: string
+  type: string
+}
+
+export interface TempFile {
+  path: string
+  age: number
+  size: number
+}
+
+export interface MaintenanceIssues {
+  orphanedScreenFiles: OrphanedScreenFile[]
+  orphanedDeviceDirs: OrphanedDeviceDir[]
+  brokenScreens: BrokenScreen[]
+  tempFiles: TempFile[]
+  oldUploads: TempFile[]
+  totalSize: number
+  scannedAt: string
+}
+
+export interface CleanupResult {
+  filesDeleted: number
+  dirsDeleted: number
+  screensDeleted: number
+  bytesFreed: number
+  errors: string[]
+}
+
+export interface MaintenanceStats {
+  fileCount: number
+  totalSize: number
+}
+
+export const useMaintenanceStore = defineStore('maintenance', () => {
+  const issues = ref<MaintenanceIssues | null>(null)
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  async function scanSystem() {
+    loading.value = true
+    error.value = null
+    try {
+      const res = await fetch('/api/maintenance/scan')
+      if (!res.ok)
+        throw new Error(`Scan failed: ${res.statusText}`)
+      issues.value = await res.json()
+    }
+    catch (err) {
+      error.value = err instanceof Error ? err.message : 'Failed to scan system'
+      throw err
+    }
+    finally {
+      loading.value = false
+    }
+  }
+
+  async function cleanupIssues(
+    orphanedFiles: string[] = [],
+    orphanedDirs: string[] = [],
+    brokenScreens: string[] = [],
+    tempFiles: string[] = [],
+    oldUploads: string[] = [],
+    dryRun: boolean = false,
+  ): Promise<CleanupResult> {
+    loading.value = true
+    error.value = null
+    try {
+      const res = await fetch('/api/maintenance/cleanup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          orphanedFiles,
+          orphanedDirs,
+          brokenScreens,
+          tempFiles,
+          oldUploads,
+          dryRun,
+        }),
+      })
+      if (!res.ok)
+        throw new Error(`Cleanup failed: ${res.statusText}`)
+      return await res.json()
+    }
+    catch (err) {
+      error.value = err instanceof Error ? err.message : 'Failed to cleanup'
+      throw err
+    }
+    finally {
+      loading.value = false
+    }
+  }
+
+  async function getStats(): Promise<MaintenanceStats> {
+    try {
+      const res = await fetch('/api/maintenance/stats')
+      if (!res.ok)
+        throw new Error(`Stats fetch failed: ${res.statusText}`)
+      return await res.json()
+    }
+    catch (err) {
+      error.value = err instanceof Error ? err.message : 'Failed to get stats'
+      throw err
+    }
+  }
+
+  function clearIssues() {
+    issues.value = null
+    error.value = null
+  }
+
+  return {
+    issues,
+    loading,
+    error,
+    scanSystem,
+    cleanupIssues,
+    getStats,
+    clearIssues,
+  }
+})

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -47,3 +47,53 @@ export interface LogEntry {
   date: Date
   entry: string
 }
+
+export interface OrphanedScreenFile {
+  deviceId: string
+  screenId: string
+  path: string
+  size: number
+}
+
+export interface OrphanedDeviceDir {
+  deviceId: string
+  path: string
+  fileCount: number
+  size: number
+}
+
+export interface BrokenScreen {
+  screenId: string
+  deviceId: string
+  filename: string
+  type: string
+}
+
+export interface TempFile {
+  path: string
+  age: number
+  size: number
+}
+
+export interface MaintenanceIssues {
+  orphanedScreenFiles: OrphanedScreenFile[]
+  orphanedDeviceDirs: OrphanedDeviceDir[]
+  brokenScreens: BrokenScreen[]
+  tempFiles: TempFile[]
+  oldUploads: TempFile[]
+  totalSize: number
+  scannedAt: string
+}
+
+export interface CleanupResult {
+  filesDeleted: number
+  dirsDeleted: number
+  screensDeleted: number
+  bytesFreed: number
+  errors: string[]
+}
+
+export interface MaintenanceStats {
+  fileCount: number
+  totalSize: number
+}

--- a/packages/ui/src/views/MaintenanceView.vue
+++ b/packages/ui/src/views/MaintenanceView.vue
@@ -1,14 +1,601 @@
 <script setup lang="ts">
+import { mdiAlertCircle, mdiCheckCircle, mdiDelete, mdiRefresh } from '@mdi/js'
+import { computed, onMounted, ref } from 'vue'
+import { VAlert, VBtn, VCard, VCardText, VCardTitle, VCheckbox, VChip, VCol, VContainer, VDialog, VDivider, VList, VListItem, VListItemSubtitle, VListItemTitle, VProgressCircular, VRow, VSwitch } from 'vuetify/components'
+import { useMaintenanceStore } from '../stores/maintenance'
+
+const maintenanceStore = useMaintenanceStore()
+
+const selectedOrphanedFiles = ref<string[]>([])
+const selectedOrphanedDirs = ref<string[]>([])
+const selectedBrokenScreens = ref<string[]>([])
+const selectedTempFiles = ref<string[]>([])
+const selectedOldUploads = ref<string[]>([])
+const dryRun = ref(true)
+const showConfirmDialog = ref(false)
+const cleanupInProgress = ref(false)
+const cleanupResult = ref<{ filesDeleted: number, dirsDeleted: number, screensDeleted: number, bytesFreed: number, errors: string[] } | null>(null)
+
+const hasSelection = computed(() => {
+  return selectedOrphanedFiles.value.length > 0
+    || selectedOrphanedDirs.value.length > 0
+    || selectedBrokenScreens.value.length > 0
+    || selectedTempFiles.value.length > 0
+    || selectedOldUploads.value.length > 0
+})
+
+const totalSelectedSize = computed(() => {
+  let size = 0
+  if (maintenanceStore.issues) {
+    selectedOrphanedFiles.value.forEach((path) => {
+      const item = maintenanceStore.issues!.orphanedScreenFiles.find(f => f.path === path)
+      if (item)
+        size += item.size
+    })
+    selectedOrphanedDirs.value.forEach((path) => {
+      const item = maintenanceStore.issues!.orphanedDeviceDirs.find(d => d.path === path)
+      if (item)
+        size += item.size
+    })
+    selectedTempFiles.value.forEach((path) => {
+      const item = maintenanceStore.issues!.tempFiles.find(f => f.path === path)
+      if (item)
+        size += item.size
+    })
+    selectedOldUploads.value.forEach((path) => {
+      const item = maintenanceStore.issues!.oldUploads.find(f => f.path === path)
+      if (item)
+        size += item.size
+    })
+  }
+  return size
+})
+
+onMounted(async () => {
+  await maintenanceStore.scanSystem()
+})
+
+async function handleScan() {
+  selectedOrphanedFiles.value = []
+  selectedOrphanedDirs.value = []
+  selectedBrokenScreens.value = []
+  selectedTempFiles.value = []
+  selectedOldUploads.value = []
+  cleanupResult.value = null
+  await maintenanceStore.scanSystem()
+}
+
+function selectAllOrphanedFiles() {
+  if (!maintenanceStore.issues)
+    return
+  selectedOrphanedFiles.value = maintenanceStore.issues.orphanedScreenFiles.map(f => f.path)
+}
+
+function selectAllOrphanedDirs() {
+  if (!maintenanceStore.issues)
+    return
+  selectedOrphanedDirs.value = maintenanceStore.issues.orphanedDeviceDirs.map(d => d.path)
+}
+
+function selectAllBrokenScreens() {
+  if (!maintenanceStore.issues)
+    return
+  selectedBrokenScreens.value = maintenanceStore.issues.brokenScreens.map(s => s.screenId)
+}
+
+function selectAllTempFiles() {
+  if (!maintenanceStore.issues)
+    return
+  selectedTempFiles.value = maintenanceStore.issues.tempFiles.map(f => f.path)
+}
+
+function selectAllOldUploads() {
+  if (!maintenanceStore.issues)
+    return
+  selectedOldUploads.value = maintenanceStore.issues.oldUploads.map(f => f.path)
+}
+
+function selectAll() {
+  selectAllOrphanedFiles()
+  selectAllOrphanedDirs()
+  selectAllBrokenScreens()
+  selectAllTempFiles()
+  selectAllOldUploads()
+}
+
+function deselectAll() {
+  selectedOrphanedFiles.value = []
+  selectedOrphanedDirs.value = []
+  selectedBrokenScreens.value = []
+  selectedTempFiles.value = []
+  selectedOldUploads.value = []
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0)
+    return '0 B'
+  const k = 1024
+  const sizes = ['B', 'KB', 'MB', 'GB']
+  const i = Math.floor(Math.log(bytes) / Math.log(k))
+  return `${Number.parseFloat((bytes / (k ** i)).toFixed(2))} ${sizes[i]}`
+}
+
+function formatAge(hours: number): string {
+  if (hours < 24)
+    return `${Math.round(hours)}h`
+  const days = Math.floor(hours / 24)
+  return `${days}d`
+}
+
+async function confirmCleanup() {
+  showConfirmDialog.value = true
+}
+
+async function executeCleanup() {
+  showConfirmDialog.value = false
+  cleanupInProgress.value = true
+  cleanupResult.value = null
+
+  try {
+    const result = await maintenanceStore.cleanupIssues(
+      selectedOrphanedFiles.value,
+      selectedOrphanedDirs.value,
+      selectedBrokenScreens.value,
+      selectedTempFiles.value,
+      selectedOldUploads.value,
+      dryRun.value,
+    )
+    cleanupResult.value = result
+
+    if (!dryRun.value) {
+      deselectAll()
+      await maintenanceStore.scanSystem()
+    }
+  }
+  finally {
+    cleanupInProgress.value = false
+  }
+}
 </script>
 
 <template>
-  <v-container fluid>
-    <v-row justify="center">
-      <v-col cols="12">
-        <p class="text-body-2 text-medium-emphasis mb-0">
-          Coming soon.
-        </p>
-      </v-col>
-    </v-row>
-  </v-container>
+  <VContainer fluid>
+    <VRow justify="center">
+      <VCol cols="12">
+        <VCard elevation="1" class="mb-4">
+          <VCardTitle class="d-flex align-center justify-space-between">
+            Maintenance Dashboard
+            <VBtn
+              :prepend-icon="mdiRefresh"
+              variant="tonal"
+              color="secondary"
+              :loading="maintenanceStore.loading"
+              @click="handleScan"
+            >
+              Scan System
+            </VBtn>
+          </VCardTitle>
+          <VDivider />
+          <VCardText>
+            <p class="text-body-2 text-medium-emphasis">
+              Scan filesystem for orphaned files, broken screens, and temporary data that can be cleaned up.
+            </p>
+          </VCardText>
+        </VCard>
+
+        <VAlert
+          v-if="maintenanceStore.error"
+          type="error"
+          variant="tonal"
+          class="mb-4"
+          :icon="mdiAlertCircle"
+        >
+          {{ maintenanceStore.error }}
+        </VAlert>
+
+        <VAlert
+          v-if="cleanupResult"
+          :type="cleanupResult.errors.length > 0 ? 'warning' : 'success'"
+          variant="tonal"
+          class="mb-4"
+          :icon="mdiCheckCircle"
+          closable
+          @click:close="cleanupResult = null"
+        >
+          <div class="text-body-2">
+            <div v-if="dryRun" class="font-weight-bold mb-2">
+              Dry Run Results (no actual changes made)
+            </div>
+            <div v-else class="font-weight-bold mb-2">
+              Cleanup Complete
+            </div>
+            <div>Files deleted: {{ cleanupResult.filesDeleted }}</div>
+            <div>Directories deleted: {{ cleanupResult.dirsDeleted }}</div>
+            <div>Screens deleted: {{ cleanupResult.screensDeleted }}</div>
+            <div>Space freed: {{ formatBytes(cleanupResult.bytesFreed) }}</div>
+            <div v-if="cleanupResult.errors.length > 0" class="mt-2">
+              <div class="font-weight-bold">
+                Errors:
+              </div>
+              <div v-for="(err, i) in cleanupResult.errors" :key="i" class="text-error">
+                {{ err }}
+              </div>
+            </div>
+          </div>
+        </VAlert>
+
+        <VProgressCircular
+          v-if="maintenanceStore.loading"
+          indeterminate
+          color="primary"
+          class="d-block mx-auto my-8"
+        />
+
+        <template v-else-if="maintenanceStore.issues">
+          <VCard elevation="1" class="mb-4">
+            <VCardTitle>
+              Scan Summary
+              <VChip v-if="maintenanceStore.issues.scannedAt" size="small" class="ml-2">
+                {{ new Date(maintenanceStore.issues.scannedAt).toLocaleString() }}
+              </VChip>
+            </VCardTitle>
+            <VDivider />
+            <VCardText>
+              <VRow>
+                <VCol cols="6" md="3">
+                  <div class="text-caption text-medium-emphasis">
+                    Orphaned Files
+                  </div>
+                  <div class="text-h6">
+                    {{ maintenanceStore.issues.orphanedScreenFiles.length }}
+                  </div>
+                </VCol>
+                <VCol cols="6" md="3">
+                  <div class="text-caption text-medium-emphasis">
+                    Orphaned Dirs
+                  </div>
+                  <div class="text-h6">
+                    {{ maintenanceStore.issues.orphanedDeviceDirs.length }}
+                  </div>
+                </VCol>
+                <VCol cols="6" md="3">
+                  <div class="text-caption text-medium-emphasis">
+                    Broken Screens
+                  </div>
+                  <div class="text-h6">
+                    {{ maintenanceStore.issues.brokenScreens.length }}
+                  </div>
+                </VCol>
+                <VCol cols="6" md="3">
+                  <div class="text-caption text-medium-emphasis">
+                    Total Size
+                  </div>
+                  <div class="text-h6">
+                    {{ formatBytes(maintenanceStore.issues.totalSize) }}
+                  </div>
+                </VCol>
+                <VCol cols="6" md="3">
+                  <div class="text-caption text-medium-emphasis">
+                    Temp Files
+                  </div>
+                  <div class="text-h6">
+                    {{ maintenanceStore.issues.tempFiles.length }}
+                  </div>
+                </VCol>
+                <VCol cols="6" md="3">
+                  <div class="text-caption text-medium-emphasis">
+                    Old Uploads
+                  </div>
+                  <div class="text-h6">
+                    {{ maintenanceStore.issues.oldUploads.length }}
+                  </div>
+                </VCol>
+              </VRow>
+            </VCardText>
+          </VCard>
+
+          <VCard v-if="maintenanceStore.issues.orphanedScreenFiles.length > 0" elevation="1" class="mb-4">
+            <VCardTitle class="d-flex align-center justify-space-between">
+              Orphaned Screen Files
+              <VBtn
+                size="small"
+                variant="text"
+                @click="selectAllOrphanedFiles"
+              >
+                Select All
+              </VBtn>
+            </VCardTitle>
+            <VDivider />
+            <VCardText>
+              <VList>
+                <VListItem
+                  v-for="file in maintenanceStore.issues.orphanedScreenFiles"
+                  :key="file.path"
+                >
+                  <template #prepend>
+                    <VCheckbox
+                      v-model="selectedOrphanedFiles"
+                      :value="file.path"
+                      hide-details
+                    />
+                  </template>
+                  <VListItemTitle class="text-body-2">
+                    Device: <span class="font-weight-bold">{{ file.deviceId }}</span> / Screen: <span class="font-weight-bold">{{ file.screenId }}</span>
+                  </VListItemTitle>
+                  <VListItemSubtitle class="text-caption">
+                    {{ file.path }} ({{ formatBytes(file.size) }})
+                  </VListItemSubtitle>
+                </VListItem>
+              </VList>
+            </VCardText>
+          </VCard>
+
+          <VCard v-if="maintenanceStore.issues.orphanedDeviceDirs.length > 0" elevation="1" class="mb-4">
+            <VCardTitle class="d-flex align-center justify-space-between">
+              Orphaned Device Directories
+              <VBtn
+                size="small"
+                variant="text"
+                @click="selectAllOrphanedDirs"
+              >
+                Select All
+              </VBtn>
+            </VCardTitle>
+            <VDivider />
+            <VCardText>
+              <VList>
+                <VListItem
+                  v-for="dir in maintenanceStore.issues.orphanedDeviceDirs"
+                  :key="dir.path"
+                >
+                  <template #prepend>
+                    <VCheckbox
+                      v-model="selectedOrphanedDirs"
+                      :value="dir.path"
+                      hide-details
+                    />
+                  </template>
+                  <VListItemTitle class="text-body-2">
+                    Device ID: <span class="font-weight-bold">{{ dir.deviceId }}</span>
+                  </VListItemTitle>
+                  <VListItemSubtitle class="text-caption">
+                    {{ dir.path }} ({{ dir.fileCount }} files, {{ formatBytes(dir.size) }})
+                  </VListItemSubtitle>
+                </VListItem>
+              </VList>
+            </VCardText>
+          </VCard>
+
+          <VCard v-if="maintenanceStore.issues.brokenScreens.length > 0" elevation="1" class="mb-4">
+            <VCardTitle class="d-flex align-center justify-space-between">
+              Broken Screens (Missing Files)
+              <VBtn
+                size="small"
+                variant="text"
+                @click="selectAllBrokenScreens"
+              >
+                Select All
+              </VBtn>
+            </VCardTitle>
+            <VDivider />
+            <VCardText>
+              <VList>
+                <VListItem
+                  v-for="screen in maintenanceStore.issues.brokenScreens"
+                  :key="screen.screenId"
+                >
+                  <template #prepend>
+                    <VCheckbox
+                      v-model="selectedBrokenScreens"
+                      :value="screen.screenId"
+                      hide-details
+                    />
+                  </template>
+                  <VListItemTitle class="text-body-2">
+                    {{ screen.filename }} <VChip size="x-small" class="ml-2">
+                      {{ screen.type }}
+                    </VChip>
+                  </VListItemTitle>
+                  <VListItemSubtitle class="text-caption">
+                    Device: {{ screen.deviceId }} / Screen: {{ screen.screenId }}
+                  </VListItemSubtitle>
+                </VListItem>
+              </VList>
+            </VCardText>
+          </VCard>
+
+          <VCard v-if="maintenanceStore.issues.tempFiles.length > 0" elevation="1" class="mb-4">
+            <VCardTitle class="d-flex align-center justify-space-between">
+              Temporary Files
+              <VBtn
+                size="small"
+                variant="text"
+                @click="selectAllTempFiles"
+              >
+                Select All
+              </VBtn>
+            </VCardTitle>
+            <VDivider />
+            <VCardText>
+              <VList>
+                <VListItem
+                  v-for="file in maintenanceStore.issues.tempFiles"
+                  :key="file.path"
+                >
+                  <template #prepend>
+                    <VCheckbox
+                      v-model="selectedTempFiles"
+                      :value="file.path"
+                      hide-details
+                    />
+                  </template>
+                  <VListItemTitle class="text-body-2">
+                    {{ file.path.split('/').pop() }} <VChip size="x-small" class="ml-2">
+                      {{ formatAge(file.age) }} old
+                    </VChip>
+                  </VListItemTitle>
+                  <VListItemSubtitle class="text-caption">
+                    {{ file.path }} ({{ formatBytes(file.size) }})
+                  </VListItemSubtitle>
+                </VListItem>
+              </VList>
+            </VCardText>
+          </VCard>
+
+          <VCard v-if="maintenanceStore.issues.oldUploads.length > 0" elevation="1" class="mb-4">
+            <VCardTitle class="d-flex align-center justify-space-between">
+              Old Upload Files
+              <VBtn
+                size="small"
+                variant="text"
+                @click="selectAllOldUploads"
+              >
+                Select All
+              </VBtn>
+            </VCardTitle>
+            <VDivider />
+            <VCardText>
+              <VList>
+                <VListItem
+                  v-for="file in maintenanceStore.issues.oldUploads"
+                  :key="file.path"
+                >
+                  <template #prepend>
+                    <VCheckbox
+                      v-model="selectedOldUploads"
+                      :value="file.path"
+                      hide-details
+                    />
+                  </template>
+                  <VListItemTitle class="text-body-2">
+                    {{ file.path.split('/').pop() }} <VChip size="x-small" class="ml-2">
+                      {{ formatAge(file.age) }} old
+                    </VChip>
+                  </VListItemTitle>
+                  <VListItemSubtitle class="text-caption">
+                    {{ file.path }} ({{ formatBytes(file.size) }})
+                  </VListItemSubtitle>
+                </VListItem>
+              </VList>
+            </VCardText>
+          </VCard>
+
+          <VCard
+            v-if="maintenanceStore.issues.orphanedScreenFiles.length === 0
+              && maintenanceStore.issues.orphanedDeviceDirs.length === 0
+              && maintenanceStore.issues.brokenScreens.length === 0
+              && maintenanceStore.issues.tempFiles.length === 0
+              && maintenanceStore.issues.oldUploads.length === 0"
+            elevation="1"
+            class="mb-4"
+          >
+            <VCardText>
+              <VAlert type="success" variant="tonal" :icon="mdiCheckCircle">
+                No maintenance issues found. System is clean!
+              </VAlert>
+            </VCardText>
+          </VCard>
+
+          <VCard v-if="hasSelection" elevation="1" class="mb-4">
+            <VCardTitle>Cleanup Actions</VCardTitle>
+            <VDivider />
+            <VCardText>
+              <div class="mb-4">
+                <div class="text-body-2 mb-2">
+                  <span class="font-weight-bold">Selected items:</span>
+                  {{ selectedOrphanedFiles.length + selectedOrphanedDirs.length + selectedBrokenScreens.length + selectedTempFiles.length + selectedOldUploads.length }}
+                </div>
+                <div class="text-body-2 mb-4">
+                  <span class="font-weight-bold">Space to be freed:</span>
+                  {{ formatBytes(totalSelectedSize) }}
+                </div>
+
+                <VSwitch
+                  v-model="dryRun"
+                  label="Dry Run (simulate without actual deletion)"
+                  color="warning"
+                  hide-details
+                  class="mb-4"
+                />
+
+                <div class="d-flex gap-2">
+                  <VBtn
+                    :prepend-icon="mdiDelete"
+                    color="error"
+                    variant="tonal"
+                    :loading="cleanupInProgress"
+                    @click="confirmCleanup"
+                  >
+                    {{ dryRun ? 'Preview Cleanup' : 'Clean Selected' }}
+                  </VBtn>
+                  <VBtn
+                    variant="text"
+                    @click="selectAll"
+                  >
+                    Select All
+                  </VBtn>
+                  <VBtn
+                    variant="text"
+                    @click="deselectAll"
+                  >
+                    Deselect All
+                  </VBtn>
+                </div>
+              </div>
+            </VCardText>
+          </VCard>
+        </template>
+      </VCol>
+    </VRow>
+
+    <VDialog v-model="showConfirmDialog" max-width="500">
+      <VCard>
+        <VCardTitle>Confirm Cleanup</VCardTitle>
+        <VDivider />
+        <VCardText>
+          <VAlert
+            :type="dryRun ? 'info' : 'warning'"
+            variant="tonal"
+            class="mb-4"
+            :icon="dryRun ? mdiCheckCircle : mdiAlertCircle"
+          >
+            <div v-if="dryRun" class="text-body-2">
+              This is a dry run. No files will be deleted.
+            </div>
+            <div v-else class="text-body-2">
+              <div class="font-weight-bold mb-2">
+                Warning: This action cannot be undone!
+              </div>
+              <div>You are about to delete:</div>
+            </div>
+          </VAlert>
+
+          <div class="text-body-2">
+            <div>Files: {{ selectedOrphanedFiles.length + selectedTempFiles.length + selectedOldUploads.length }}</div>
+            <div>Directories: {{ selectedOrphanedDirs.length }}</div>
+            <div>Screens: {{ selectedBrokenScreens.length }}</div>
+            <div class="mt-2 font-weight-bold">
+              Total space: {{ formatBytes(totalSelectedSize) }}
+            </div>
+          </div>
+        </VCardText>
+        <VDivider />
+        <VCardText class="d-flex justify-end gap-2">
+          <VBtn
+            variant="text"
+            @click="showConfirmDialog = false"
+          >
+            Cancel
+          </VBtn>
+          <VBtn
+            :color="dryRun ? 'primary' : 'error'"
+            variant="tonal"
+            @click="executeCleanup"
+          >
+            {{ dryRun ? 'Preview' : 'Confirm Delete' }}
+          </VBtn>
+        </VCardText>
+      </VCard>
+    </VDialog>
+  </VContainer>
 </template>


### PR DESCRIPTION
Implements maintenance dashboard to scan and clean up orphaned files and broken screens.

Backend:
- maintenance.service.ts: Scans filesystem for orphaned files, broken screens, temp files
- maintenance.controller.ts: REST endpoints (GET /scan, POST /cleanup, GET /stats)
- Detects orphaned screen files, device directories, broken screens, old temp files
- Safe deletion with path validation and system file protection

Frontend:
- MaintenanceView.vue: Complete dashboard with scan/cleanup UI
- maintenance.ts store: Pinia store for state management
- Checkbox selection, dry-run mode, confirmation dialogs
- Real-time size calculations and cleanup results

Features:
- Orphaned file detection (PNG files without DB records)
- Broken screen detection (DB records without files)
- Temp file cleanup (source files older than 24h)
- Old upload cleanup (ZIP/YAML files older than 24h)
- Dry-run preview before deletion
- Safety features (system file protection, path validation)

Closes https://github.com/PhyberApex/kuroshiro/issues/51