### PR TITLE
feat: Add screen reordering endpoint and drag-and-drop UI

### DIFF
--- a/packages/api/src/screens/__test__/screens.controller.spec.ts
+++ b/packages/api/src/screens/__test__/screens.controller.spec.ts
@@ -13,6 +13,7 @@ function createMockService() {
     getByDevice: vi.fn(),
     delete: vi.fn(),
     updateExternalScreen: vi.fn(),
+    reorder: vi.fn(),
   }
 }
 
@@ -63,5 +64,13 @@ describe('screensController (unit)', () => {
     service.updateExternalScreen.mockResolvedValue(undefined)
     await expect(controller.updateExternalScreen('1')).resolves.toBeUndefined()
     expect(service.updateExternalScreen).toHaveBeenCalledWith('1')
+  })
+
+  it('reorder calls service with device id and screen ids', async () => {
+    const screens = [{ id: '2' } as Screen, { id: '1' } as Screen]
+    service.reorder.mockResolvedValue(screens)
+    const result = await controller.reorder('dev', { screenIds: ['2', '1'] })
+    expect(service.reorder).toHaveBeenCalledWith('dev', ['2', '1'])
+    expect(result).toBe(screens)
   })
 })

--- a/packages/api/src/screens/__test__/screens.service.spec.ts
+++ b/packages/api/src/screens/__test__/screens.service.spec.ts
@@ -3,6 +3,7 @@ import type { CreateScreenDto } from '../dto/create-screen.dto'
 import type { Screen } from '../screens.entity'
 import buffer from 'node:buffer'
 import * as fs from 'node:fs'
+import { BadRequestException, NotFoundException } from '@nestjs/common'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ScreensService } from '../screens.service'
@@ -13,7 +14,7 @@ vi.mock('../../utils/imageUtils', () => ({
 }))
 
 function createMockRepo() {
-  return {
+  const repo: any = {
     find: vi.fn(),
     findOne: vi.fn(),
     findOneBy: vi.fn(),
@@ -23,6 +24,11 @@ function createMockRepo() {
     remove: vi.fn(),
     delete: vi.fn(),
   }
+  repo.manager = {
+    getRepository: vi.fn(() => repo),
+    transaction: vi.fn(async (cb: (manager: any) => Promise<void>) => cb(repo.manager)),
+  }
+  return repo
 }
 
 describe('screensService', () => {
@@ -123,5 +129,69 @@ describe('screensService', () => {
   it('updateExternalScreen throws if not found', async () => {
     screensRepo.findOne.mockResolvedValue(null)
     await expect(service.updateExternalScreen('1')).rejects.toThrow()
+  })
+
+  it('reorder throws if device not found', async () => {
+    devicesRepo.findOne.mockResolvedValue(null)
+    await expect(service.reorder('dev', ['1', '2'])).rejects.toThrow(NotFoundException)
+  })
+
+  it('reorder reassigns order sequentially to match submitted array within a transaction', async () => {
+    const device = { id: 'dev' } as Device
+    devicesRepo.findOne.mockResolvedValue(device)
+    const screenA = { id: 'a', order: 1, device } as Screen
+    const screenB = { id: 'b', order: 2, device } as Screen
+    screensRepo.find
+      .mockResolvedValueOnce([screenA, screenB]) // fetch device screens
+      .mockResolvedValueOnce([screenB, screenA]) // getByDevice after reorder
+    screensRepo.save.mockResolvedValue(undefined)
+
+    const result = await service.reorder('dev', ['b', 'a'])
+
+    expect(screensRepo.manager.transaction).toHaveBeenCalled()
+    expect(screenB.order).toBe(1)
+    expect(screenA.order).toBe(2)
+    expect(screensRepo.save).toHaveBeenCalledWith(screenB)
+    expect(screensRepo.save).toHaveBeenCalledWith(screenA)
+    expect(result).toEqual([screenB, screenA])
+  })
+
+  it('reorder rejects payload with duplicate ids', async () => {
+    const device = { id: 'dev' } as Device
+    devicesRepo.findOne.mockResolvedValue(device)
+    const screenA = { id: 'a', order: 1, device } as Screen
+    const screenB = { id: 'b', order: 2, device } as Screen
+    screensRepo.find.mockResolvedValue([screenA, screenB])
+
+    await expect(service.reorder('dev', ['a', 'a'])).rejects.toThrow(BadRequestException)
+  })
+
+  it('reorder rejects payload missing a screen id', async () => {
+    const device = { id: 'dev' } as Device
+    devicesRepo.findOne.mockResolvedValue(device)
+    const screenA = { id: 'a', order: 1, device } as Screen
+    const screenB = { id: 'b', order: 2, device } as Screen
+    screensRepo.find.mockResolvedValue([screenA, screenB])
+
+    await expect(service.reorder('dev', ['a'])).rejects.toThrow(BadRequestException)
+  })
+
+  it('reorder rejects payload with a foreign screen id', async () => {
+    const device = { id: 'dev' } as Device
+    devicesRepo.findOne.mockResolvedValue(device)
+    const screenA = { id: 'a', order: 1, device } as Screen
+    const screenB = { id: 'b', order: 2, device } as Screen
+    screensRepo.find.mockResolvedValue([screenA, screenB])
+
+    await expect(service.reorder('dev', ['a', 'foreign-id'])).rejects.toThrow(BadRequestException)
+  })
+
+  it('reorder rejects payload with an extra screen id', async () => {
+    const device = { id: 'dev' } as Device
+    devicesRepo.findOne.mockResolvedValue(device)
+    const screenA = { id: 'a', order: 1, device } as Screen
+    screensRepo.find.mockResolvedValue([screenA])
+
+    await expect(service.reorder('dev', ['a', 'b'])).rejects.toThrow(BadRequestException)
   })
 })

--- a/packages/api/src/screens/dto/__test__/reorder-screens.dto.spec.ts
+++ b/packages/api/src/screens/dto/__test__/reorder-screens.dto.spec.ts
@@ -1,0 +1,47 @@
+import { validate } from 'class-validator'
+import { describe, expect, it } from 'vitest'
+import { ReorderScreensDto } from '../reorder-screens.dto'
+
+describe('reorder-screens dto', () => {
+  it('creates dto with screenIds', () => {
+    const dto = new ReorderScreensDto()
+    dto.screenIds = ['screen-1', 'screen-2']
+
+    expect(dto.screenIds).toEqual(['screen-1', 'screen-2'])
+  })
+
+  it('passes validation with a non-empty array of string ids', async () => {
+    const dto = new ReorderScreensDto()
+    dto.screenIds = ['screen-1', 'screen-2']
+
+    const errors = await validate(dto)
+
+    expect(errors).toHaveLength(0)
+  })
+
+  it('fails validation when screenIds is missing', async () => {
+    const dto = new ReorderScreensDto()
+
+    const errors = await validate(dto)
+
+    expect(errors.length).toBeGreaterThan(0)
+  })
+
+  it('fails validation when screenIds is empty', async () => {
+    const dto = new ReorderScreensDto()
+    dto.screenIds = []
+
+    const errors = await validate(dto)
+
+    expect(errors.length).toBeGreaterThan(0)
+  })
+
+  it('fails validation when screenIds contains non-string entries', async () => {
+    const dto = new ReorderScreensDto()
+    dto.screenIds = [1, 2] as unknown as string[]
+
+    const errors = await validate(dto)
+
+    expect(errors.length).toBeGreaterThan(0)
+  })
+})

--- a/packages/api/src/screens/dto/reorder-screens.dto.ts
+++ b/packages/api/src/screens/dto/reorder-screens.dto.ts
@@ -1,0 +1,8 @@
+import { ArrayNotEmpty, IsArray, IsString } from 'class-validator'
+
+export class ReorderScreensDto {
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsString({ each: true })
+  screenIds: string[]
+}

--- a/packages/api/src/screens/screens.controller.ts
+++ b/packages/api/src/screens/screens.controller.ts
@@ -5,6 +5,7 @@ import {
   Get,
   MethodNotAllowedException,
   Param,
+  Patch,
   Post,
   UploadedFile,
   UseInterceptors,
@@ -14,6 +15,7 @@ import {
 import { ConfigService } from '@nestjs/config'
 import { FileInterceptor } from '@nestjs/platform-express'
 import { CreateScreenDto } from './dto/create-screen.dto'
+import { ReorderScreensDto } from './dto/reorder-screens.dto'
 import { Screen } from './screens.entity'
 import { ScreensService } from './screens.service'
 
@@ -38,6 +40,12 @@ export class ScreensController {
   @Get('device/:deviceId')
   async getByDevice(@Param('deviceId') deviceId: string): Promise<Screen[]> {
     return this.screensService.getByDevice(deviceId)
+  }
+
+  @Patch('device/:deviceId/reorder')
+  @UsePipes(new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true }))
+  async reorder(@Param('deviceId') deviceId: string, @Body() body: ReorderScreensDto): Promise<Screen[]> {
+    return this.screensService.reorder(deviceId, body.screenIds)
   }
 
   @Delete(':id')

--- a/packages/api/src/screens/screens.service.ts
+++ b/packages/api/src/screens/screens.service.ts
@@ -3,7 +3,7 @@ import * as path from 'node:path'
 import { BadRequestException, Injectable, InternalServerErrorException, Logger, NotFoundException } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import { InjectRepository } from '@nestjs/typeorm'
-import { Repository } from 'typeorm'
+import { EntityManager, Repository } from 'typeorm'
 import { Device } from '../devices/devices.entity'
 import { convertToPng, downloadImage } from '../utils/imageUtils'
 import { resolveAppPath } from '../utils/pathHelper'
@@ -135,15 +135,56 @@ export class ScreensService {
     }
     await this.screensRepository.delete(id)
     this.logger.log(`Screen deleted: ${id}`)
-    // Reindex order for remaining screens
+    // Reindex order for remaining screens, closing the gap left by the deleted screen
     const screens = await this.screensRepository.find({ where: { device: { id: deviceId } }, order: { order: 'ASC' } })
+    await this.reindexScreens(screens)
+    this.logger.log(`Reindexed screen order for device ${deviceId}`)
+  }
+
+  async reorder(deviceId: string, screenIds: string[]): Promise<Screen[]> {
+    this.logger.log(`Reordering screens for device ${deviceId}`)
+    const device = await this.devicesRepository.findOne({ where: { id: deviceId } })
+    if (!device) {
+      this.logger.warn(`Device not found: ${deviceId}`)
+      throw new NotFoundException('Device not found')
+    }
+
+    const screens = await this.screensRepository.find({ where: { device: { id: deviceId } } })
+    const invalidPermutationMessage = 'screenIds must be an exact permutation of the device\'s current screens'
+    const uniqueIds = new Set(screenIds)
+    if (uniqueIds.size !== screenIds.length || screens.length !== screenIds.length) {
+      throw new BadRequestException(invalidPermutationMessage)
+    }
+
+    const screensById = new Map(screens.map(screen => [screen.id, screen]))
+    const orderedScreens = screenIds.map((screenId) => {
+      const screen = screensById.get(screenId)
+      if (!screen)
+        throw new BadRequestException(invalidPermutationMessage)
+      return screen
+    })
+
+    await this.screensRepository.manager.transaction(async (manager) => {
+      await this.reindexScreens(orderedScreens, manager)
+    })
+    this.logger.log(`Reordered screens for device ${deviceId}`)
+
+    return this.getByDevice(deviceId)
+  }
+
+  /**
+   * Assigns sequential order (1..N) to the given screens in the order they were passed,
+   * persisting only the screens whose order actually changed. Shared by the delete-reindex
+   * path (gap closing) and the reorder path (arbitrary new order).
+   */
+  private async reindexScreens(screens: Screen[], manager: EntityManager = this.screensRepository.manager): Promise<void> {
+    const repository = manager.getRepository(Screen)
     for (let i = 0; i < screens.length; i++) {
       if (screens[i].order !== i + 1) {
         screens[i].order = i + 1
-        await this.screensRepository.save(screens[i])
+        await repository.save(screens[i])
       }
     }
-    this.logger.log(`Reindexed screen order for device ${deviceId}`)
   }
 
   async updateExternalScreen(id: string) {

--- a/packages/ui/src/components/ScreenListCard.vue
+++ b/packages/ui/src/components/ScreenListCard.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import type { Screen } from '@/types'
-import { mdiDelete, mdiEye, mdiOpenInNew, mdiRefresh } from '@mdi/js'
+import { mdiChevronDown, mdiChevronUp, mdiDelete, mdiDrag, mdiEye, mdiOpenInNew, mdiRefresh } from '@mdi/js'
 import { computed, nextTick, ref, useTemplateRef } from 'vue'
-import { VAlert, VBtn, VCard, VCardActions, VCardText, VCardTitle, VChip, VDialog, VDivider, VOverlay, VSpacer, VTable, VTooltip } from 'vuetify/components'
+import { VAlert, VBtn, VCard, VCardActions, VCardText, VCardTitle, VChip, VDialog, VDivider, VIcon, VOverlay, VSpacer, VTable, VTooltip } from 'vuetify/components'
 import { useDeviceStore } from '@/stores/device.ts'
 import { useScreensStore } from '@/stores/screens'
 
@@ -21,6 +21,65 @@ async function updateExternalImage(screenId: string) {
   if (!device.value)
     return
   await screensStore.updateExternalScreen(device.value.id, screenId)
+}
+
+const isReordering = ref(false)
+const reorderError = ref<string | null>(null)
+const draggingIndex = ref<number | null>(null)
+const dragOverIndex = ref<number | null>(null)
+
+async function persistOrder(orderedIds: string[]) {
+  if (!device.value)
+    return
+  isReordering.value = true
+  reorderError.value = null
+  try {
+    await screensStore.reorderScreens(device.value.id, orderedIds)
+  }
+  catch {
+    reorderError.value = 'Failed to save the new screen order. The list has been reloaded.'
+  }
+  finally {
+    isReordering.value = false
+  }
+}
+
+function onDragStart(index: number) {
+  draggingIndex.value = index
+}
+
+function onDragEnter(index: number) {
+  dragOverIndex.value = index
+}
+
+function onDragEnd() {
+  draggingIndex.value = null
+  dragOverIndex.value = null
+}
+
+function currentScreenIds() {
+  return screensStore.screens.map(screen => screen.id)
+}
+
+function onDrop(targetIndex: number) {
+  const sourceIndex = draggingIndex.value
+  draggingIndex.value = null
+  dragOverIndex.value = null
+  if (sourceIndex === null || sourceIndex === targetIndex)
+    return
+  const orderedIds = currentScreenIds()
+  const [movedId] = orderedIds.splice(sourceIndex, 1)
+  orderedIds.splice(targetIndex, 0, movedId)
+  persistOrder(orderedIds)
+}
+
+function moveScreen(index: number, direction: -1 | 1) {
+  const targetIndex = index + direction
+  if (targetIndex < 0 || targetIndex >= screensStore.screens.length)
+    return
+  const orderedIds = currentScreenIds()
+  ;[orderedIds[index], orderedIds[targetIndex]] = [orderedIds[targetIndex], orderedIds[index]]
+  persistOrder(orderedIds)
 }
 const showHtmlPreview = ref(false)
 const showScreenPreview = ref(false)
@@ -68,14 +127,31 @@ function previewScreen(screen: Screen) {
 <template>
   <template v-if="device">
     <VCard elevation="1" class="mb-6">
-      <VCardTitle>Screens</VCardTitle>
+      <VCardTitle class="d-flex align-center">
+        Screens
+        <VChip v-if="isReordering" size="small" color="info" variant="tonal" class="ml-3" data-test-id="reorder-saving-indicator">
+          Saving order…
+        </VChip>
+      </VCardTitle>
       <VDivider />
       <VCardText>
+        <VAlert
+          v-if="reorderError"
+          type="error"
+          variant="tonal"
+          class="mb-4"
+          closable
+          data-test-id="reorder-error-alert"
+          @click:close="reorderError = null"
+        >
+          {{ reorderError }}
+        </VAlert>
         <template v-if="screensStore.screens.length">
           <div class="overflow-x-auto">
             <VTable density="comfortable" data-test-id="screen-table">
               <thead>
                 <tr>
+                  <th>Order</th>
                   <th>Type</th>
                   <th>Filename</th>
                   <th>Status</th>
@@ -85,7 +161,44 @@ function previewScreen(screen: Screen) {
                 </tr>
               </thead>
               <tbody>
-                <tr v-for="screen in screensStore.screens" :key="screen.id">
+                <tr
+                  v-for="(screen, index) in screensStore.screens"
+                  :key="screen.id"
+                  :draggable="!isReordering"
+                  :class="{ 'bg-grey-lighten-3': dragOverIndex === index && draggingIndex !== null && draggingIndex !== index }"
+                  :data-test-id="`screen-row-${screen.id}`"
+                  @dragstart="onDragStart(index)"
+                  @dragover.prevent="onDragEnter(index)"
+                  @drop="onDrop(index)"
+                  @dragend="onDragEnd"
+                >
+                  <td>
+                    <div class="d-flex align-center">
+                      <VIcon :icon="mdiDrag" class="mr-1 cursor-grab" aria-hidden="true" />
+                      <div class="d-flex flex-column">
+                        <VBtn
+                          size="x-small"
+                          variant="text"
+                          density="compact"
+                          :icon="mdiChevronUp"
+                          :disabled="isReordering || index === 0"
+                          aria-label="Move screen up"
+                          :data-test-id="`screen-move-up-${screen.id}`"
+                          @click="moveScreen(index, -1)"
+                        />
+                        <VBtn
+                          size="x-small"
+                          variant="text"
+                          density="compact"
+                          :icon="mdiChevronDown"
+                          :disabled="isReordering || index === screensStore.screens.length - 1"
+                          aria-label="Move screen down"
+                          :data-test-id="`screen-move-down-${screen.id}`"
+                          @click="moveScreen(index, 1)"
+                        />
+                      </div>
+                    </div>
+                  </td>
                   <td>
                     <VChip
                       :color="screen.type === 'mashup' ? 'orange' : screen.plugin ? 'purple' : screen.externalLink ? 'info' : 'primary'"

--- a/packages/ui/src/components/__test__/ScreenListCard.spec.ts
+++ b/packages/ui/src/components/__test__/ScreenListCard.spec.ts
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils'
+import { flushPromises, mount } from '@vue/test-utils'
 import { createPinia } from 'pinia'
 import rop from 'resize-observer-polyfill'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -48,6 +48,7 @@ describe('screenListCard', () => {
       screens: [],
       deleteScreen: vi.fn(),
       updateExternalScreen: vi.fn(),
+      reorderScreens: vi.fn(),
     }
   })
 
@@ -134,6 +135,111 @@ describe('screenListCard', () => {
     expect((wrapper.vm as any).selectedPreviewScreen.cachedPluginOutput).toBe(cachedHtml)
 
     wrapper.unmount()
+  })
+
+  it('moving a screen down with the button calls reorderScreens with the swapped id order', async () => {
+    screensStoreMock.screens = [
+      { id: 'screen1', filename: 'file1', externalLink: null, isActive: true, device: 'device1', fetchManual: false, html: '' },
+      { id: 'screen2', filename: 'file2', externalLink: null, isActive: false, device: 'device1', fetchManual: false, html: '' },
+    ]
+    screensStoreMock.reorderScreens.mockResolvedValue(undefined)
+    const wrapper = mount(ScreenListCard, {
+      props: { deviceId: 'device1' },
+      global: {
+        plugins: [createPinia(), vuetify],
+      },
+    })
+
+    await wrapper.find('[data-test-id="screen-move-down-screen1"]').trigger('click')
+
+    expect(screensStoreMock.reorderScreens).toHaveBeenCalledWith('device1', ['screen2', 'screen1'])
+  })
+
+  it('the up button is disabled for the first row and the down button for the last row', () => {
+    screensStoreMock.screens = [
+      { id: 'screen1', filename: 'file1', externalLink: null, isActive: true, device: 'device1', fetchManual: false, html: '' },
+      { id: 'screen2', filename: 'file2', externalLink: null, isActive: false, device: 'device1', fetchManual: false, html: '' },
+    ]
+    const wrapper = mount(ScreenListCard, {
+      props: { deviceId: 'device1' },
+      global: {
+        plugins: [createPinia(), vuetify],
+      },
+    })
+
+    expect(wrapper.find('[data-test-id="screen-move-up-screen1"]').attributes('disabled')).toBeDefined()
+    expect(wrapper.find('[data-test-id="screen-move-down-screen2"]').attributes('disabled')).toBeDefined()
+    expect(wrapper.find('[data-test-id="screen-move-down-screen1"]').attributes('disabled')).toBeUndefined()
+    expect(wrapper.find('[data-test-id="screen-move-up-screen2"]').attributes('disabled')).toBeUndefined()
+  })
+
+  it('shows a saving indicator and disables the move buttons while a reorder request is in flight', async () => {
+    screensStoreMock.screens = [
+      { id: 'screen1', filename: 'file1', externalLink: null, isActive: true, device: 'device1', fetchManual: false, html: '' },
+      { id: 'screen2', filename: 'file2', externalLink: null, isActive: false, device: 'device1', fetchManual: false, html: '' },
+    ]
+    let resolveReorder: () => void = () => {}
+    screensStoreMock.reorderScreens.mockReturnValue(new Promise<void>((resolve) => {
+      resolveReorder = resolve
+    }))
+    const wrapper = mount(ScreenListCard, {
+      props: { deviceId: 'device1' },
+      global: {
+        plugins: [createPinia(), vuetify],
+      },
+    })
+
+    expect(wrapper.find('[data-test-id="reorder-saving-indicator"]').exists()).toBe(false)
+
+    await wrapper.find('[data-test-id="screen-move-down-screen1"]').trigger('click')
+    expect(wrapper.find('[data-test-id="reorder-saving-indicator"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test-id="screen-move-up-screen2"]').attributes('disabled')).toBeDefined()
+
+    resolveReorder()
+    await flushPromises()
+
+    expect(wrapper.find('[data-test-id="reorder-saving-indicator"]').exists()).toBe(false)
+  })
+
+  it('shows an error alert when the reorder request fails', async () => {
+    screensStoreMock.screens = [
+      { id: 'screen1', filename: 'file1', externalLink: null, isActive: true, device: 'device1', fetchManual: false, html: '' },
+      { id: 'screen2', filename: 'file2', externalLink: null, isActive: false, device: 'device1', fetchManual: false, html: '' },
+    ]
+    screensStoreMock.reorderScreens.mockRejectedValue(new Error('Failed to reorder screens'))
+    const wrapper = mount(ScreenListCard, {
+      props: { deviceId: 'device1' },
+      global: {
+        plugins: [createPinia(), vuetify],
+      },
+    })
+
+    await wrapper.find('[data-test-id="screen-move-down-screen1"]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.find('[data-test-id="reorder-error-alert"]').exists()).toBe(true)
+  })
+
+  it('reorders via drag and drop and calls reorderScreens with the new order', async () => {
+    screensStoreMock.screens = [
+      { id: 'screen1', filename: 'file1', externalLink: null, isActive: true, device: 'device1', fetchManual: false, html: '' },
+      { id: 'screen2', filename: 'file2', externalLink: null, isActive: false, device: 'device1', fetchManual: false, html: '' },
+    ]
+    screensStoreMock.reorderScreens.mockResolvedValue(undefined)
+    const wrapper = mount(ScreenListCard, {
+      props: { deviceId: 'device1' },
+      global: {
+        plugins: [createPinia(), vuetify],
+      },
+    })
+
+    const firstRow = wrapper.find('[data-test-id="screen-row-screen1"]')
+    const secondRow = wrapper.find('[data-test-id="screen-row-screen2"]')
+    await firstRow.trigger('dragstart')
+    await secondRow.trigger('dragover')
+    await secondRow.trigger('drop')
+
+    expect(screensStoreMock.reorderScreens).toHaveBeenCalledWith('device1', ['screen2', 'screen1'])
   })
 
   it('shows info alert when mashup has no cached output', async () => {

--- a/packages/ui/src/stores/__test__/screens.spec.ts
+++ b/packages/ui/src/stores/__test__/screens.spec.ts
@@ -1,0 +1,41 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useScreensStore } from '../screens'
+
+describe('screens store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    globalThis.fetch = vi.fn()
+  })
+
+  it('reorderScreens sends the ordered ids and stores the server-confirmed order', async () => {
+    const reordered = [{ id: 'b', order: 1 }, { id: 'a', order: 2 }]
+    ;(globalThis.fetch as any).mockResolvedValue({
+      ok: true,
+      json: async () => reordered,
+    })
+
+    const store = useScreensStore()
+    await store.reorderScreens('device-1', ['b', 'a'])
+
+    expect(globalThis.fetch).toHaveBeenCalledWith('/api/screens/device/device-1/reorder', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ screenIds: ['b', 'a'] }),
+    })
+    expect(store.screens).toEqual(reordered)
+  })
+
+  it('reorderScreens refetches the device screens and throws on failure', async () => {
+    const serverScreens = [{ id: 'a', order: 1 }, { id: 'b', order: 2 }]
+    ;(globalThis.fetch as any)
+      .mockResolvedValueOnce({ ok: false })
+      .mockResolvedValueOnce({ ok: true, json: async () => serverScreens })
+
+    const store = useScreensStore()
+    await expect(store.reorderScreens('device-1', ['b', 'a'])).rejects.toThrow('Failed to reorder screens')
+
+    expect(globalThis.fetch).toHaveBeenCalledWith('/api/screens/device/device-1')
+    expect(store.screens).toEqual(serverScreens)
+  })
+})

--- a/packages/ui/src/stores/screens.ts
+++ b/packages/ui/src/stores/screens.ts
@@ -75,5 +75,18 @@ export const useScreensStore = defineStore('screens', () => {
     }
   }
 
-  return { screens, currentScreen, fetchScreensForDevice, addScreen, addScreenFile, addScreenHtml, deleteScreen, updateExternalScreen, fetchCurrentScreenForDevice }
+  async function reorderScreens(deviceId: string, screenIds: string[]) {
+    const res = await fetch(`/api/screens/device/${deviceId}/reorder`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ screenIds }),
+    })
+    if (!res.ok) {
+      await fetchScreensForDevice(deviceId)
+      throw new Error('Failed to reorder screens')
+    }
+    screens.value = await res.json()
+  }
+
+  return { screens, currentScreen, fetchScreensForDevice, addScreen, addScreenFile, addScreenHtml, deleteScreen, updateExternalScreen, reorderScreens, fetchCurrentScreenForDevice }
 })

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -33,6 +33,7 @@ export interface Screen {
   devicePluginId?: string | null
   cachedPluginOutput?: string | null
   mashupConfiguration?: { id: string, layout: string }
+  order?: number
 }
 
 export interface CurrentScreen {


### PR DESCRIPTION
## Summary
- Adds `PATCH /screens/device/:deviceId/reorder`, which reassigns a device's screen `order` from a submitted ordered ID array in one transaction, strictly rejecting any payload that isn't an exact permutation of the device's current screens (missing/extra/foreign/duplicate IDs → 400)
- Extracts a shared `reindexScreens` helper used by both the new reorder path and the existing delete-reindex path; delete behavior is unchanged
- `ScreenListCard.vue` rows are now draggable to reorder, with per-row up/down buttons as a keyboard-accessible alternative, working uniformly across all screen types (file/external/html/plugin/mashup)
- The UI is pessimistic: drag/buttons disable with a "Saving order…" indicator while a request is in flight; success reflects the server-confirmed order, failure shows an error and refetches the server's actual state

Closes #675

## Test plan
- [x] `pnpm run test` — all 404 tests pass (backend service/controller/DTO tests for the reorder endpoint incl. permutation-rejection cases; frontend store + component tests for drag, up/down buttons, saving indicator, and error/refetch flow)
- [x] `pnpm run lint` — clean
- [x] `pnpm run type-check` — clean