### PR TITLE
fix(api): pass device id instead of full entity to screen findOneBy

### DIFF
--- a/packages/api/src/devices/display.service.ts
+++ b/packages/api/src/devices/display.service.ts
@@ -94,7 +94,7 @@ export class DeviceDisplayService {
     device.lastSeen = new Date()
     await this.deviceRepository.save(device)
     this.logger.log(`Device info updated for MAC: ${headers.id}`)
-    const activeScreen = await this.screenRepository.findOneBy({ device, isActive: true })
+    const activeScreen = await this.screenRepository.findOneBy({ device: { id: device.id }, isActive: true })
     if (!activeScreen && !device.mirrorEnabled) {
       this.logger.log('No screen found returning default no screen image')
       return new Display({
@@ -110,10 +110,10 @@ export class DeviceDisplayService {
     if (!device.mirrorEnabled) {
       this.logger.log(`Device ${device.id} is not mirrored. Cycling screens.`)
       await this.screenRepository.update({ device: { id: device.id } }, { isActive: false })
-      let nextScreen = await this.screenRepository.findOneBy({ device, order: activeScreen.order + 1 })
+      let nextScreen = await this.screenRepository.findOneBy({ device: { id: device.id }, order: activeScreen.order + 1 })
       if (!nextScreen) {
         this.logger.log(`No next screen found, cycling to first screen for device ${device.id}`)
-        nextScreen = await this.screenRepository.findOneBy({ device, order: 1 })
+        nextScreen = await this.screenRepository.findOneBy({ device: { id: device.id }, order: 1 })
       }
       nextScreen.isActive = true
       await this.screenRepository.save(nextScreen)
@@ -187,7 +187,7 @@ export class DeviceDisplayService {
       this.logger.warn(`Invalid API key for device: ${headers.id}`)
       throw new UnauthorizedException('Invalid API key')
     }
-    const activeScreen = await this.screenRepository.findOneBy({ device, isActive: true })
+    const activeScreen = await this.screenRepository.findOneBy({ device: { id: device.id }, isActive: true })
     if (!activeScreen && !device.mirrorEnabled) {
       this.logger.log('No screen found returning default no screen image')
       return new DisplayScreen({


### PR DESCRIPTION
## Summary
- `getCurrentImage` / `getCurrentImageWithoutProgressing` in `display.service.ts` passed the full `Device` entity into `screenRepository.findOneBy({ device, ... })`
- `Device` has an unloaded `screens: Screen[]` `OneToMany` relation; TypeORM v1 walks the whole passed-in relation object when building the WHERE clause and throws on the `undefined` value, crashing both display endpoints in production (`TypeORMError: Undefined value encountered in property 'Screen__Screen_device.screens'`)
- Fixed by passing `{ id: device.id }` instead, matching the pattern already used elsewhere in the file (e.g. the `update({ device: { id: device.id } }, ...)` call)

Follow-up from #723 (TypeORM 0.3.x -> 1.1.0 migration) — same root cause (full entities vs. relation objects tripping the stricter v1 query builder), different call pattern than the one #723 fixed.

## Test plan
- [x] `vitest run src/devices/__test__/display.service.spec.ts` — 21 passed
- [x] `vitest run src/devices/__test__/display.controller.spec.ts` — 4 passed
- [x] `eslint src/devices/display.service.ts` — clean