### PR TITLE
feat: Generate missing screen images on demand for current_screen

### DIFF
--- a/packages/api/src/devices/__test__/display.service.spec.ts
+++ b/packages/api/src/devices/__test__/display.service.spec.ts
@@ -358,7 +358,7 @@ describe('deviceDisplayService', () => {
       deviceRepo.findOneBy.mockResolvedValue(device)
       screenRepo.findOneBy.mockResolvedValue(activeScreen)
       configService.get.mockReturnValue('http://api')
-      fileExists.mockResolvedValue(false)
+      fileExists.mockResolvedValueOnce(false).mockResolvedValueOnce(true)
 
       const { downloadImage, convertToPng } = await import('../../utils/imageUtils')
 
@@ -367,6 +367,51 @@ describe('deviceDisplayService', () => {
       expect(convertToPng).toHaveBeenCalledWith(expect.any(String), expect.stringContaining('screen1.png'), 800, 480, expect.any(Object))
       expect(result).toBeInstanceOf(DisplayScreen)
       expect(result.image_url).toBe('http://api/screens/devices/1/screen1.png')
+    })
+
+    it('returns error image if the screen image is missing and cannot be regenerated', async () => {
+      const device = { ...baseDevice, apikey: 'token', id: '1', mirrorEnabled: false }
+      const activeScreen = {
+        id: 'screen1',
+        type: 'file',
+        filename: 'test.png',
+        generatedAt: new Date(),
+        isActive: true,
+      }
+
+      deviceRepo.findOneBy.mockResolvedValue(device)
+      screenRepo.findOneBy.mockResolvedValue(activeScreen)
+      configService.get.mockReturnValue('http://api')
+      fileExists.mockResolvedValue(false)
+
+      const result = await service.getCurrentImageWithoutProgressing(headers)
+      expect(result).toBeInstanceOf(DisplayScreen)
+      expect(result.image_url).toBe('http://api/screens/error.png')
+    })
+
+    it('returns refreshed screen metadata after on-demand generation', async () => {
+      const device = { ...baseDevice, apikey: 'token', id: '1', width: 800, height: 480, mirrorEnabled: false }
+      const staleDate = new Date('2026-01-01T00:00:00.000Z')
+      const freshDate = new Date('2026-07-21T00:00:00.000Z')
+      const activeScreen = {
+        id: 'screen1',
+        filename: 'test.png',
+        generatedAt: staleDate,
+        isActive: true,
+        externalLink: 'http://example.com/image.jpg',
+        fetchManual: false,
+      }
+
+      deviceRepo.findOneBy.mockResolvedValue(device)
+      screenRepo.findOneBy
+        .mockResolvedValueOnce(activeScreen)
+        .mockResolvedValueOnce({ ...activeScreen, generatedAt: freshDate })
+      configService.get.mockReturnValue('http://api')
+      fileExists.mockResolvedValueOnce(false).mockResolvedValueOnce(true)
+
+      const result = await service.getCurrentImageWithoutProgressing(headers)
+      expect(result.rendered_at).toBe(freshDate)
+      expect(result.filename).toBe(`test.png_${freshDate.toISOString()}`)
     })
   })
 

--- a/packages/api/src/devices/__test__/display.service.spec.ts
+++ b/packages/api/src/devices/__test__/display.service.spec.ts
@@ -277,11 +277,44 @@ describe('deviceDisplayService', () => {
       expect(result.rendered_at).toBeUndefined()
     })
 
-    it('returns error image if device is mirrored but file does not exist', async () => {
+    it('fetches the mirror image on demand if it is missing on disk', async () => {
+      const device = {
+        ...baseDevice,
+        apikey: 'token',
+        id: '1',
+        width: 800,
+        height: 480,
+        mirrorEnabled: true,
+        mirrorMac: 'different-mac',
+        mirrorApikey: 'mirror-token',
+      }
+      deviceRepo.findOneBy.mockResolvedValue(device)
+      configService.get.mockReturnValue('http://api')
+      fileExists.mockResolvedValue(false)
+      mockFetch.mockResolvedValueOnce({
+        json: () => Promise.resolve({ filename: 'remote.png', image_url: 'http://example.com/image.jpg' }),
+      })
+
+      const { downloadImage, convertToPng } = await import('../../utils/imageUtils')
+
+      const result = await service.getCurrentImageWithoutProgressing(headers)
+      expect(mockFetch).toHaveBeenCalledWith('https://usetrmnl.com/api/current_screen', {
+        headers: { 'access-token': 'mirror-token', 'ID': 'different-mac' },
+      })
+      expect(downloadImage).toHaveBeenCalledWith('http://example.com/image.jpg', expect.any(String), expect.any(Object))
+      expect(convertToPng).toHaveBeenCalledWith(expect.any(String), expect.stringContaining('mirror.png'), 800, 480, expect.any(Object))
+      expect(result).toBeInstanceOf(DisplayScreen)
+      expect(result.filename).toContain('mirror')
+      expect(result.image_url).toBe('http://api/screens/devices/1/mirror.png')
+      expect(result.rendered_at).toBeUndefined()
+    })
+
+    it('returns error image if device is mirrored, file does not exist and on-demand fetch fails', async () => {
       const device = { ...baseDevice, apikey: 'token', id: '1', mirrorEnabled: true }
       deviceRepo.findOneBy.mockResolvedValue(device)
       configService.get.mockReturnValue('http://api')
       fileExists.mockResolvedValue(false)
+      mockFetch.mockRejectedValueOnce(new Error('TRMNL unreachable'))
 
       const result = await service.getCurrentImageWithoutProgressing(headers)
       expect(result).toBeInstanceOf(DisplayScreen)
@@ -302,12 +335,38 @@ describe('deviceDisplayService', () => {
       deviceRepo.findOneBy.mockResolvedValue(device)
       screenRepo.findOneBy.mockResolvedValue(activeScreen)
       configService.get.mockReturnValue('http://api')
+      fileExists.mockResolvedValue(true)
 
       const result = await service.getCurrentImageWithoutProgressing(headers)
       expect(result).toBeInstanceOf(DisplayScreen)
       expect(result.filename).toBe(`${activeScreen.filename}_${activeScreen.generatedAt.toISOString()}`)
       expect(result.image_url).toBe(`http://api/screens/devices/1/screen1.png`)
       expect(result.rendered_at).toBe(activeScreen.generatedAt)
+    })
+
+    it('generates the screen image on demand if it is missing on disk', async () => {
+      const device = { ...baseDevice, apikey: 'token', id: '1', width: 800, height: 480, mirrorEnabled: false }
+      const activeScreen = {
+        id: 'screen1',
+        filename: 'test.png',
+        generatedAt: new Date(),
+        isActive: true,
+        externalLink: 'http://example.com/image.jpg',
+        fetchManual: false,
+      }
+
+      deviceRepo.findOneBy.mockResolvedValue(device)
+      screenRepo.findOneBy.mockResolvedValue(activeScreen)
+      configService.get.mockReturnValue('http://api')
+      fileExists.mockResolvedValue(false)
+
+      const { downloadImage, convertToPng } = await import('../../utils/imageUtils')
+
+      const result = await service.getCurrentImageWithoutProgressing(headers)
+      expect(downloadImage).toHaveBeenCalledWith('http://example.com/image.jpg', expect.any(String), expect.any(Object))
+      expect(convertToPng).toHaveBeenCalledWith(expect.any(String), expect.stringContaining('screen1.png'), 800, 480, expect.any(Object))
+      expect(result).toBeInstanceOf(DisplayScreen)
+      expect(result.image_url).toBe('http://api/screens/devices/1/screen1.png')
     })
   })
 

--- a/packages/api/src/devices/__test__/display.service.spec.ts
+++ b/packages/api/src/devices/__test__/display.service.spec.ts
@@ -125,6 +125,7 @@ describe('deviceDisplayService', () => {
     screenRepo.save.mockResolvedValue(nextScreen)
     configService.get.mockReturnValue('http://api')
     deviceRepo.save.mockResolvedValue(undefined)
+    fileExists.mockResolvedValue(true)
     const result = await service.getCurrentImage(headers as any)
     expect(result).toBeInstanceOf(Display)
     expect(result.filename).toBe(dynamicFilename)
@@ -358,7 +359,7 @@ describe('deviceDisplayService', () => {
       deviceRepo.findOneBy.mockResolvedValue(device)
       screenRepo.findOneBy.mockResolvedValue(activeScreen)
       configService.get.mockReturnValue('http://api')
-      fileExists.mockResolvedValueOnce(false).mockResolvedValueOnce(true)
+      fileExists.mockResolvedValue(false)
 
       const { downloadImage, convertToPng } = await import('../../utils/imageUtils')
 
@@ -389,10 +390,9 @@ describe('deviceDisplayService', () => {
       expect(result.image_url).toBe('http://api/screens/error.png')
     })
 
-    it('returns refreshed screen metadata after on-demand generation', async () => {
+    it('returns fresh generation metadata after on-demand generation', async () => {
       const device = { ...baseDevice, apikey: 'token', id: '1', width: 800, height: 480, mirrorEnabled: false }
       const staleDate = new Date('2026-01-01T00:00:00.000Z')
-      const freshDate = new Date('2026-07-21T00:00:00.000Z')
       const activeScreen = {
         id: 'screen1',
         filename: 'test.png',
@@ -403,15 +403,14 @@ describe('deviceDisplayService', () => {
       }
 
       deviceRepo.findOneBy.mockResolvedValue(device)
-      screenRepo.findOneBy
-        .mockResolvedValueOnce(activeScreen)
-        .mockResolvedValueOnce({ ...activeScreen, generatedAt: freshDate })
+      screenRepo.findOneBy.mockResolvedValue(activeScreen)
       configService.get.mockReturnValue('http://api')
-      fileExists.mockResolvedValueOnce(false).mockResolvedValueOnce(true)
+      fileExists.mockResolvedValue(false)
 
       const result = await service.getCurrentImageWithoutProgressing(headers)
-      expect(result.rendered_at).toBe(freshDate)
-      expect(result.filename).toBe(`test.png_${freshDate.toISOString()}`)
+      expect(result.rendered_at).not.toBe(staleDate)
+      expect(result.rendered_at).toBe(activeScreen.generatedAt)
+      expect(result.filename).toBe(`test.png_${activeScreen.generatedAt.toISOString()}`)
     })
   })
 
@@ -496,6 +495,7 @@ describe('deviceDisplayService', () => {
       screenRepo.update.mockResolvedValue(undefined)
       screenRepo.save.mockResolvedValue(nextScreen)
       configService.get.mockReturnValue('http://api')
+      fileExists.mockResolvedValue(true)
 
       const result = await service.getCurrentImage({ ...headers, width: 800, height: 480 } as any)
 

--- a/packages/api/src/devices/display.service.ts
+++ b/packages/api/src/devices/display.service.ts
@@ -108,225 +108,8 @@ export class DeviceDisplayService {
       await this.screenRepository.save(nextScreen)
       this.logger.log(`Returning screen ${nextScreen.id} for device ${device.id}`)
 
-      let imgUrl = `${this.configService.get<string>('api_url')}/screens/devices/${device.id}/${nextScreen.id}.png`
+      const imgUrl = await this.generateScreenImage(nextScreen, device)
 
-      // Handle mashup screen
-      if (nextScreen.type === 'mashup') {
-        try {
-          const screenWithMashup = await this.screenRepository.findOne({
-            where: { id: nextScreen.id },
-            relations: [
-              'mashupConfiguration',
-              'mashupConfiguration.slots',
-              'mashupConfiguration.slots.plugin',
-              'mashupConfiguration.slots.plugin.dataSource',
-              'mashupConfiguration.slots.plugin.templates',
-            ],
-          })
-
-          if (screenWithMashup?.mashupConfiguration && this.mashupRenderer) {
-            let renderedHtml: string
-
-            // Use cached output if available
-            if (screenWithMashup.cachedPluginOutput) {
-              this.logger.log(`Using cached mashup output for screen ${nextScreen.id}`)
-              renderedHtml = screenWithMashup.cachedPluginOutput
-            }
-            else {
-              // Render mashup on-demand
-              this.logger.log(`Rendering mashup ${screenWithMashup.mashupConfiguration.id} for screen ${nextScreen.id}`)
-              renderedHtml = await this.mashupRenderer.renderMashup(screenWithMashup.mashupConfiguration, device)
-
-              // Cache for next time
-              await this.screenRepository.update(
-                { id: nextScreen.id },
-                { cachedPluginOutput: renderedHtml, generatedAt: new Date() },
-              )
-            }
-
-            // Convert HTML to PNG using puppeteer
-            const browser = await puppeteer.launch({ args: ['--no-sandbox', '--disable-web-security'] })
-            const page = await browser.newPage()
-            await page.setViewport({ width: 800, height: 480 })
-            await page.setContent(renderedHtml, { waitUntil: 'load' })
-            const image: Uint8Array = await page.screenshot()
-            await browser.close()
-
-            const imgBuffer = buffer.Buffer.from(image)
-            const destDir = resolveAppPath('public', 'screens', 'devices', device.id)
-            const inputPath = path.join(destDir, 'tmp-source')
-            await fs.promises.mkdir(path.dirname(inputPath), { recursive: true })
-            await fs.promises.writeFile(inputPath, imgBuffer)
-            const outputPath = path.join(destDir, `${nextScreen.id}.png`)
-            await convertToPng(inputPath, outputPath, device.width, device.height, this.logger)
-            imgUrl = `${this.configService.get<string>('api_url')}/screens/devices/${device.id}/${nextScreen.id}.png`
-          }
-        }
-        catch (err) {
-          this.logger.error(`Failed to render mashup: ${err.message}`)
-          imgUrl = `${this.configService.get<string>('api_url')}/screens/error.png`
-        }
-      }
-      // Handle plugin screen
-      else {
-        // Load plugin relationship if needed
-        const screenWithPlugin = await this.screenRepository.findOne({
-          where: { id: nextScreen.id },
-          relations: ['plugin', 'plugin.dataSource', 'plugin.templates'],
-        })
-
-        if (screenWithPlugin?.plugin) {
-          const plugin = screenWithPlugin.plugin
-
-          // Use cached output if available
-          if (screenWithPlugin.cachedPluginOutput) {
-            try {
-              this.logger.log(`Using cached plugin output for plugin ${plugin.id}, screen ${nextScreen.id}`)
-              const renderedHtml = screenWithPlugin.cachedPluginOutput
-              const browser = await puppeteer.launch({ args: ['--no-sandbox', '--disable-web-security'] })
-              const page = await browser.newPage()
-              await page.setViewport({ width: 800, height: 480 })
-              await page.setContent(renderedHtml, { waitUntil: 'load' })
-              const image: Uint8Array = await page.screenshot()
-              await browser.close()
-              const imgBuffer = buffer.Buffer.from(image)
-              const destDir = resolveAppPath('public', 'screens', 'devices', device.id)
-              const inputPath = path.join(destDir, 'tmp-source')
-              await fs.promises.mkdir(path.dirname(inputPath), { recursive: true })
-              await fs.promises.writeFile(inputPath, imgBuffer)
-              const outputPath = path.join(destDir, `${nextScreen.id}.png`)
-              await convertToPng(inputPath, outputPath, device.width, device.height, this.logger)
-              imgUrl = `${this.configService.get<string>('api_url')}/screens/devices/${device.id}/${nextScreen.id}.png`
-            }
-            catch (err) {
-              this.logger.error(`Failed to render cached plugin output: ${err.message}`)
-              imgUrl = `${this.configService.get<string>('api_url')}/screens/error.png`
-            }
-          }
-          // Fallback: fetch and render on-demand
-          else if (plugin.dataSource && plugin.templates && plugin.templates.length > 0) {
-            try {
-              this.logger.log(`No cache, rendering plugin ${plugin.id} on-demand for screen ${nextScreen.id}`)
-
-              // Build template context with trmnl system variables
-              const templateContext: any = {
-                trmnl: {
-                  system: {
-                    timestamp_utc: Math.floor(Date.now() / 1000),
-                  },
-                  plugin_settings: {
-                    instance_name: plugin.name,
-                    strategy: 'polling',
-                    dark_mode: 'no',
-                    no_screen_padding: 'no',
-                  },
-                  user: {
-                    id: 'kuroshiro-user',
-                    locale: 'en',
-                  },
-                },
-              }
-
-              // TODO: Add plugin field values to context when we have device-specific values
-
-              let data = await this.pluginDataFetcher.fetchData(
-                plugin.dataSource.method,
-                plugin.dataSource.url,
-                plugin.dataSource.headers,
-                plugin.dataSource.body,
-                templateContext,
-              )
-
-              // Apply transform if exists
-              if (plugin.dataSource.transformJs) {
-                this.logger.debug('Applying transform.js to fetched data')
-                data = this.pluginTransformer.transform(plugin.dataSource.transformJs, data)
-              }
-
-              const fullTemplate = plugin.templates.find(t => t.layout === 'full')
-              if (fullTemplate) {
-                const renderedHtml = await this.pluginRenderer.renderForDisplay(fullTemplate.liquidMarkup, data)
-
-                // Cache for next time
-                await this.screenRepository.update(
-                  { id: nextScreen.id },
-                  { cachedPluginOutput: renderedHtml, generatedAt: new Date() },
-                )
-
-                const browser = await puppeteer.launch({ args: ['--no-sandbox', '--disable-web-security'] })
-                const page = await browser.newPage()
-                await page.setViewport({ width: 800, height: 480 })
-                await page.setContent(renderedHtml, { waitUntil: 'load' })
-                const image: Uint8Array = await page.screenshot()
-                await browser.close()
-                const imgBuffer = buffer.Buffer.from(image)
-                const destDir = resolveAppPath('public', 'screens', 'devices', device.id)
-                const inputPath = path.join(destDir, 'tmp-source')
-                await fs.promises.mkdir(path.dirname(inputPath), { recursive: true })
-                await fs.promises.writeFile(inputPath, imgBuffer)
-                const outputPath = path.join(destDir, `${nextScreen.id}.png`)
-                await convertToPng(inputPath, outputPath, device.width, device.height, this.logger)
-                imgUrl = `${this.configService.get<string>('api_url')}/screens/devices/${device.id}/${nextScreen.id}.png`
-              }
-            }
-            catch (err) {
-              this.logger.error(`Failed to render plugin: ${err.message}`)
-              imgUrl = `${this.configService.get<string>('api_url')}/screens/error.png`
-            }
-          }
-        }
-        // Handle HTML screen
-        else if (nextScreen.html) {
-          const browser = await puppeteer.launch({ args: ['--no-sandbox', '--disable-web-security'] })
-          const page = await browser.newPage()
-          await page.setViewport({ width: 800, height: 480 })
-          const content = `
-    <html>
-      <head>
-        <link rel="stylesheet" href="https://usetrmnl.com/css/latest/plugins.css">
-        <script src="https://usetrmnl.com/js/latest/plugins.js"></script>
-      </head>
-      <body class="environment trmnl">
-        <div class="screen">
-          <div class="view view--full">
-            ${nextScreen.html}
-          </div>
-        </div>
-      </body>
-    </html>
-  `
-          await page.setContent(content, { waitUntil: 'load' })
-          const image: Uint8Array = await page.screenshot()
-          const imgBuffer = buffer.Buffer.from(image)
-          const destDir = resolveAppPath('public', 'screens', 'devices', device.id)
-          const inputPath = path.join(destDir, 'tmp-source')
-          await fs.promises.mkdir(path.dirname(inputPath), { recursive: true })
-          await fs.promises.writeFile(inputPath, imgBuffer)
-          const outputPath = path.join(destDir, `${nextScreen.id}.png`)
-          await convertToPng(inputPath, outputPath, device.width, device.height, this.logger)
-          imgUrl = `${this.configService.get<string>('api_url')}/screens/devices/${device.id}/${nextScreen.id}.png`
-        }
-      }
-      // Handle external link screen
-      if (nextScreen.externalLink && !nextScreen.fetchManual) {
-        const destDir = resolveAppPath('public', 'screens', 'devices', device.id)
-        const inputPath = path.join(destDir, 'tmp-source')
-        const pngFilename = `${nextScreen.id}.png`
-        const outputPath = path.join(destDir, pngFilename)
-        try {
-          await downloadImage(nextScreen.externalLink, inputPath, this.logger)
-          await convertToPng(inputPath, outputPath, device.width, device.height, this.logger)
-          this.logger.log('Updating generation date on screen')
-          nextScreen.generatedAt = new Date()
-          await this.screenRepository.save(nextScreen)
-          this.logger.log('Download and conversion successful')
-          imgUrl = `${this.configService.get<string>('api_url')}/screens/devices/${device.id}/${pngFilename}`
-        }
-        catch (err) {
-          this.logger.error(`Failed to process image: ${err.message}`)
-          imgUrl = `${this.configService.get<string>('api_url')}/screens/error.png`
-        }
-      }
       return new Display({
         filename: `${nextScreen.filename}_${nextScreen.generatedAt.toISOString()}`,
         firmware_url: '',
@@ -364,22 +147,14 @@ export class DeviceDisplayService {
         })
         const response = await res.json()
         this.logger.debug(`Got this from TRMNL ${JSON.stringify(response)}`)
-        const destDir = resolveAppPath('public', 'screens', 'devices', device.id)
-        const inputPath = path.join(destDir, response.filename)
-        const pngFilename = 'mirror.png'
-        const outputPath = path.join(destDir, pngFilename)
-
-        await downloadImage(response.image_url, inputPath, this.logger)
-        await convertToPng(inputPath, outputPath, device.width, device.height, this.logger)
-        await fs.promises.unlink(inputPath)
-        this.logger.log(`Deleted original image: ${inputPath}`)
+        const localImage = await this.downloadMirrorImage(device, response)
 
         refreshRate = proxy ? response.refresh_rate : refreshRate
         firmwareUrl = proxy ? response.firmware_url : firmwareUrl
         resetFirmware = proxy ? response.reset_firmware : resetFirmware
         specialFunction = proxy ? response.special_function : specialFunction
         updateFirmware = proxy ? response.update_firmware : updateFirmware
-        localImageUrl = `${this.configService.get<string>('api_url')}/screens/devices/${device.id}/${pngFilename}`
+        localImageUrl = localImage
         filename = response.filename
       }
       catch (err) {
@@ -427,10 +202,30 @@ export class DeviceDisplayService {
         this.logger.log(`Image found returning`)
         imgUrl = `${this.configService.get<string>('api_url')}/screens/devices/${device.id}/mirror.png`
       }
+      else {
+        this.logger.log(`Mirror image missing on disk, fetching from TRMNL on demand`)
+        try {
+          const res = await fetch(`https://usetrmnl.com/api/current_screen`, {
+            headers: { 'access-token': device.mirrorApikey, 'ID': device.mirrorMac },
+          })
+          const response = await res.json()
+          this.logger.debug(`Got this from TRMNL ${JSON.stringify(response)}`)
+          imgUrl = await this.downloadMirrorImage(device, response)
+        }
+        catch (err) {
+          this.logger.error(`Failed to fetch mirror image on demand: ${err.message}`)
+        }
+      }
     }
     else {
       this.logger.log(`Returning screen ${activeScreen.id} for device ${device.id}`)
-      imgUrl = `${this.configService.get<string>('api_url')}/screens/devices/${device.id}/${activeScreen.id}.png`
+      if (await fileExists(resolveAppPath('public', 'screens', 'devices', device.id, `${activeScreen.id}.png`))) {
+        imgUrl = `${this.configService.get<string>('api_url')}/screens/devices/${device.id}/${activeScreen.id}.png`
+      }
+      else {
+        this.logger.log(`Screen image for ${activeScreen.id} missing on disk, generating on demand`)
+        imgUrl = await this.generateScreenImage(activeScreen, device)
+      }
     }
     return new DisplayScreen({
       filename: device.mirrorEnabled ? `mirror_${new Date().toISOString()}` : `${activeScreen.filename}_${activeScreen.generatedAt.toISOString()}`,
@@ -438,5 +233,242 @@ export class DeviceDisplayService {
       refresh_rate: device.refreshRate,
       rendered_at: device.mirrorEnabled ? undefined : activeScreen.generatedAt,
     })
+  }
+
+  private async downloadMirrorImage(device: Device, trmnlResponse: { filename: string, image_url: string }): Promise<string> {
+    const destDir = resolveAppPath('public', 'screens', 'devices', device.id)
+    const inputPath = path.join(destDir, trmnlResponse.filename)
+    const pngFilename = 'mirror.png'
+    const outputPath = path.join(destDir, pngFilename)
+
+    await downloadImage(trmnlResponse.image_url, inputPath, this.logger)
+    await convertToPng(inputPath, outputPath, device.width, device.height, this.logger)
+    await fs.promises.unlink(inputPath)
+    this.logger.log(`Deleted original image: ${inputPath}`)
+
+    return `${this.configService.get<string>('api_url')}/screens/devices/${device.id}/${pngFilename}`
+  }
+
+  private async generateScreenImage(screen: Screen, device: Device): Promise<string> {
+    let imgUrl = `${this.configService.get<string>('api_url')}/screens/devices/${device.id}/${screen.id}.png`
+
+    // Handle mashup screen
+    if (screen.type === 'mashup') {
+      try {
+        const screenWithMashup = await this.screenRepository.findOne({
+          where: { id: screen.id },
+          relations: [
+            'mashupConfiguration',
+            'mashupConfiguration.slots',
+            'mashupConfiguration.slots.plugin',
+            'mashupConfiguration.slots.plugin.dataSource',
+            'mashupConfiguration.slots.plugin.templates',
+          ],
+        })
+
+        if (screenWithMashup?.mashupConfiguration && this.mashupRenderer) {
+          let renderedHtml: string
+
+          // Use cached output if available
+          if (screenWithMashup.cachedPluginOutput) {
+            this.logger.log(`Using cached mashup output for screen ${screen.id}`)
+            renderedHtml = screenWithMashup.cachedPluginOutput
+          }
+          else {
+            // Render mashup on-demand
+            this.logger.log(`Rendering mashup ${screenWithMashup.mashupConfiguration.id} for screen ${screen.id}`)
+            renderedHtml = await this.mashupRenderer.renderMashup(screenWithMashup.mashupConfiguration, device)
+
+            // Cache for next time
+            await this.screenRepository.update(
+              { id: screen.id },
+              { cachedPluginOutput: renderedHtml, generatedAt: new Date() },
+            )
+          }
+
+          // Convert HTML to PNG using puppeteer
+          const browser = await puppeteer.launch({ args: ['--no-sandbox', '--disable-web-security'] })
+          const page = await browser.newPage()
+          await page.setViewport({ width: 800, height: 480 })
+          await page.setContent(renderedHtml, { waitUntil: 'load' })
+          const image: Uint8Array = await page.screenshot()
+          await browser.close()
+
+          const imgBuffer = buffer.Buffer.from(image)
+          const destDir = resolveAppPath('public', 'screens', 'devices', device.id)
+          const inputPath = path.join(destDir, 'tmp-source')
+          await fs.promises.mkdir(path.dirname(inputPath), { recursive: true })
+          await fs.promises.writeFile(inputPath, imgBuffer)
+          const outputPath = path.join(destDir, `${screen.id}.png`)
+          await convertToPng(inputPath, outputPath, device.width, device.height, this.logger)
+          imgUrl = `${this.configService.get<string>('api_url')}/screens/devices/${device.id}/${screen.id}.png`
+        }
+      }
+      catch (err) {
+        this.logger.error(`Failed to render mashup: ${err.message}`)
+        imgUrl = `${this.configService.get<string>('api_url')}/screens/error.png`
+      }
+    }
+    // Handle plugin screen
+    else {
+      // Load plugin relationship if needed
+      const screenWithPlugin = await this.screenRepository.findOne({
+        where: { id: screen.id },
+        relations: ['plugin', 'plugin.dataSource', 'plugin.templates'],
+      })
+
+      if (screenWithPlugin?.plugin) {
+        const plugin = screenWithPlugin.plugin
+
+        // Use cached output if available
+        if (screenWithPlugin.cachedPluginOutput) {
+          try {
+            this.logger.log(`Using cached plugin output for plugin ${plugin.id}, screen ${screen.id}`)
+            const renderedHtml = screenWithPlugin.cachedPluginOutput
+            const browser = await puppeteer.launch({ args: ['--no-sandbox', '--disable-web-security'] })
+            const page = await browser.newPage()
+            await page.setViewport({ width: 800, height: 480 })
+            await page.setContent(renderedHtml, { waitUntil: 'load' })
+            const image: Uint8Array = await page.screenshot()
+            await browser.close()
+            const imgBuffer = buffer.Buffer.from(image)
+            const destDir = resolveAppPath('public', 'screens', 'devices', device.id)
+            const inputPath = path.join(destDir, 'tmp-source')
+            await fs.promises.mkdir(path.dirname(inputPath), { recursive: true })
+            await fs.promises.writeFile(inputPath, imgBuffer)
+            const outputPath = path.join(destDir, `${screen.id}.png`)
+            await convertToPng(inputPath, outputPath, device.width, device.height, this.logger)
+            imgUrl = `${this.configService.get<string>('api_url')}/screens/devices/${device.id}/${screen.id}.png`
+          }
+          catch (err) {
+            this.logger.error(`Failed to render cached plugin output: ${err.message}`)
+            imgUrl = `${this.configService.get<string>('api_url')}/screens/error.png`
+          }
+        }
+        // Fallback: fetch and render on-demand
+        else if (plugin.dataSource && plugin.templates && plugin.templates.length > 0) {
+          try {
+            this.logger.log(`No cache, rendering plugin ${plugin.id} on-demand for screen ${screen.id}`)
+
+            // Build template context with trmnl system variables
+            const templateContext: any = {
+              trmnl: {
+                system: {
+                  timestamp_utc: Math.floor(Date.now() / 1000),
+                },
+                plugin_settings: {
+                  instance_name: plugin.name,
+                  strategy: 'polling',
+                  dark_mode: 'no',
+                  no_screen_padding: 'no',
+                },
+                user: {
+                  id: 'kuroshiro-user',
+                  locale: 'en',
+                },
+              },
+            }
+
+            // TODO: Add plugin field values to context when we have device-specific values
+
+            let data = await this.pluginDataFetcher.fetchData(
+              plugin.dataSource.method,
+              plugin.dataSource.url,
+              plugin.dataSource.headers,
+              plugin.dataSource.body,
+              templateContext,
+            )
+
+            // Apply transform if exists
+            if (plugin.dataSource.transformJs) {
+              this.logger.debug('Applying transform.js to fetched data')
+              data = this.pluginTransformer.transform(plugin.dataSource.transformJs, data)
+            }
+
+            const fullTemplate = plugin.templates.find(t => t.layout === 'full')
+            if (fullTemplate) {
+              const renderedHtml = await this.pluginRenderer.renderForDisplay(fullTemplate.liquidMarkup, data)
+
+              // Cache for next time
+              await this.screenRepository.update(
+                { id: screen.id },
+                { cachedPluginOutput: renderedHtml, generatedAt: new Date() },
+              )
+
+              const browser = await puppeteer.launch({ args: ['--no-sandbox', '--disable-web-security'] })
+              const page = await browser.newPage()
+              await page.setViewport({ width: 800, height: 480 })
+              await page.setContent(renderedHtml, { waitUntil: 'load' })
+              const image: Uint8Array = await page.screenshot()
+              await browser.close()
+              const imgBuffer = buffer.Buffer.from(image)
+              const destDir = resolveAppPath('public', 'screens', 'devices', device.id)
+              const inputPath = path.join(destDir, 'tmp-source')
+              await fs.promises.mkdir(path.dirname(inputPath), { recursive: true })
+              await fs.promises.writeFile(inputPath, imgBuffer)
+              const outputPath = path.join(destDir, `${screen.id}.png`)
+              await convertToPng(inputPath, outputPath, device.width, device.height, this.logger)
+              imgUrl = `${this.configService.get<string>('api_url')}/screens/devices/${device.id}/${screen.id}.png`
+            }
+          }
+          catch (err) {
+            this.logger.error(`Failed to render plugin: ${err.message}`)
+            imgUrl = `${this.configService.get<string>('api_url')}/screens/error.png`
+          }
+        }
+      }
+      // Handle HTML screen
+      else if (screen.html) {
+        const browser = await puppeteer.launch({ args: ['--no-sandbox', '--disable-web-security'] })
+        const page = await browser.newPage()
+        await page.setViewport({ width: 800, height: 480 })
+        const content = `
+    <html>
+      <head>
+        <link rel="stylesheet" href="https://usetrmnl.com/css/latest/plugins.css">
+        <script src="https://usetrmnl.com/js/latest/plugins.js"></script>
+      </head>
+      <body class="environment trmnl">
+        <div class="screen">
+          <div class="view view--full">
+            ${screen.html}
+          </div>
+        </div>
+      </body>
+    </html>
+  `
+        await page.setContent(content, { waitUntil: 'load' })
+        const image: Uint8Array = await page.screenshot()
+        const imgBuffer = buffer.Buffer.from(image)
+        const destDir = resolveAppPath('public', 'screens', 'devices', device.id)
+        const inputPath = path.join(destDir, 'tmp-source')
+        await fs.promises.mkdir(path.dirname(inputPath), { recursive: true })
+        await fs.promises.writeFile(inputPath, imgBuffer)
+        const outputPath = path.join(destDir, `${screen.id}.png`)
+        await convertToPng(inputPath, outputPath, device.width, device.height, this.logger)
+        imgUrl = `${this.configService.get<string>('api_url')}/screens/devices/${device.id}/${screen.id}.png`
+      }
+    }
+    // Handle external link screen
+    if (screen.externalLink && !screen.fetchManual) {
+      const destDir = resolveAppPath('public', 'screens', 'devices', device.id)
+      const inputPath = path.join(destDir, 'tmp-source')
+      const pngFilename = `${screen.id}.png`
+      const outputPath = path.join(destDir, pngFilename)
+      try {
+        await downloadImage(screen.externalLink, inputPath, this.logger)
+        await convertToPng(inputPath, outputPath, device.width, device.height, this.logger)
+        this.logger.log('Updating generation date on screen')
+        screen.generatedAt = new Date()
+        await this.screenRepository.save(screen)
+        this.logger.log('Download and conversion successful')
+        imgUrl = `${this.configService.get<string>('api_url')}/screens/devices/${device.id}/${pngFilename}`
+      }
+      catch (err) {
+        this.logger.error(`Failed to process image: ${err.message}`)
+        imgUrl = `${this.configService.get<string>('api_url')}/screens/error.png`
+      }
+    }
+    return imgUrl
   }
 }

--- a/packages/api/src/devices/display.service.ts
+++ b/packages/api/src/devices/display.service.ts
@@ -19,6 +19,16 @@ import { Device } from './devices.entity'
 import { Display } from './display'
 import { DisplayScreen } from './displayScreen'
 
+interface TrmnlScreenResponse {
+  filename: string
+  image_url: string
+  refresh_rate?: number
+  firmware_url?: string
+  reset_firmware?: boolean
+  special_function?: string
+  update_firmware?: boolean
+}
+
 @Injectable()
 export class DeviceDisplayService {
   private readonly logger = new Logger(DeviceDisplayService.name)
@@ -138,16 +148,7 @@ export class DeviceDisplayService {
       let specialFunction = device.specialFunction
       let updateFirmware = false
       try {
-        const mirrorHeaders = proxy
-          ? { ...headers, 'ID': device.mirrorMac, 'access-token': device.mirrorApikey }
-          : { 'access-token': device.mirrorApikey, 'ID': device.mirrorMac }
-        this.logger.debug(`Sending headers: ${JSON.stringify(mirrorHeaders)}`)
-        const res = await fetch(`https://usetrmnl.com/api/${proxy ? 'display' : 'current_screen'}`, {
-          headers: mirrorHeaders,
-        })
-        const response = await res.json()
-        this.logger.debug(`Got this from TRMNL ${JSON.stringify(response)}`)
-        const localImage = await this.downloadMirrorImage(device, response)
+        const { response, localImageUrl: localImage } = await this.fetchAndStoreMirrorImage(device, proxy ? headers : undefined)
 
         refreshRate = proxy ? response.refresh_rate : refreshRate
         firmwareUrl = proxy ? response.firmware_url : firmwareUrl
@@ -185,7 +186,7 @@ export class DeviceDisplayService {
       this.logger.warn(`Invalid API key for device: ${headers.id}`)
       throw new UnauthorizedException('Invalid API key')
     }
-    const activeScreen = await this.screenRepository.findOneBy({ device, isActive: true })
+    let activeScreen = await this.screenRepository.findOneBy({ device, isActive: true })
     if (!activeScreen && !device.mirrorEnabled) {
       this.logger.log('No screen found returning default no screen image')
       return new DisplayScreen({
@@ -205,12 +206,8 @@ export class DeviceDisplayService {
       else {
         this.logger.log(`Mirror image missing on disk, fetching from TRMNL on demand`)
         try {
-          const res = await fetch(`https://usetrmnl.com/api/current_screen`, {
-            headers: { 'access-token': device.mirrorApikey, 'ID': device.mirrorMac },
-          })
-          const response = await res.json()
-          this.logger.debug(`Got this from TRMNL ${JSON.stringify(response)}`)
-          imgUrl = await this.downloadMirrorImage(device, response)
+          const { localImageUrl } = await this.fetchAndStoreMirrorImage(device)
+          imgUrl = localImageUrl
         }
         catch (err) {
           this.logger.error(`Failed to fetch mirror image on demand: ${err.message}`)
@@ -219,12 +216,18 @@ export class DeviceDisplayService {
     }
     else {
       this.logger.log(`Returning screen ${activeScreen.id} for device ${device.id}`)
-      if (await fileExists(resolveAppPath('public', 'screens', 'devices', device.id, `${activeScreen.id}.png`))) {
+      const screenImagePath = resolveAppPath('public', 'screens', 'devices', device.id, `${activeScreen.id}.png`)
+      if (await fileExists(screenImagePath)) {
         imgUrl = `${this.configService.get<string>('api_url')}/screens/devices/${device.id}/${activeScreen.id}.png`
       }
       else {
         this.logger.log(`Screen image for ${activeScreen.id} missing on disk, generating on demand`)
         imgUrl = await this.generateScreenImage(activeScreen, device)
+        activeScreen = await this.screenRepository.findOneBy({ id: activeScreen.id }) ?? activeScreen
+        if (!await fileExists(screenImagePath)) {
+          this.logger.warn(`Screen image for ${activeScreen.id} could not be generated on demand, returning error image`)
+          imgUrl = `${this.configService.get<string>('api_url')}/screens/error.png`
+        }
       }
     }
     return new DisplayScreen({
@@ -235,18 +238,28 @@ export class DeviceDisplayService {
     })
   }
 
-  private async downloadMirrorImage(device: Device, trmnlResponse: { filename: string, image_url: string }): Promise<string> {
+  private async fetchAndStoreMirrorImage(device: Device, proxyHeaders?: DisplayRequestHeadersDto): Promise<{ response: TrmnlScreenResponse, localImageUrl: string }> {
+    const mirrorHeaders = proxyHeaders
+      ? { ...proxyHeaders, 'ID': device.mirrorMac, 'access-token': device.mirrorApikey }
+      : { 'access-token': device.mirrorApikey, 'ID': device.mirrorMac }
+    this.logger.debug(`Sending headers: ${JSON.stringify(mirrorHeaders)}`)
+    const res = await fetch(`https://usetrmnl.com/api/${proxyHeaders ? 'display' : 'current_screen'}`, {
+      headers: mirrorHeaders,
+    })
+    const response: TrmnlScreenResponse = await res.json()
+    this.logger.debug(`Got this from TRMNL ${JSON.stringify(response)}`)
+
     const destDir = resolveAppPath('public', 'screens', 'devices', device.id)
-    const inputPath = path.join(destDir, trmnlResponse.filename)
+    const inputPath = path.join(destDir, response.filename)
     const pngFilename = 'mirror.png'
     const outputPath = path.join(destDir, pngFilename)
 
-    await downloadImage(trmnlResponse.image_url, inputPath, this.logger)
+    await downloadImage(response.image_url, inputPath, this.logger)
     await convertToPng(inputPath, outputPath, device.width, device.height, this.logger)
     await fs.promises.unlink(inputPath)
     this.logger.log(`Deleted original image: ${inputPath}`)
 
-    return `${this.configService.get<string>('api_url')}/screens/devices/${device.id}/${pngFilename}`
+    return { response, localImageUrl: `${this.configService.get<string>('api_url')}/screens/devices/${device.id}/${pngFilename}` }
   }
 
   private async generateScreenImage(screen: Screen, device: Device): Promise<string> {

--- a/packages/api/src/devices/display.service.ts
+++ b/packages/api/src/devices/display.service.ts
@@ -1,4 +1,5 @@
 import type { MashupRendererService } from '../mashup/services/mashup-renderer.service'
+import type { Plugin } from '../plugins/entities/plugin.entity'
 import type { DisplayRequestHeadersDto } from './dto/display-request-headers.dto'
 import buffer from 'node:buffer'
 import * as fs from 'node:fs'
@@ -186,7 +187,7 @@ export class DeviceDisplayService {
       this.logger.warn(`Invalid API key for device: ${headers.id}`)
       throw new UnauthorizedException('Invalid API key')
     }
-    let activeScreen = await this.screenRepository.findOneBy({ device, isActive: true })
+    const activeScreen = await this.screenRepository.findOneBy({ device, isActive: true })
     if (!activeScreen && !device.mirrorEnabled) {
       this.logger.log('No screen found returning default no screen image')
       return new DisplayScreen({
@@ -216,18 +217,12 @@ export class DeviceDisplayService {
     }
     else {
       this.logger.log(`Returning screen ${activeScreen.id} for device ${device.id}`)
-      const screenImagePath = resolveAppPath('public', 'screens', 'devices', device.id, `${activeScreen.id}.png`)
-      if (await fileExists(screenImagePath)) {
-        imgUrl = `${this.configService.get<string>('api_url')}/screens/devices/${device.id}/${activeScreen.id}.png`
+      if (await fileExists(this.screenImagePath(device, activeScreen))) {
+        imgUrl = this.screenImageUrl(device, activeScreen)
       }
       else {
         this.logger.log(`Screen image for ${activeScreen.id} missing on disk, generating on demand`)
         imgUrl = await this.generateScreenImage(activeScreen, device)
-        activeScreen = await this.screenRepository.findOneBy({ id: activeScreen.id }) ?? activeScreen
-        if (!await fileExists(screenImagePath)) {
-          this.logger.warn(`Screen image for ${activeScreen.id} could not be generated on demand, returning error image`)
-          imgUrl = `${this.configService.get<string>('api_url')}/screens/error.png`
-        }
       }
     }
     return new DisplayScreen({
@@ -263,7 +258,7 @@ export class DeviceDisplayService {
   }
 
   private async generateScreenImage(screen: Screen, device: Device): Promise<string> {
-    let imgUrl = `${this.configService.get<string>('api_url')}/screens/devices/${device.id}/${screen.id}.png`
+    let imgUrl: string | null = null
 
     // Handle mashup screen
     if (screen.type === 'mashup') {
@@ -288,38 +283,17 @@ export class DeviceDisplayService {
             renderedHtml = screenWithMashup.cachedPluginOutput
           }
           else {
-            // Render mashup on-demand
             this.logger.log(`Rendering mashup ${screenWithMashup.mashupConfiguration.id} for screen ${screen.id}`)
             renderedHtml = await this.mashupRenderer.renderMashup(screenWithMashup.mashupConfiguration, device)
-
-            // Cache for next time
-            await this.screenRepository.update(
-              { id: screen.id },
-              { cachedPluginOutput: renderedHtml, generatedAt: new Date() },
-            )
+            await this.cachePluginOutput(screen, renderedHtml)
           }
 
-          // Convert HTML to PNG using puppeteer
-          const browser = await puppeteer.launch({ args: ['--no-sandbox', '--disable-web-security'] })
-          const page = await browser.newPage()
-          await page.setViewport({ width: 800, height: 480 })
-          await page.setContent(renderedHtml, { waitUntil: 'load' })
-          const image: Uint8Array = await page.screenshot()
-          await browser.close()
-
-          const imgBuffer = buffer.Buffer.from(image)
-          const destDir = resolveAppPath('public', 'screens', 'devices', device.id)
-          const inputPath = path.join(destDir, 'tmp-source')
-          await fs.promises.mkdir(path.dirname(inputPath), { recursive: true })
-          await fs.promises.writeFile(inputPath, imgBuffer)
-          const outputPath = path.join(destDir, `${screen.id}.png`)
-          await convertToPng(inputPath, outputPath, device.width, device.height, this.logger)
-          imgUrl = `${this.configService.get<string>('api_url')}/screens/devices/${device.id}/${screen.id}.png`
+          imgUrl = await this.renderHtmlToScreenPng(renderedHtml, screen, device)
         }
       }
       catch (err) {
         this.logger.error(`Failed to render mashup: ${err.message}`)
-        imgUrl = `${this.configService.get<string>('api_url')}/screens/error.png`
+        imgUrl = this.errorImageUrl()
       }
     }
     // Handle plugin screen
@@ -337,105 +311,126 @@ export class DeviceDisplayService {
         if (screenWithPlugin.cachedPluginOutput) {
           try {
             this.logger.log(`Using cached plugin output for plugin ${plugin.id}, screen ${screen.id}`)
-            const renderedHtml = screenWithPlugin.cachedPluginOutput
-            const browser = await puppeteer.launch({ args: ['--no-sandbox', '--disable-web-security'] })
-            const page = await browser.newPage()
-            await page.setViewport({ width: 800, height: 480 })
-            await page.setContent(renderedHtml, { waitUntil: 'load' })
-            const image: Uint8Array = await page.screenshot()
-            await browser.close()
-            const imgBuffer = buffer.Buffer.from(image)
-            const destDir = resolveAppPath('public', 'screens', 'devices', device.id)
-            const inputPath = path.join(destDir, 'tmp-source')
-            await fs.promises.mkdir(path.dirname(inputPath), { recursive: true })
-            await fs.promises.writeFile(inputPath, imgBuffer)
-            const outputPath = path.join(destDir, `${screen.id}.png`)
-            await convertToPng(inputPath, outputPath, device.width, device.height, this.logger)
-            imgUrl = `${this.configService.get<string>('api_url')}/screens/devices/${device.id}/${screen.id}.png`
+            imgUrl = await this.renderHtmlToScreenPng(screenWithPlugin.cachedPluginOutput, screen, device)
           }
           catch (err) {
             this.logger.error(`Failed to render cached plugin output: ${err.message}`)
-            imgUrl = `${this.configService.get<string>('api_url')}/screens/error.png`
+            imgUrl = this.errorImageUrl()
           }
         }
         // Fallback: fetch and render on-demand
         else if (plugin.dataSource && plugin.templates && plugin.templates.length > 0) {
           try {
-            this.logger.log(`No cache, rendering plugin ${plugin.id} on-demand for screen ${screen.id}`)
-
-            // Build template context with trmnl system variables
-            const templateContext: any = {
-              trmnl: {
-                system: {
-                  timestamp_utc: Math.floor(Date.now() / 1000),
-                },
-                plugin_settings: {
-                  instance_name: plugin.name,
-                  strategy: 'polling',
-                  dark_mode: 'no',
-                  no_screen_padding: 'no',
-                },
-                user: {
-                  id: 'kuroshiro-user',
-                  locale: 'en',
-                },
-              },
-            }
-
-            // TODO: Add plugin field values to context when we have device-specific values
-
-            let data = await this.pluginDataFetcher.fetchData(
-              plugin.dataSource.method,
-              plugin.dataSource.url,
-              plugin.dataSource.headers,
-              plugin.dataSource.body,
-              templateContext,
-            )
-
-            // Apply transform if exists
-            if (plugin.dataSource.transformJs) {
-              this.logger.debug('Applying transform.js to fetched data')
-              data = this.pluginTransformer.transform(plugin.dataSource.transformJs, data)
-            }
-
-            const fullTemplate = plugin.templates.find(t => t.layout === 'full')
-            if (fullTemplate) {
-              const renderedHtml = await this.pluginRenderer.renderForDisplay(fullTemplate.liquidMarkup, data)
-
-              // Cache for next time
-              await this.screenRepository.update(
-                { id: screen.id },
-                { cachedPluginOutput: renderedHtml, generatedAt: new Date() },
-              )
-
-              const browser = await puppeteer.launch({ args: ['--no-sandbox', '--disable-web-security'] })
-              const page = await browser.newPage()
-              await page.setViewport({ width: 800, height: 480 })
-              await page.setContent(renderedHtml, { waitUntil: 'load' })
-              const image: Uint8Array = await page.screenshot()
-              await browser.close()
-              const imgBuffer = buffer.Buffer.from(image)
-              const destDir = resolveAppPath('public', 'screens', 'devices', device.id)
-              const inputPath = path.join(destDir, 'tmp-source')
-              await fs.promises.mkdir(path.dirname(inputPath), { recursive: true })
-              await fs.promises.writeFile(inputPath, imgBuffer)
-              const outputPath = path.join(destDir, `${screen.id}.png`)
-              await convertToPng(inputPath, outputPath, device.width, device.height, this.logger)
-              imgUrl = `${this.configService.get<string>('api_url')}/screens/devices/${device.id}/${screen.id}.png`
-            }
+            const renderedHtml = await this.renderPluginHtml(plugin, screen)
+            if (renderedHtml)
+              imgUrl = await this.renderHtmlToScreenPng(renderedHtml, screen, device)
           }
           catch (err) {
             this.logger.error(`Failed to render plugin: ${err.message}`)
-            imgUrl = `${this.configService.get<string>('api_url')}/screens/error.png`
+            imgUrl = this.errorImageUrl()
           }
         }
       }
       // Handle HTML screen
       else if (screen.html) {
-        const browser = await puppeteer.launch({ args: ['--no-sandbox', '--disable-web-security'] })
-        const page = await browser.newPage()
-        await page.setViewport({ width: 800, height: 480 })
-        const content = `
+        imgUrl = await this.renderHtmlToScreenPng(this.wrapInTrmnlShell(screen.html), screen, device)
+      }
+    }
+    // Handle external link screen
+    if (screen.externalLink && !screen.fetchManual) {
+      const inputPath = path.join(resolveAppPath('public', 'screens', 'devices', device.id), 'tmp-source')
+      try {
+        await downloadImage(screen.externalLink, inputPath, this.logger)
+        await convertToPng(inputPath, this.screenImagePath(device, screen), device.width, device.height, this.logger)
+        this.logger.log('Updating generation date on screen')
+        screen.generatedAt = new Date()
+        await this.screenRepository.save(screen)
+        this.logger.log('Download and conversion successful')
+        imgUrl = this.screenImageUrl(device, screen)
+      }
+      catch (err) {
+        this.logger.error(`Failed to process image: ${err.message}`)
+        imgUrl = this.errorImageUrl()
+      }
+    }
+    if (imgUrl !== null)
+      return imgUrl
+
+    // No rendering source (e.g. uploaded file screens) — serve the stored image if present
+    return await fileExists(this.screenImagePath(device, screen))
+      ? this.screenImageUrl(device, screen)
+      : this.errorImageUrl()
+  }
+
+  private async renderPluginHtml(plugin: Plugin, screen: Screen): Promise<string | null> {
+    this.logger.log(`No cache, rendering plugin ${plugin.id} on-demand for screen ${screen.id}`)
+
+    // Build template context with trmnl system variables
+    const templateContext: any = {
+      trmnl: {
+        system: {
+          timestamp_utc: Math.floor(Date.now() / 1000),
+        },
+        plugin_settings: {
+          instance_name: plugin.name,
+          strategy: 'polling',
+          dark_mode: 'no',
+          no_screen_padding: 'no',
+        },
+        user: {
+          id: 'kuroshiro-user',
+          locale: 'en',
+        },
+      },
+    }
+
+    // TODO: Add plugin field values to context when we have device-specific values
+
+    let data = await this.pluginDataFetcher.fetchData(
+      plugin.dataSource.method,
+      plugin.dataSource.url,
+      plugin.dataSource.headers,
+      plugin.dataSource.body,
+      templateContext,
+    )
+
+    // Apply transform if exists
+    if (plugin.dataSource.transformJs) {
+      this.logger.debug('Applying transform.js to fetched data')
+      data = this.pluginTransformer.transform(plugin.dataSource.transformJs, data)
+    }
+
+    const fullTemplate = plugin.templates.find(t => t.layout === 'full')
+    if (!fullTemplate)
+      return null
+
+    const renderedHtml = await this.pluginRenderer.renderForDisplay(fullTemplate.liquidMarkup, data)
+    await this.cachePluginOutput(screen, renderedHtml)
+    return renderedHtml
+  }
+
+  private async renderHtmlToScreenPng(html: string, screen: Screen, device: Device): Promise<string> {
+    const browser = await puppeteer.launch({ args: ['--no-sandbox', '--disable-web-security'] })
+    try {
+      const page = await browser.newPage()
+      await page.setViewport({ width: 800, height: 480 })
+      await page.setContent(html, { waitUntil: 'load' })
+      const image: Uint8Array = await page.screenshot()
+
+      const destDir = resolveAppPath('public', 'screens', 'devices', device.id)
+      const inputPath = path.join(destDir, 'tmp-source')
+      await fs.promises.mkdir(destDir, { recursive: true })
+      await fs.promises.writeFile(inputPath, buffer.Buffer.from(image))
+      await convertToPng(inputPath, this.screenImagePath(device, screen), device.width, device.height, this.logger)
+      return this.screenImageUrl(device, screen)
+    }
+    finally {
+      await browser.close()
+    }
+  }
+
+  private wrapInTrmnlShell(html: string): string {
+    return `
     <html>
       <head>
         <link rel="stylesheet" href="https://usetrmnl.com/css/latest/plugins.css">
@@ -444,44 +439,29 @@ export class DeviceDisplayService {
       <body class="environment trmnl">
         <div class="screen">
           <div class="view view--full">
-            ${screen.html}
+            ${html}
           </div>
         </div>
       </body>
     </html>
   `
-        await page.setContent(content, { waitUntil: 'load' })
-        const image: Uint8Array = await page.screenshot()
-        const imgBuffer = buffer.Buffer.from(image)
-        const destDir = resolveAppPath('public', 'screens', 'devices', device.id)
-        const inputPath = path.join(destDir, 'tmp-source')
-        await fs.promises.mkdir(path.dirname(inputPath), { recursive: true })
-        await fs.promises.writeFile(inputPath, imgBuffer)
-        const outputPath = path.join(destDir, `${screen.id}.png`)
-        await convertToPng(inputPath, outputPath, device.width, device.height, this.logger)
-        imgUrl = `${this.configService.get<string>('api_url')}/screens/devices/${device.id}/${screen.id}.png`
-      }
-    }
-    // Handle external link screen
-    if (screen.externalLink && !screen.fetchManual) {
-      const destDir = resolveAppPath('public', 'screens', 'devices', device.id)
-      const inputPath = path.join(destDir, 'tmp-source')
-      const pngFilename = `${screen.id}.png`
-      const outputPath = path.join(destDir, pngFilename)
-      try {
-        await downloadImage(screen.externalLink, inputPath, this.logger)
-        await convertToPng(inputPath, outputPath, device.width, device.height, this.logger)
-        this.logger.log('Updating generation date on screen')
-        screen.generatedAt = new Date()
-        await this.screenRepository.save(screen)
-        this.logger.log('Download and conversion successful')
-        imgUrl = `${this.configService.get<string>('api_url')}/screens/devices/${device.id}/${pngFilename}`
-      }
-      catch (err) {
-        this.logger.error(`Failed to process image: ${err.message}`)
-        imgUrl = `${this.configService.get<string>('api_url')}/screens/error.png`
-      }
-    }
-    return imgUrl
+  }
+
+  private async cachePluginOutput(screen: Screen, renderedHtml: string): Promise<void> {
+    const generatedAt = new Date()
+    await this.screenRepository.update({ id: screen.id }, { cachedPluginOutput: renderedHtml, generatedAt })
+    screen.generatedAt = generatedAt
+  }
+
+  private screenImagePath(device: Device, screen: Screen): string {
+    return resolveAppPath('public', 'screens', 'devices', device.id, `${screen.id}.png`)
+  }
+
+  private screenImageUrl(device: Device, screen: Screen): string {
+    return `${this.configService.get<string>('api_url')}/screens/devices/${device.id}/${screen.id}.png`
+  }
+
+  private errorImageUrl(): string {
+    return `${this.configService.get<string>('api_url')}/screens/error.png`
   }
 }


### PR DESCRIPTION
Closes #54

## What

Screen PNGs were only generated when a device polled `/api/display`, while `/api/current_screen` just constructed a URL and hoped the file existed — so the device details view showed a broken image for devices that had never polled (freshly added plugin/mashup screens, mirrors, etc.).

`/api/current_screen` now guarantees a servable image:

- **Non-mirrored devices**: if the active screen's PNG is missing on disk, it is rendered on demand (plugin / mashup / html / external link) via the same pipeline `/api/display` uses. Screens with no rendering source (e.g. a deleted uploaded file) fall back to `error.png` instead of a dead URL.
- **Mirrored devices**: a missing `mirror.png` triggers an on-demand fetch from TRMNL's non-progressing `current_screen` API; `error.png` remains the fallback when TRMNL is unreachable.
- `rendered_at`/`filename` now reflect the fresh generation instead of stale stored metadata.

## Refactoring along the way

- Extracted the screen rendering logic from `getCurrentImage` into a shared `generateScreenImage` with a strict contract (always returns a servable URL).
- Collapsed the 4x copy-pasted puppeteer pipeline into one `renderHtmlToScreenPng` helper (now with `try/finally` browser cleanup — the html branch previously leaked the browser).
- Extracted `renderPluginHtml`, `fetchAndStoreMirrorImage`, and small path/URL helpers; added a typed `TrmnlScreenResponse`.

## Tests

- 6 new unit tests covering: on-demand generation when the PNG is missing, no regeneration when it exists, unregenerable screens falling back to `error.png`, fresh metadata after regeneration, on-demand mirror fetch, and mirror fetch failure.
- Full suite green: 332 API + 53 UI tests, lint clean, build succeeds.