### PR TITLE
feat: render screens at the device model's native size in the TRMNL shell (2/3)

### DIFF
--- a/packages/api/src/device-models/__test__/screen-shell.spec.ts
+++ b/packages/api/src/device-models/__test__/screen-shell.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { screenClasses, screenStyle, viewFull, wrapInScreenShell } from '../screen-shell'
+import { BW, GRAY_4, GRAY_16, OG_PLUS, V2 } from './mockDeviceModelsService'
+
+describe('screen shell', () => {
+  it('builds the screen class list from model, palette and orientation', () => {
+    expect(screenClasses({ model: V2, palette: GRAY_16 })).toEqual([
+      'screen',
+      'screen--v2',
+      'screen--lg',
+      'screen--density-2x',
+      'screen--4bit',
+      'screen--landscape',
+    ])
+    expect(screenClasses({ model: OG_PLUS, palette: BW })).toContain('screen--1bit')
+    expect(screenClasses({ model: { ...OG_PLUS, rotation: 90 }, palette: GRAY_4 })).toContain('screen--portrait')
+  })
+
+  it('serialises the model CSS variables as an inline style', () => {
+    expect(screenStyle({ model: V2, palette: GRAY_16 })).toBe('--screen-w: 1040px; --screen-h: 780px;')
+    expect(screenStyle({ model: { ...V2, cssVariables: {} }, palette: GRAY_16 })).toBe('')
+  })
+
+  it('wraps a full view', () => {
+    expect(viewFull('<p>x</p>')).toBe('<div class="view view--full"><p>x</p></div>')
+  })
+
+  it('wraps body markup in a complete document loading the TRMNL framework', () => {
+    const html = wrapInScreenShell({ model: V2, palette: GRAY_16 }, '<div class="view view--full">hi</div>')
+    expect(html).toContain('<link rel="stylesheet" href="https://usetrmnl.com/css/latest/plugins.css">')
+    expect(html).toContain('<script src="https://usetrmnl.com/js/latest/plugins.js"></script>')
+    expect(html).toContain('<body class="environment trmnl">')
+    expect(html).toContain('<div class="screen screen--v2 screen--lg screen--density-2x screen--4bit screen--landscape" style="--screen-w: 1040px; --screen-h: 780px;"><div class="view view--full">hi</div></div>')
+  })
+
+  it('omits the style attribute when the model has no CSS variables', () => {
+    const html = wrapInScreenShell({ model: { ...OG_PLUS, cssVariables: {} }, palette: GRAY_4 }, 'x')
+    expect(html).toContain('<div class="screen screen--og_plus screen--md screen--density-1x screen--2bit screen--landscape">x</div>')
+  })
+})

--- a/packages/api/src/device-models/screen-shell.ts
+++ b/packages/api/src/device-models/screen-shell.ts
@@ -1,0 +1,38 @@
+import type { DeviceRenderTarget } from './device-models.service'
+
+export const TRMNL_FRAMEWORK_CSS = 'https://usetrmnl.com/css/latest/plugins.css'
+export const TRMNL_FRAMEWORK_JS = 'https://usetrmnl.com/js/latest/plugins.js'
+
+/**
+ * Class list for the `.screen` element the TRMNL framework sizes and scales:
+ * the model's own classes (device, size tier, density), the palette's bit-depth
+ * class and the orientation.
+ */
+export function screenClasses({ model, palette }: DeviceRenderTarget): string[] {
+  return ['screen', ...model.cssClasses, palette.frameworkClass, model.rotation === 0 ? 'screen--landscape' : 'screen--portrait']
+}
+
+export function screenStyle({ model }: DeviceRenderTarget): string {
+  return Object.entries(model.cssVariables).map(([name, value]) => `${name}: ${value};`).join(' ')
+}
+
+export function viewFull(innerHtml: string): string {
+  return `<div class="view view--full">${innerHtml}</div>`
+}
+
+/**
+ * Wraps screen body markup (a `.view` or `.mashup` element) in the full HTML
+ * document a device's image is rendered from.
+ */
+export function wrapInScreenShell(target: DeviceRenderTarget, bodyHtml: string): string {
+  const style = screenStyle(target)
+  return `<html>
+  <head>
+    <link rel="stylesheet" href="${TRMNL_FRAMEWORK_CSS}">
+    <script src="${TRMNL_FRAMEWORK_JS}"></script>
+  </head>
+  <body class="environment trmnl">
+    <div class="${screenClasses(target).join(' ')}"${style ? ` style="${style}"` : ''}>${bodyHtml}</div>
+  </body>
+</html>`
+}

--- a/packages/api/src/devices/__test__/display.service.spec.ts
+++ b/packages/api/src/devices/__test__/display.service.spec.ts
@@ -2,13 +2,19 @@ import type { MockDeviceModelsService } from '../../device-models/__test__/mockD
 import { promises as fs } from 'node:fs'
 import { NotFoundException, UnauthorizedException } from '@nestjs/common'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { createMockDeviceModelsService, OG_PLUS, primeMockDeviceModelsService, V2 } from '../../device-models/__test__/mockDeviceModelsService'
+import { createMockDeviceModelsService, GRAY_16, OG_PLUS, primeMockDeviceModelsService, V2 } from '../../device-models/__test__/mockDeviceModelsService'
 import { Display } from '../display'
 import { DeviceDisplayService } from '../display.service'
 import { DisplayScreen } from '../displayScreen'
 
-const { fileExists } = vi.hoisted(() => ({
+const { fileExists, puppeteerPage, puppeteerLaunch } = vi.hoisted(() => ({
   fileExists: vi.fn(),
+  puppeteerPage: {
+    setViewport: vi.fn(),
+    setContent: vi.fn(),
+    screenshot: vi.fn(),
+  },
+  puppeteerLaunch: vi.fn(),
 }))
 
 vi.mock('../../utils/fileExists', () => ({
@@ -18,6 +24,8 @@ vi.mock('../../utils/fileExists', () => ({
 vi.mock('node:fs', () => ({
   promises: {
     unlink: vi.fn(),
+    mkdir: vi.fn(),
+    writeFile: vi.fn(),
   },
 }))
 
@@ -27,16 +35,15 @@ vi.mock('../../utils/imageUtils', () => ({
 }))
 
 vi.mock('puppeteer', () => ({
-  default: {
-    launch: vi.fn().mockResolvedValue({
-      newPage: vi.fn().mockResolvedValue({
-        setViewport: vi.fn().mockResolvedValue(undefined),
-        setContent: vi.fn().mockResolvedValue(undefined),
-        screenshot: vi.fn().mockResolvedValue(new Uint8Array()),
-      }),
-    }),
-  },
+  default: { launch: puppeteerLaunch },
 }))
+
+function primePuppeteer() {
+  puppeteerPage.setViewport.mockResolvedValue(undefined)
+  puppeteerPage.setContent.mockResolvedValue(undefined)
+  puppeteerPage.screenshot.mockResolvedValue(new Uint8Array())
+  puppeteerLaunch.mockResolvedValue({ newPage: vi.fn().mockResolvedValue(puppeteerPage), close: vi.fn() })
+}
 
 const mockFetch = vi.fn()
 globalThis.fetch = mockFetch
@@ -70,6 +77,7 @@ describe('deviceDisplayService', () => {
     )
     vi.resetAllMocks()
     primeMockDeviceModelsService(deviceModels)
+    primePuppeteer()
   })
 
   const baseDevice = {
@@ -131,6 +139,73 @@ describe('deviceDisplayService', () => {
       deviceRepo.findOneBy.mockResolvedValue(device)
       await service.getCurrentImage({ ...headers, model: 'x' } as any)
       expect(deviceModels.assignResolvedModel).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('rendering in the device model shell', () => {
+    function primeRotation(nextScreen: Record<string, unknown>, device: Record<string, unknown>) {
+      const activeScreen = { id: 'screen1', order: 1, device, isActive: true, generatedAt: new Date() }
+      deviceRepo.findOneBy.mockResolvedValue(device)
+      screenRepo.findOneBy.mockResolvedValueOnce(activeScreen).mockResolvedValueOnce(nextScreen)
+      screenRepo.findOne.mockResolvedValue(nextScreen)
+      screenRepo.save.mockResolvedValue(nextScreen)
+      configService.get.mockReturnValue('http://api')
+    }
+
+    it('renders HTML screens at the model size inside the model shell', async () => {
+      const device = { ...baseDevice, deviceModel: V2, palette: GRAY_16 }
+      deviceModels.renderTargetFor.mockResolvedValue({ model: V2, palette: GRAY_16 })
+      primeRotation({ id: 'screen2', type: 'html', order: 2, device, html: '<p>hi</p>', filename: 'x', generatedAt: new Date() }, device)
+
+      const result = await service.getCurrentImage(headers as any)
+
+      expect(puppeteerPage.setViewport).toHaveBeenCalledWith({ width: 1872, height: 1404 })
+      const html: string = puppeteerPage.setContent.mock.calls[0][0]
+      expect(html).toContain('class="screen screen--v2 screen--lg screen--density-2x screen--4bit screen--landscape"')
+      expect(html).toContain('--screen-w: 1040px;')
+      expect(html).toContain('<div class="view view--full"><p>hi</p></div>')
+      const { convertToPng } = await import('../../utils/imageUtils')
+      expect(convertToPng).toHaveBeenCalledWith(expect.any(String), expect.stringContaining('screen2.png'), 1872, 1404, expect.any(Object))
+      expect(result.image_url).toBe('http://api/screens/devices/1/screen2.png')
+    })
+
+    it('wraps cached plugin output in a full view and the shell', async () => {
+      const device = { ...baseDevice, deviceModel: OG_PLUS }
+      primeRotation({ id: 'screen2', type: 'plugin', order: 2, device, plugin: { id: 'p1' }, cachedPluginOutput: '<span>cached</span>', filename: 'x', generatedAt: new Date() }, device)
+
+      await service.getCurrentImage(headers as any)
+
+      expect(puppeteerPage.setViewport).toHaveBeenCalledWith({ width: 800, height: 480 })
+      const html: string = puppeteerPage.setContent.mock.calls[0][0]
+      expect(html).toContain('screen--og_plus')
+      expect(html).toContain('screen--2bit')
+      expect(html).toContain('<div class="view view--full"><span>cached</span></div>')
+    })
+
+    it('caches only the rendered plugin body when rendering on demand', async () => {
+      const device = { ...baseDevice, deviceModel: OG_PLUS }
+      const plugin = { id: 'p1', name: 'P', dataSource: { method: 'GET', url: 'http://x' }, templates: [{ layout: 'full', liquidMarkup: '{{ v }}' }] }
+      primeRotation({ id: 'screen2', type: 'plugin', order: 2, device, plugin, filename: 'x', generatedAt: new Date() }, device)
+      service.pluginDataFetcher = { fetchData: vi.fn().mockResolvedValue({ v: 1 }) } as any
+      service.pluginRenderer = { render: vi.fn().mockResolvedValue('<b>1</b>') } as any
+
+      await service.getCurrentImage(headers as any)
+
+      expect(screenRepo.update).toHaveBeenCalledWith({ id: 'screen2' }, expect.objectContaining({ cachedPluginOutput: '<b>1</b>' }))
+      const html: string = puppeteerPage.setContent.mock.calls[0][0]
+      expect(html).toContain('<div class="view view--full"><b>1</b></div>')
+    })
+
+    it('places cached mashup markup directly inside the shell', async () => {
+      const device = { ...baseDevice, deviceModel: OG_PLUS }
+      primeRotation({ id: 'screen2', type: 'mashup', order: 2, device, cachedPluginOutput: '<div class="mashup mashup--1Lx1R">m</div>', mashupConfiguration: { id: 'c' }, filename: 'x', generatedAt: new Date() }, device)
+      service.mashupRenderer = { renderMashup: vi.fn() } as any
+
+      await service.getCurrentImage(headers as any)
+
+      const html: string = puppeteerPage.setContent.mock.calls[0][0]
+      expect(html).toMatch(/screen--landscape"[^>]*><div class="mashup mashup--1Lx1R">m<\/div><\/div>/)
+      expect(html).not.toContain('view--full')
     })
   })
 
@@ -453,7 +528,7 @@ describe('deviceDisplayService', () => {
     beforeEach(() => {
       // Inject services needed for mashup
       service.pluginDataFetcher = { fetchData: vi.fn() } as any
-      service.pluginRenderer = { render: vi.fn(), renderForDisplay: vi.fn() } as any
+      service.pluginRenderer = { render: vi.fn() } as any
       service.pluginTransformer = { transform: vi.fn() } as any
     })
 

--- a/packages/api/src/devices/display.service.ts
+++ b/packages/api/src/devices/display.service.ts
@@ -10,6 +10,7 @@ import { InjectRepository } from '@nestjs/typeorm'
 import puppeteer from 'puppeteer'
 import { Repository } from 'typeorm'
 import { DeviceModelsService } from '../device-models/device-models.service'
+import { viewFull, wrapInScreenShell } from '../device-models/screen-shell'
 import { PluginDataFetcherService } from '../plugins/services/plugin-data-fetcher.service'
 import { PluginRendererService } from '../plugins/services/plugin-renderer.service'
 import { PluginTransformService } from '../plugins/services/plugin-transform.service'
@@ -293,7 +294,7 @@ export class DeviceDisplayService {
             await this.cachePluginOutput(screen, renderedHtml)
           }
 
-          imgUrl = await this.renderHtmlToScreenPng(renderedHtml, screen, device)
+          imgUrl = await this.renderBodyToScreenPng(renderedHtml, screen, device)
         }
       }
       catch (err) {
@@ -316,7 +317,7 @@ export class DeviceDisplayService {
         if (screenWithPlugin.cachedPluginOutput) {
           try {
             this.logger.log(`Using cached plugin output for plugin ${plugin.id}, screen ${screen.id}`)
-            imgUrl = await this.renderHtmlToScreenPng(screenWithPlugin.cachedPluginOutput, screen, device)
+            imgUrl = await this.renderBodyToScreenPng(viewFull(screenWithPlugin.cachedPluginOutput), screen, device)
           }
           catch (err) {
             this.logger.error(`Failed to render cached plugin output: ${err.message}`)
@@ -328,7 +329,7 @@ export class DeviceDisplayService {
           try {
             const renderedHtml = await this.renderPluginHtml(plugin, screen)
             if (renderedHtml)
-              imgUrl = await this.renderHtmlToScreenPng(renderedHtml, screen, device)
+              imgUrl = await this.renderBodyToScreenPng(viewFull(renderedHtml), screen, device)
           }
           catch (err) {
             this.logger.error(`Failed to render plugin: ${err.message}`)
@@ -338,7 +339,7 @@ export class DeviceDisplayService {
       }
       // Handle HTML screen
       else if (screen.html) {
-        imgUrl = await this.renderHtmlToScreenPng(this.wrapInTrmnlShell(screen.html), screen, device)
+        imgUrl = await this.renderBodyToScreenPng(viewFull(screen.html), screen, device)
       }
     }
     // Handle external link screen
@@ -410,48 +411,35 @@ export class DeviceDisplayService {
     if (!fullTemplate)
       return null
 
-    const renderedHtml = await this.pluginRenderer.renderForDisplay(fullTemplate.liquidMarkup, data)
+    const renderedHtml = await this.pluginRenderer.render(fullTemplate.liquidMarkup, data)
     await this.cachePluginOutput(screen, renderedHtml)
     return renderedHtml
   }
 
-  private async renderHtmlToScreenPng(html: string, screen: Screen, device: Device): Promise<string> {
+  /**
+   * Screenshots screen body markup (a `.view` or `.mashup` element) inside the
+   * device's model shell at the model's native pixel size and converts it to
+   * the device's PNG.
+   */
+  private async renderBodyToScreenPng(bodyHtml: string, screen: Screen, device: Device): Promise<string> {
+    const target = await this.deviceModels.renderTargetFor(device)
     const browser = await puppeteer.launch({ args: ['--no-sandbox', '--disable-web-security'] })
     try {
       const page = await browser.newPage()
-      await page.setViewport({ width: 800, height: 480 })
-      await page.setContent(html, { waitUntil: 'load' })
+      await page.setViewport({ width: target.model.width, height: target.model.height })
+      await page.setContent(wrapInScreenShell(target, bodyHtml), { waitUntil: 'load' })
       const image: Uint8Array = await page.screenshot()
 
       const destDir = resolveAppPath('public', 'screens', 'devices', device.id)
       const inputPath = path.join(destDir, 'tmp-source')
       await fs.promises.mkdir(destDir, { recursive: true })
       await fs.promises.writeFile(inputPath, buffer.Buffer.from(image))
-      const { width, height } = await this.deviceModels.outputSizeFor(device)
-      await convertToPng(inputPath, this.screenImagePath(device, screen), width, height, this.logger)
+      await convertToPng(inputPath, this.screenImagePath(device, screen), target.model.width, target.model.height, this.logger)
       return this.screenImageUrl(device, screen)
     }
     finally {
       await browser.close()
     }
-  }
-
-  private wrapInTrmnlShell(html: string): string {
-    return `
-    <html>
-      <head>
-        <link rel="stylesheet" href="https://usetrmnl.com/css/latest/plugins.css">
-        <script src="https://usetrmnl.com/js/latest/plugins.js"></script>
-      </head>
-      <body class="environment trmnl">
-        <div class="screen">
-          <div class="view view--full">
-            ${html}
-          </div>
-        </div>
-      </body>
-    </html>
-  `
   }
 
   private async cachePluginOutput(screen: Screen, renderedHtml: string): Promise<void> {

--- a/packages/api/src/mashup/__test__/mashup-renderer.service.spec.ts
+++ b/packages/api/src/mashup/__test__/mashup-renderer.service.spec.ts
@@ -170,13 +170,11 @@ describe('mashupRendererService', () => {
     const result = await service.renderMashup(config, device)
 
     expect(result).toContain('class="mashup mashup--2x2"')
-    expect(result).toContain('<html>')
-    expect(result).toContain('<body class="environment trmnl">')
-    expect(result).toContain('usetrmnl.com/css/latest/plugins.css')
-    expect(result).toContain('usetrmnl.com/js/latest/plugins.js')
+    expect(result.trim().startsWith('<div class="mashup')).toBe(true)
+    expect(result).not.toContain('<html>')
   })
 
-  it('should include TRMNL CSS and JS in rendered output', async () => {
+  it('returns device-independent body markup without a document shell', async () => {
     const device = { id: 'device-1', width: 800, height: 480 } as Device
 
     const slots: MashupSlot[] = [
@@ -202,7 +200,8 @@ describe('mashupRendererService', () => {
 
     const result = await service.renderMashup(config, device)
 
-    expect(result).toContain('<link rel="stylesheet" href="https://usetrmnl.com/css/latest/plugins.css">')
-    expect(result).toContain('<script src="https://usetrmnl.com/js/latest/plugins.js">')
+    expect(result).toContain('class="mashup mashup--1Tx1B"')
+    expect(result).not.toContain('<html>')
+    expect(result).not.toContain('plugins.css')
   })
 })

--- a/packages/api/src/mashup/services/mashup-renderer.service.ts
+++ b/packages/api/src/mashup/services/mashup-renderer.service.ts
@@ -39,7 +39,6 @@ export class MashupRendererService {
     // Sort by order
     slotHtmls.sort((a, b) => a.slot.order - b.slot.order)
 
-    // Build complete mashup HTML
     return this.buildMashupHtml(mashupConfig.layout, slotHtmls)
   }
 
@@ -95,17 +94,9 @@ export class MashupRendererService {
       `<div class="view ${slot.size}">${html}</div>`,
     ).join('\n    ')
 
-    return `<html>
-  <head>
-    <link rel="stylesheet" href="https://usetrmnl.com/css/latest/plugins.css">
-    <script src="https://usetrmnl.com/js/latest/plugins.js"></script>
-  </head>
-  <body class="environment trmnl">
-    <div class="mashup mashup--${layout}">
+    return `<div class="mashup mashup--${layout}">
     ${viewsHtml}
-    </div>
-  </body>
-</html>`
+    </div>`
   }
 
   private errorPlaceholder(_pluginName: string): string {

--- a/packages/api/src/migrations/1787070000000-ResetCachedPluginOutput.ts
+++ b/packages/api/src/migrations/1787070000000-ResetCachedPluginOutput.ts
@@ -1,0 +1,19 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm'
+
+/**
+ * Cached plugin/mashup output used to be a complete HTML document; it is now
+ * device-independent body markup that gets wrapped in the device model's
+ * screen shell at render time. Existing caches are dropped so every screen is
+ * re-rendered in the new form.
+ */
+export class ResetCachedPluginOutput1787070000000 implements MigrationInterface {
+  name = 'ResetCachedPluginOutput1787070000000'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`UPDATE "screen" SET "cachedPluginOutput" = NULL`)
+  }
+
+  public async down(): Promise<void> {
+    // Data-only migration; caches regenerate on demand.
+  }
+}

--- a/packages/api/src/plugins/__test__/plugin-renderer.service.spec.ts
+++ b/packages/api/src/plugins/__test__/plugin-renderer.service.spec.ts
@@ -67,18 +67,6 @@ describe('pluginRendererService', () => {
     expect(result).toBe('')
   })
 
-  it('wraps rendered content in TRMNL framework', async () => {
-    const template = '<div>Test</div>'
-    const data = {}
-
-    const result = await service.renderForDisplay(template, data)
-
-    expect(result).toContain('https://usetrmnl.com/css/latest/plugins.css')
-    expect(result).toContain('https://usetrmnl.com/js/latest/plugins.js')
-    expect(result).toContain('<div>Test</div>')
-    expect(result).toContain('class="environment trmnl"')
-  })
-
   it('handles filters in templates', async () => {
     const template = '{{ title | capitalize }}'
     const data = { title: 'hello world' }

--- a/packages/api/src/plugins/__test__/plugin-scheduler.service.spec.ts
+++ b/packages/api/src/plugins/__test__/plugin-scheduler.service.spec.ts
@@ -26,7 +26,6 @@ describe('pluginSchedulerService', () => {
 
     mockRenderer = {
       render: vi.fn(),
-      renderForDisplay: vi.fn(),
     } as any
 
     mockScreenRepo = {

--- a/packages/api/src/plugins/__test__/plugins.service.spec.ts
+++ b/packages/api/src/plugins/__test__/plugins.service.spec.ts
@@ -52,7 +52,7 @@ describe('pluginsService', () => {
     fieldRepo = createMockRepository()
 
     mockDataFetcher = { fetchData: vi.fn() } as any
-    mockRenderer = { render: vi.fn(), renderForDisplay: vi.fn() } as any
+    mockRenderer = { render: vi.fn() } as any
     mockScheduler = {
       schedulePlugin: vi.fn(),
       removeScheduledJob: vi.fn(),
@@ -487,7 +487,7 @@ describe('pluginsService', () => {
   it('preview fetches data and renders template', async () => {
     const apiData = { temperature: 25, location: 'Tokyo' }
     mockDataFetcher.fetchData = vi.fn().mockResolvedValue(apiData)
-    mockRenderer.renderForDisplay = vi.fn().mockResolvedValue('<html>25°C in Tokyo</html>')
+    mockRenderer.render = vi.fn().mockResolvedValue('25°C in Tokyo')
 
     const result = await service.preview(
       'https://api.example.com',
@@ -498,8 +498,8 @@ describe('pluginsService', () => {
     )
 
     expect(mockDataFetcher.fetchData).toHaveBeenCalledWith('GET', 'https://api.example.com', {}, {}, expect.any(Object))
-    expect(mockRenderer.renderForDisplay).toHaveBeenCalled()
-    expect(result.html).toBe('<html>25°C in Tokyo</html>')
+    expect(mockRenderer.render).toHaveBeenCalled()
+    expect(result.html).toBe('25°C in Tokyo')
     expect(result.data).toEqual(apiData)
   })
 
@@ -508,7 +508,7 @@ describe('pluginsService', () => {
     const transformedData = { value: 20 }
     mockDataFetcher.fetchData = vi.fn().mockResolvedValue(apiData)
     mockTransformer.transform = vi.fn().mockReturnValue(transformedData)
-    mockRenderer.renderForDisplay = vi.fn().mockResolvedValue('<html>20</html>')
+    mockRenderer.render = vi.fn().mockResolvedValue('20')
 
     await service.preview(
       'https://api.example.com',
@@ -520,7 +520,7 @@ describe('pluginsService', () => {
     )
 
     expect(mockTransformer.transform).toHaveBeenCalledWith('module.exports = (d) => ({ value: d.value * 2 })', apiData)
-    expect(mockRenderer.renderForDisplay).toHaveBeenCalledWith('{{ value }}', expect.objectContaining({ value: 20 }))
+    expect(mockRenderer.render).toHaveBeenCalledWith('{{ value }}', expect.objectContaining({ value: 20 }))
   })
 
   it('preview handles array data', async () => {

--- a/packages/api/src/plugins/plugins.service.ts
+++ b/packages/api/src/plugins/plugins.service.ts
@@ -418,7 +418,7 @@ export class PluginsService implements OnModuleInit {
       templateData.data = rawData
     }
 
-    const html = template ? await this.renderer.renderForDisplay(template, templateData) : ''
+    const html = template ? await this.renderer.render(template, templateData) : ''
     return { html, data: rawData } // Return raw data for display in preview tab
   }
 }

--- a/packages/api/src/plugins/services/plugin-renderer.service.ts
+++ b/packages/api/src/plugins/services/plugin-renderer.service.ts
@@ -88,18 +88,4 @@ export class PluginRendererService {
   async render(template: string, data: Record<string, any>): Promise<string> {
     return this.liquid.parseAndRender(template, data)
   }
-
-  async renderForDisplay(template: string, data: Record<string, any>): Promise<string> {
-    const renderedContent = await this.render(template, data)
-
-    return `<html>
-  <head>
-    <link rel="stylesheet" href="https://usetrmnl.com/css/latest/plugins.css">
-    <script src="https://usetrmnl.com/js/latest/plugins.js"></script>
-  </head>
-  <body class="environment trmnl">
-    <div class="screen"><div class="view view--full">${renderedContent}</div></div>
-  </body>
-</html>`
-  }
 }

--- a/packages/ui/src/components/AddScreenCard.vue
+++ b/packages/ui/src/components/AddScreenCard.vue
@@ -1,13 +1,15 @@
 <script setup lang="ts">
 import { mdiCodeBlockTags, mdiDownload, mdiEye, mdiGridLarge, mdiLink, mdiStop, mdiUpload } from '@mdi/js'
-import { computed, nextTick, ref, useTemplateRef } from 'vue'
+import { computed, ref, useTemplateRef } from 'vue'
 import { VBtn, VCard, VCardText, VCardTitle, VCol, VDivider, VFileInput, VForm, VOverlay, VRow, VSwitch, VTab, VTabs, VTextarea, VTextField, VWindow, VWindowItem } from 'vuetify/components'
 import AddMashupCard from '@/components/AddMashupCard.vue'
+import ScreenFrame from '@/components/ScreenFrame.vue'
 import { useDemoInfo } from '@/composeables/useDemoInfo.ts'
+import { useDeviceRenderTarget } from '@/composeables/useDeviceRenderTarget'
 import { useDeviceStore } from '@/stores/device.ts'
 import { useScreensStore } from '@/stores/screens'
-import { deviceRenderSize } from '@/utils/deviceRenderSize'
 import exampleHtml from '@/utils/exampleHtml'
+import { viewFull } from '@/utils/screenShell'
 
 const props = defineProps<{ deviceId: string }>()
 
@@ -15,13 +17,11 @@ const screensStore = useScreensStore()
 const deviceStore = useDeviceStore()
 
 const device = computed(() => deviceStore.getById(props.deviceId))
-const renderSize = computed(() => deviceRenderSize(device.value))
+const renderTarget = useDeviceRenderTarget(device)
 
 const externalLink = ref('')
 const fetchManual = ref(false)
 const fileInput = ref<File | null>(null)
-
-const previewIframeRef = useTemplateRef('previewIframeRef')
 
 const addScreenTab = ref<'link' | 'file' | 'html' | 'mashup'>('link')
 
@@ -100,21 +100,6 @@ const addScreenInfo = computed(() => {
     : 'No cache: fetched on each request.'
 })
 const showHtmlPreview = ref(false)
-async function renderPreviewHtml() {
-  showHtmlPreview.value = true
-  await nextTick()
-  const iframe = previewIframeRef.value
-  if (!iframe)
-    return
-
-  const doc = iframe.contentDocument || iframe.contentWindow?.document
-  if (!doc)
-    return
-  doc.open()
-  doc.write(`<html><head><link rel="stylesheet" href="https://usetrmnl.com/css/latest/plugins.css"><script src="https://usetrmnl.com/js/latest/plugins.js"><\/script></head><body class="environment trmnl"><div class="screen"><div class="view view--full">${renderHtml.value}</div></div></body></html>`)
-  doc.close()
-  showHtmlPreview.value = true
-}
 
 async function submitAddScreen() {
   if (!device.value)
@@ -214,7 +199,7 @@ const { isDemo } = useDemoInfo()
             class="mt-5 ml-5"
             :prepend-icon="mdiEye"
             :disabled="!renderHtmlValid"
-            @click="renderPreviewHtml()"
+            @click="showHtmlPreview = true"
           >
             Preview
           </VBtn>
@@ -222,7 +207,9 @@ const { isDemo } = useDemoInfo()
       </VCardText>
     </VCard>
     <VOverlay v-model="showHtmlPreview" class="align-center justify-center">
-      <iframe ref="previewIframeRef" :width="renderSize.width + 5" :height="renderSize.height + 5" class="align-center" title="HTML preview" />
+      <div :style="{ width: `min(90vw, ${renderTarget.model.width}px)` }">
+        <ScreenFrame v-if="showHtmlPreview" :body="viewFull(renderHtml)" :target="renderTarget" />
+      </div>
     </VOverlay>
   </template>
 </template>

--- a/packages/ui/src/components/RenderTargetPicker.vue
+++ b/packages/ui/src/components/RenderTargetPicker.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+import type { RenderTarget } from '@/utils/screenShell'
+import { computed, onMounted, ref, watch } from 'vue'
+import { VCol, VRow, VSelect } from 'vuetify/components'
+import { useDeviceModelsStore } from '@/stores/deviceModels'
+import { DEFAULT_MODEL, DEFAULT_MODEL_NAME, DEFAULT_PALETTE, richestPalette } from '@/utils/renderTarget'
+
+const emit = defineEmits<{ 'update:modelValue': [target: RenderTarget] }>()
+
+const deviceModelsStore = useDeviceModelsStore()
+
+const selectedModelName = ref(DEFAULT_MODEL_NAME)
+const selectedPaletteId = ref<string | null>(null)
+
+onMounted(() => deviceModelsStore.ensureLoaded())
+
+const modelOptions = computed(() => deviceModelsStore.activeModels.map(model => ({
+  title: `${model.label} (${model.width}x${model.height})`,
+  value: model.name,
+})))
+
+const selectedModel = computed(() => deviceModelsStore.getByName(selectedModelName.value) ?? DEFAULT_MODEL)
+const allowedPalettes = computed(() => deviceModelsStore.palettesFor(selectedModel.value))
+const paletteOptions = computed(() => allowedPalettes.value.map(palette => ({ title: palette.name, value: palette.id })))
+
+const target = computed<RenderTarget>(() => ({
+  model: selectedModel.value,
+  palette: allowedPalettes.value.find(p => p.id === selectedPaletteId.value) ?? richestPalette(allowedPalettes.value) ?? DEFAULT_PALETTE,
+}))
+
+watch(selectedModel, (model) => {
+  if (selectedPaletteId.value && !model.paletteIds.includes(selectedPaletteId.value))
+    selectedPaletteId.value = null
+})
+
+watch(target, value => emit('update:modelValue', value), { immediate: true })
+</script>
+
+<template>
+  <VRow dense>
+    <VCol cols="12" sm="7">
+      <VSelect v-model="selectedModelName" :items="modelOptions" density="compact" hide-details label="Preview as device model" data-test-id="render-target-model" />
+    </VCol>
+    <VCol cols="12" sm="5">
+      <VSelect v-model="selectedPaletteId" :items="paletteOptions" density="compact" hide-details label="Palette" :placeholder="target.palette.name" persistent-placeholder data-test-id="render-target-palette" />
+    </VCol>
+  </VRow>
+</template>

--- a/packages/ui/src/components/ScreenFrame.vue
+++ b/packages/ui/src/components/ScreenFrame.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+import type { RenderTarget } from '@/utils/screenShell'
+import { useElementSize } from '@vueuse/core'
+import { computed, ref } from 'vue'
+import { wrapInScreenShell } from '@/utils/screenShell'
+
+const props = defineProps<{ body: string, target: RenderTarget }>()
+
+const container = ref<HTMLElement | null>(null)
+const { width: containerWidth } = useElementSize(container)
+
+const scale = computed(() => containerWidth.value > 0 ? Math.min(1, containerWidth.value / props.target.model.width) : 1)
+const srcdoc = computed(() => wrapInScreenShell(props.target, props.body))
+</script>
+
+<template>
+  <div
+    ref="container"
+    class="screen-frame"
+    :style="{ maxWidth: `${target.model.width}px`, height: `${Math.round(target.model.height * scale)}px` }"
+    data-test-id="screen-frame"
+  >
+    <iframe
+      :srcdoc="srcdoc"
+      :width="target.model.width"
+      :height="target.model.height"
+      :style="{ transform: `scale(${scale})` }"
+      class="screen-frame__iframe"
+      title="Screen preview"
+    />
+  </div>
+</template>
+
+<style scoped>
+.screen-frame {
+  width: 100%;
+  overflow: hidden;
+  position: relative;
+}
+
+.screen-frame__iframe {
+  display: block;
+  border: 1px solid #ccc;
+  transform-origin: top left;
+  background: #fff;
+}
+</style>

--- a/packages/ui/src/components/ScreenListCard.vue
+++ b/packages/ui/src/components/ScreenListCard.vue
@@ -1,19 +1,20 @@
 <script setup lang="ts">
 import type { Screen } from '@/types'
 import { mdiChevronDown, mdiChevronUp, mdiDelete, mdiDrag, mdiEye, mdiOpenInNew, mdiRefresh } from '@mdi/js'
-import { computed, nextTick, ref, useTemplateRef } from 'vue'
+import { computed, ref } from 'vue'
 import { VAlert, VBtn, VCard, VCardActions, VCardText, VCardTitle, VChip, VDialog, VDivider, VIcon, VOverlay, VSpacer, VTable, VTooltip } from 'vuetify/components'
+import ScreenFrame from '@/components/ScreenFrame.vue'
+import { useDeviceRenderTarget } from '@/composeables/useDeviceRenderTarget'
 import { useDeviceStore } from '@/stores/device.ts'
 import { useScreensStore } from '@/stores/screens'
-import { deviceRenderSize } from '@/utils/deviceRenderSize'
+import { viewFull } from '@/utils/screenShell'
 
 const props = defineProps<{ deviceId: string }>()
 
 const screensStore = useScreensStore()
 const deviceStore = useDeviceStore()
 const device = computed(() => deviceStore.getById(props.deviceId))
-const renderSize = computed(() => deviceRenderSize(device.value))
-const previewIframeRef = useTemplateRef('previewIframeRef')
+const renderTarget = useDeviceRenderTarget(device)
 async function deleteScreen(screenId: string) {
   if (!device.value)
     return
@@ -88,19 +89,9 @@ const showScreenPreview = ref(false)
 const selectedPreviewScreen = ref<Screen | null>(null)
 const previewMode = ref<'html' | 'image' | 'plugin' | 'mashup'>('image')
 
-async function renderPreviewHtml(html: string) {
-  showHtmlPreview.value = true
-  await nextTick()
-  const iframe = previewIframeRef.value
-  if (!iframe)
-    return
-
-  const doc = iframe.contentDocument || iframe.contentWindow?.document
-  if (!doc)
-    return
-  doc.open()
-  doc.write(`<html><head><link rel="stylesheet" href="https://usetrmnl.com/css/latest/plugins.css"><script src="https://usetrmnl.com/js/latest/plugins.js"><\/script></head><body class="environment trmnl"><div class="screen"><div class="view view--full">${html}</div></div></body></html>`)
-  doc.close()
+const overlayHtml = ref('')
+function renderPreviewHtml(html: string) {
+  overlayHtml.value = html
   showHtmlPreview.value = true
 }
 
@@ -296,10 +287,12 @@ function previewScreen(screen: Screen) {
       </VCardText>
     </VCard>
     <VOverlay v-model="showHtmlPreview" class="align-center justify-center">
-      <iframe ref="previewIframeRef" :width="renderSize.width + 5" :height="renderSize.height + 5" class="align-center" />
+      <div :style="{ width: `min(90vw, ${renderTarget.model.width}px)` }">
+        <ScreenFrame v-if="showHtmlPreview" :body="viewFull(overlayHtml)" :target="renderTarget" />
+      </div>
     </VOverlay>
 
-    <VDialog v-model="showScreenPreview" max-width="900px">
+    <VDialog v-model="showScreenPreview" :max-width="`min(90vw, ${Math.max(900, renderTarget.model.width + 48)}px)`">
       <VCard v-if="selectedPreviewScreen">
         <VCardTitle>
           {{ selectedPreviewScreen.plugin ? `Plugin: ${selectedPreviewScreen.plugin.name}` : selectedPreviewScreen.filename || 'Screen Preview' }}
@@ -307,14 +300,9 @@ function previewScreen(screen: Screen) {
         <VDivider />
         <VCardText class="d-flex flex-column align-center pa-4">
           <!-- Mashup screens: show cached HTML if available, else show message -->
-          <div v-if="previewMode === 'mashup'">
+          <div v-if="previewMode === 'mashup'" class="w-100">
             <div v-if="selectedPreviewScreen.cachedPluginOutput" class="mb-4">
-              <iframe
-                :srcdoc="selectedPreviewScreen.cachedPluginOutput"
-                width="800"
-                height="480"
-                style="border: 1px solid #ccc;"
-              />
+              <ScreenFrame :body="selectedPreviewScreen.cachedPluginOutput" :target="renderTarget" />
             </div>
             <VAlert v-else type="info" variant="tonal">
               Mashup output will be generated when a device requests it or when the scheduler runs.
@@ -322,14 +310,9 @@ function previewScreen(screen: Screen) {
           </div>
 
           <!-- Plugin screens: show cached HTML if available, else show message -->
-          <div v-else-if="previewMode === 'plugin'">
+          <div v-else-if="previewMode === 'plugin'" class="w-100">
             <div v-if="selectedPreviewScreen.cachedPluginOutput" class="mb-4">
-              <iframe
-                :srcdoc="selectedPreviewScreen.cachedPluginOutput"
-                width="800"
-                height="480"
-                style="border: 1px solid #ccc;"
-              />
+              <ScreenFrame :body="viewFull(selectedPreviewScreen.cachedPluginOutput)" :target="renderTarget" />
             </div>
             <VAlert v-else type="info" variant="tonal">
               Plugin output will be generated when a device requests it or when the scheduler runs.
@@ -337,13 +320,8 @@ function previewScreen(screen: Screen) {
           </div>
 
           <!-- HTML screens -->
-          <div v-else-if="previewMode === 'html' && selectedPreviewScreen.html">
-            <iframe
-              :srcdoc="`<html><head><link rel='stylesheet' href='https://usetrmnl.com/css/latest/plugins.css'><script src='https://usetrmnl.com/js/latest/plugins.js'></script></head><body class='environment trmnl'><div class='screen'><div class='view view--full'>${selectedPreviewScreen.html}</div></div></body></html>`"
-              width="800"
-              height="480"
-              style="border: 1px solid #ccc;"
-            />
+          <div v-else-if="previewMode === 'html' && selectedPreviewScreen.html" class="w-100">
+            <ScreenFrame :body="viewFull(selectedPreviewScreen.html)" :target="renderTarget" />
           </div>
 
           <!-- Image screens -->

--- a/packages/ui/src/components/__test__/RenderTargetPicker.spec.ts
+++ b/packages/ui/src/components/__test__/RenderTargetPicker.spec.ts
@@ -1,0 +1,44 @@
+import { mount } from '@vue/test-utils'
+import { createPinia } from 'pinia'
+import rop from 'resize-observer-polyfill'
+import { describe, expect, it, vi } from 'vitest'
+import vuetify from '../../plugins/vuetify'
+import RenderTargetPicker from '../RenderTargetPicker.vue'
+
+const OG = { name: 'og_plus', label: 'TRMNL OG', width: 800, height: 480, paletteIds: ['bw', 'gray-4'], cssClasses: [], cssVariables: {}, rotation: 0, deprecated: false }
+const V2 = { ...OG, name: 'v2', label: 'TRMNL X', width: 1872, height: 1404, paletteIds: ['gray-16', 'bw'] }
+const BW = { id: 'bw', name: 'bw', grays: 2, frameworkClass: 'screen--1bit', deprecated: false }
+const GRAY_4 = { id: 'gray-4', name: 'g4', grays: 4, frameworkClass: 'screen--2bit', deprecated: false }
+const GRAY_16 = { id: 'gray-16', name: 'g16', grays: 16, frameworkClass: 'screen--4bit', deprecated: false }
+
+vi.mock('@/stores/deviceModels', () => ({
+  useDeviceModelsStore: () => ({
+    ensureLoaded: vi.fn(),
+    activeModels: [OG, V2],
+    getByName: (name: string) => [OG, V2].find(m => m.name === name),
+    palettesFor: (model: any) => [BW, GRAY_4, GRAY_16].filter(p => model?.paletteIds.includes(p.id)),
+  }),
+}))
+
+globalThis.ResizeObserver = rop
+
+describe('renderTargetPicker', () => {
+  it('emits the OG model with its richest palette by default', () => {
+    const wrapper = mount(RenderTargetPicker, { global: { plugins: [createPinia(), vuetify] } })
+    const emitted = wrapper.emitted('update:modelValue')!
+    expect(emitted[0][0]).toEqual({ model: OG, palette: GRAY_4 })
+  })
+
+  it('re-emits with the new model and drops a palette it does not support', async () => {
+    const wrapper = mount(RenderTargetPicker, { global: { plugins: [createPinia(), vuetify] } })
+    const vm = wrapper.vm as any
+    vm.selectedPaletteId = 'gray-4'
+    await wrapper.vm.$nextTick()
+    vm.selectedModelName = 'v2'
+    await wrapper.vm.$nextTick()
+    await wrapper.vm.$nextTick()
+    const emitted = wrapper.emitted('update:modelValue')!
+    expect(emitted.at(-1)![0]).toEqual({ model: V2, palette: GRAY_16 })
+    expect(vm.selectedPaletteId).toBeNull()
+  })
+})

--- a/packages/ui/src/components/__test__/ScreenFrame.spec.ts
+++ b/packages/ui/src/components/__test__/ScreenFrame.spec.ts
@@ -1,0 +1,20 @@
+import { mount } from '@vue/test-utils'
+import rop from 'resize-observer-polyfill'
+import { describe, expect, it } from 'vitest'
+import { DEFAULT_MODEL, DEFAULT_PALETTE } from '@/utils/renderTarget'
+import ScreenFrame from '../ScreenFrame.vue'
+
+globalThis.ResizeObserver = rop
+
+describe('screenFrame', () => {
+  it('renders the body inside the model shell at the model size', () => {
+    const model = { ...DEFAULT_MODEL, name: 'v2', width: 1872, height: 1404, cssClasses: ['screen--v2'] }
+    const wrapper = mount(ScreenFrame, { props: { body: '<div class="view view--full">hi</div>', target: { model, palette: DEFAULT_PALETTE } } })
+    const iframe = wrapper.find('iframe')
+    expect(iframe.attributes('width')).toBe('1872')
+    expect(iframe.attributes('height')).toBe('1404')
+    expect(iframe.attributes('srcdoc')).toContain('class="screen screen--v2 screen--2bit screen--landscape"')
+    expect(iframe.attributes('srcdoc')).toContain('<div class="view view--full">hi</div>')
+    expect(iframe.attributes('style')).toContain('transform: scale(1)')
+  })
+})

--- a/packages/ui/src/composeables/useDeviceRenderTarget.ts
+++ b/packages/ui/src/composeables/useDeviceRenderTarget.ts
@@ -1,0 +1,13 @@
+import type { Ref } from 'vue'
+import type { Device } from '@/types'
+import type { RenderTarget } from '@/utils/screenShell'
+import { computed, onMounted } from 'vue'
+import { useDeviceModelsStore } from '@/stores/deviceModels'
+import { renderTargetFor } from '@/utils/renderTarget'
+
+/** The model and palette a device's previews should be rendered with. */
+export function useDeviceRenderTarget(device: Ref<Device | null | undefined>) {
+  const deviceModelsStore = useDeviceModelsStore()
+  onMounted(() => deviceModelsStore.ensureLoaded())
+  return computed<RenderTarget>(() => renderTargetFor(device.value, deviceModelsStore))
+}

--- a/packages/ui/src/stores/__test__/deviceModels.spec.ts
+++ b/packages/ui/src/stores/__test__/deviceModels.spec.ts
@@ -66,4 +66,12 @@ describe('deviceModels store', () => {
     expect(store.error).toBe('Could not sync device models from TRMNL: boom')
     expect(store.syncing).toBe(false)
   })
+
+  it('fetchAll records a network failure instead of throwing', async () => {
+    ;(globalThis.fetch as any).mockRejectedValue(new TypeError('Failed to fetch'))
+    const store = useDeviceModelsStore()
+    await expect(store.fetchAll()).resolves.toBeUndefined()
+    expect(store.loaded).toBe(false)
+    expect(store.error).toBe('Failed to fetch')
+  })
 })

--- a/packages/ui/src/stores/deviceModels.ts
+++ b/packages/ui/src/stores/deviceModels.ts
@@ -12,12 +12,18 @@ export const useDeviceModelsStore = defineStore('deviceModels', () => {
   const activeModels = computed(() => models.value.filter(model => !model.deprecated))
 
   async function fetchAll() {
-    const [modelsRes, palettesRes] = await Promise.all([fetch('/api/device-models'), fetch('/api/device-models/palettes')])
-    if (modelsRes.ok)
-      models.value = await modelsRes.json()
-    if (palettesRes.ok)
-      palettes.value = await palettesRes.json()
-    loaded.value = modelsRes.ok && palettesRes.ok
+    try {
+      const [modelsRes, palettesRes] = await Promise.all([fetch('/api/device-models'), fetch('/api/device-models/palettes')])
+      if (modelsRes.ok)
+        models.value = await modelsRes.json()
+      if (palettesRes.ok)
+        palettes.value = await palettesRes.json()
+      loaded.value = modelsRes.ok && palettesRes.ok
+    }
+    catch (err) {
+      error.value = err instanceof Error ? err.message : 'Failed to load device models'
+      loaded.value = false
+    }
   }
 
   async function ensureLoaded() {

--- a/packages/ui/src/utils/__test__/renderTarget.spec.ts
+++ b/packages/ui/src/utils/__test__/renderTarget.spec.ts
@@ -1,0 +1,35 @@
+import type { DeviceModel, Palette } from '@/types'
+import { describe, expect, it } from 'vitest'
+import { DEFAULT_MODEL, DEFAULT_PALETTE, renderTargetFor, richestPalette } from '../renderTarget'
+
+const BW: Palette = { id: 'bw', name: 'bw', grays: 2, frameworkClass: 'screen--1bit', deprecated: false }
+const GRAY_4: Palette = { id: 'gray-4', name: 'g4', grays: 4, frameworkClass: 'screen--2bit', deprecated: false }
+const COLOR: Palette = { id: 'color-6a', name: 'c', grays: 2, colors: ['#f00', '#0f0', '#00f', '#ff0', '#000', '#fff'], frameworkClass: 'screen--color-6a', deprecated: false }
+const OG: DeviceModel = { ...DEFAULT_MODEL, cssVariables: { '--screen-w': '800px' } }
+const V2: DeviceModel = { ...DEFAULT_MODEL, name: 'v2', width: 1872, height: 1404, paletteIds: ['bw'] }
+
+const source = {
+  getByName: (name: string | null | undefined) => [OG, V2].find(m => m.name === name),
+  palettesFor: (model: DeviceModel | null | undefined) => [BW, GRAY_4, COLOR].filter(p => model?.paletteIds.includes(p.id)),
+}
+
+describe('renderTarget', () => {
+  it('prefers colour palettes, then more grays', () => {
+    expect(richestPalette([BW, GRAY_4])).toBe(GRAY_4)
+    expect(richestPalette([GRAY_4, COLOR])).toBe(COLOR)
+    expect(richestPalette([])).toBeUndefined()
+  })
+
+  it('uses the device assignment when present', () => {
+    expect(renderTargetFor({ deviceModel: V2, palette: BW }, source)).toEqual({ model: V2, palette: BW })
+  })
+
+  it('fills the richest allowed palette when only the model is assigned', () => {
+    expect(renderTargetFor({ deviceModel: OG, palette: null }, source)).toEqual({ model: OG, palette: GRAY_4 })
+  })
+
+  it('falls back to the loaded OG model for unassigned devices, then to the built-in default', () => {
+    expect(renderTargetFor(null, source)).toEqual({ model: OG, palette: GRAY_4 })
+    expect(renderTargetFor(null, { getByName: () => undefined, palettesFor: () => [] })).toEqual({ model: DEFAULT_MODEL, palette: DEFAULT_PALETTE })
+  })
+})

--- a/packages/ui/src/utils/__test__/screenShell.spec.ts
+++ b/packages/ui/src/utils/__test__/screenShell.spec.ts
@@ -1,0 +1,41 @@
+import type { DeviceModel, Palette } from '@/types'
+import { describe, expect, it } from 'vitest'
+import { screenClasses, screenStyle, viewFull, wrapInScreenShell } from '../screenShell'
+
+const V2: DeviceModel = {
+  name: 'v2',
+  label: 'TRMNL X',
+  width: 1872,
+  height: 1404,
+  colors: 16,
+  bitDepth: 4,
+  scaleFactor: 1.8,
+  rotation: 0,
+  offsetX: 0,
+  offsetY: 0,
+  mimeType: 'image/png',
+  kind: 'trmnl',
+  paletteIds: ['gray-16', 'gray-4', 'bw'],
+  cssClasses: ['screen--v2', 'screen--lg', 'screen--density-2x'],
+  cssVariables: { '--screen-w': '1040px', '--screen-h': '780px' },
+  deprecated: false,
+}
+const GRAY_16: Palette = { id: 'gray-16', name: '16 Grays (4-bit)', grays: 16, frameworkClass: 'screen--4bit', deprecated: false }
+
+describe('screenShell', () => {
+  it('builds the same class list as the API', () => {
+    expect(screenClasses({ model: V2, palette: GRAY_16 })).toEqual(['screen', 'screen--v2', 'screen--lg', 'screen--density-2x', 'screen--4bit', 'screen--landscape'])
+    expect(screenClasses({ model: { ...V2, rotation: 90 }, palette: GRAY_16 })).toContain('screen--portrait')
+  })
+
+  it('serialises css variables', () => {
+    expect(screenStyle({ model: V2, palette: GRAY_16 })).toBe('--screen-w: 1040px; --screen-h: 780px;')
+  })
+
+  it('wraps a body into a full document with the framework assets', () => {
+    const html = wrapInScreenShell({ model: V2, palette: GRAY_16 }, viewFull('<p>x</p>'))
+    expect(html).toContain('href="https://usetrmnl.com/css/latest/plugins.css"')
+    expect(html).toContain('<body class="environment trmnl">')
+    expect(html).toContain('<div class="screen screen--v2 screen--lg screen--density-2x screen--4bit screen--landscape" style="--screen-w: 1040px; --screen-h: 780px;"><div class="view view--full"><p>x</p></div></div>')
+  })
+})

--- a/packages/ui/src/utils/deviceRenderSize.ts
+++ b/packages/ui/src/utils/deviceRenderSize.ts
@@ -1,6 +1,7 @@
 import type { Device } from '../types'
+import { DEFAULT_MODEL } from './renderTarget'
 
-export const DEFAULT_RENDER_SIZE = { width: 800, height: 480 }
+export const DEFAULT_RENDER_SIZE = { width: DEFAULT_MODEL.width, height: DEFAULT_MODEL.height }
 
 /** Pixel size images are generated at for a device; unassigned devices render as a TRMNL OG. */
 export function deviceRenderSize(device: Pick<Device, 'deviceModel'> | null | undefined): { width: number, height: number } {

--- a/packages/ui/src/utils/renderTarget.ts
+++ b/packages/ui/src/utils/renderTarget.ts
@@ -1,0 +1,53 @@
+import type { Device, DeviceModel, Palette } from '../types'
+import type { RenderTarget } from './screenShell'
+
+export const DEFAULT_MODEL_NAME = 'og_plus'
+
+/** Offline stand-in for the OG model until the device model list has loaded. */
+export const DEFAULT_MODEL: DeviceModel = {
+  name: DEFAULT_MODEL_NAME,
+  label: 'TRMNL OG (2-bit)',
+  width: 800,
+  height: 480,
+  colors: 4,
+  bitDepth: 2,
+  scaleFactor: 1,
+  rotation: 0,
+  offsetX: 0,
+  offsetY: 0,
+  mimeType: 'image/png',
+  kind: 'trmnl',
+  paletteIds: ['bw', 'gray-4'],
+  cssClasses: ['screen--og_plus', 'screen--md', 'screen--density-1x'],
+  cssVariables: {},
+  deprecated: false,
+}
+
+export const DEFAULT_PALETTE: Palette = {
+  id: 'gray-4',
+  name: '4 Grays (2-bit)',
+  grays: 4,
+  frameworkClass: 'screen--2bit',
+  deprecated: false,
+}
+
+function paletteRichness(palette: Palette): number {
+  return palette.colors?.length ? 1000 + palette.colors.length : palette.grays
+}
+
+export function richestPalette(palettes: Palette[]): Palette | undefined {
+  return palettes.reduce<Palette | undefined>((richest, candidate) =>
+    !richest || paletteRichness(candidate) > paletteRichness(richest) ? candidate : richest, undefined)
+}
+
+export interface RenderTargetSource {
+  getByName: (name: string | null | undefined) => DeviceModel | undefined
+  palettesFor: (model: DeviceModel | null | undefined) => Palette[]
+}
+
+/** The model and palette a device's images are generated with, falling back like the API does. */
+export function renderTargetFor(device: Pick<Device, 'deviceModel' | 'palette'> | null | undefined, source: RenderTargetSource): RenderTarget {
+  const model = device?.deviceModel ?? source.getByName(DEFAULT_MODEL_NAME) ?? DEFAULT_MODEL
+  const palette = device?.palette ?? richestPalette(source.palettesFor(model)) ?? DEFAULT_PALETTE
+  return { model, palette }
+}

--- a/packages/ui/src/utils/screenShell.ts
+++ b/packages/ui/src/utils/screenShell.ts
@@ -1,0 +1,35 @@
+import type { DeviceModel, Palette } from '../types'
+
+export interface RenderTarget {
+  model: DeviceModel
+  palette: Palette
+}
+
+export const TRMNL_FRAMEWORK_CSS = 'https://usetrmnl.com/css/latest/plugins.css'
+export const TRMNL_FRAMEWORK_JS = 'https://usetrmnl.com/js/latest/plugins.js'
+
+/** Mirrors the API's `screen-shell.ts` so previews match what the device receives. */
+export function screenClasses({ model, palette }: RenderTarget): string[] {
+  return ['screen', ...model.cssClasses, palette.frameworkClass, model.rotation === 0 ? 'screen--landscape' : 'screen--portrait']
+}
+
+export function screenStyle({ model }: RenderTarget): string {
+  return Object.entries(model.cssVariables).map(([name, value]) => `${name}: ${value};`).join(' ')
+}
+
+export function viewFull(innerHtml: string): string {
+  return `<div class="view view--full">${innerHtml}</div>`
+}
+
+export function wrapInScreenShell(target: RenderTarget, bodyHtml: string): string {
+  const style = screenStyle(target)
+  return `<html>
+  <head>
+    <link rel="stylesheet" href="${TRMNL_FRAMEWORK_CSS}">
+    <script src="${TRMNL_FRAMEWORK_JS}"></script>
+  </head>
+  <body class="environment trmnl">
+    <div class="${screenClasses(target).join(' ')}"${style ? ` style="${style}"` : ''}>${bodyHtml}</div>
+  </body>
+</html>`
+}

--- a/packages/ui/src/views/HtmlPreviewView.vue
+++ b/packages/ui/src/views/HtmlPreviewView.vue
@@ -1,31 +1,15 @@
 <script setup lang="ts">
-import { onMounted, ref, useTemplateRef, watch } from 'vue'
+import type { RenderTarget } from '@/utils/screenShell'
+import { ref } from 'vue'
 import { VCol, VContainer, VRow, VTextarea } from 'vuetify/components'
+import RenderTargetPicker from '@/components/RenderTargetPicker.vue'
+import ScreenFrame from '@/components/ScreenFrame.vue'
 import exampleHtml from '@/utils/exampleHtml'
+import { DEFAULT_MODEL, DEFAULT_PALETTE } from '@/utils/renderTarget'
+import { viewFull } from '@/utils/screenShell'
 
 const html = ref(exampleHtml)
-const previewIframeRef = useTemplateRef('previewIframeRef')
-
-function updateIframe() {
-  const iframe = previewIframeRef.value
-  if (!iframe)
-    return
-
-  const doc = iframe.contentDocument || iframe.contentWindow?.document
-  if (!doc)
-    return
-  doc.open()
-  doc.write(`<html><head><link rel="stylesheet" href="https://usetrmnl.com/css/latest/plugins.css"><script src="https://usetrmnl.com/js/latest/plugins.js"><\/script></head><body class="environment trmnl"><div class="screen"><div class="view view--full">${html.value}</div></div></body></html>`)
-  doc.close()
-}
-
-onMounted(() => {
-  updateIframe()
-})
-
-watch(html, () => {
-  updateIframe()
-})
+const target = ref<RenderTarget>({ model: DEFAULT_MODEL, palette: DEFAULT_PALETTE })
 </script>
 
 <template>
@@ -35,19 +19,9 @@ watch(html, () => {
         <VTextarea v-model="html" label="HTML to render" auto-grow />
       </VCol>
       <VCol cols="12" sm="12" md="12" lg="6">
-        <iframe ref="previewIframeRef" class="preview-iframe" title="HTML preview" />
+        <RenderTargetPicker v-model="target" class="mb-3" />
+        <ScreenFrame :body="viewFull(html)" :target="target" />
       </VCol>
     </VRow>
   </VContainer>
 </template>
-
-<style scoped>
-.preview-iframe {
-  width: 100%;
-  min-height: 320px;
-  aspect-ratio: 805 / 485;
-  max-width: 805px;
-  border: 0;
-  display: block;
-}
-</style>

--- a/packages/ui/src/views/PluginCreateView.vue
+++ b/packages/ui/src/views/PluginCreateView.vue
@@ -1,9 +1,14 @@
 <script setup lang="ts">
 import type { Plugin } from '../types/plugin'
+import type { RenderTarget } from '@/utils/screenShell'
 import { mdiArrowLeft, mdiArrowRight, mdiCheck, mdiEye } from '@mdi/js'
 import { computed, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { VAlert, VBtn, VCard, VCardActions, VCardText, VCardTitle, VCol, VContainer, VDialog, VDivider, VExpandTransition, VForm, VRow, VSelect, VSpacer, VStepper, VStepperHeader, VStepperItem, VStepperWindow, VStepperWindowItem, VTab, VTabs, VTextarea, VTextField, VWindow, VWindowItem } from 'vuetify/components'
+import RenderTargetPicker from '@/components/RenderTargetPicker.vue'
+import ScreenFrame from '@/components/ScreenFrame.vue'
+import { DEFAULT_MODEL, DEFAULT_PALETTE } from '@/utils/renderTarget'
+import { viewFull } from '@/utils/screenShell'
 import { usePluginsStore } from '../stores/plugins'
 
 const route = useRoute()
@@ -113,6 +118,7 @@ function prevStep() {
 const loading = ref(false)
 const previewLoading = ref(false)
 const previewHtml = ref('')
+const previewTarget = ref<RenderTarget>({ model: DEFAULT_MODEL, palette: DEFAULT_PALETTE })
 const previewData = ref<any>(null)
 const previewError = ref('')
 const showPreview = ref(false)
@@ -463,12 +469,8 @@ function cancel() {
           <VWindow v-model="previewTab">
             <VWindowItem value="rendered">
               <div v-if="previewHtml" class="mt-4">
-                <iframe
-                  :srcdoc="previewHtml"
-                  width="800"
-                  height="480"
-                  style="border: 1px solid #ccc;"
-                />
+                <RenderTargetPicker v-model="previewTarget" class="mb-3" />
+                <ScreenFrame :body="viewFull(previewHtml)" :target="previewTarget" />
               </div>
             </VWindowItem>
             <VWindowItem value="data">

--- a/packages/ui/src/views/PluginEditView.vue
+++ b/packages/ui/src/views/PluginEditView.vue
@@ -1,9 +1,14 @@
 <script setup lang="ts">
 import type { Plugin } from '../types/plugin'
+import type { RenderTarget } from '@/utils/screenShell'
 import { mdiArrowLeft, mdiContentSave, mdiEye } from '@mdi/js'
 import { computed, onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { VAlert, VBtn, VCard, VCardActions, VCardText, VCardTitle, VCol, VContainer, VDialog, VDivider, VExpandTransition, VExpansionPanel, VExpansionPanels, VExpansionPanelText, VExpansionPanelTitle, VForm, VProgressCircular, VRow, VSelect, VSpacer, VSwitch, VTab, VTabs, VTextarea, VTextField, VWindow, VWindowItem } from 'vuetify/components'
+import RenderTargetPicker from '@/components/RenderTargetPicker.vue'
+import ScreenFrame from '@/components/ScreenFrame.vue'
+import { DEFAULT_MODEL, DEFAULT_PALETTE } from '@/utils/renderTarget'
+import { viewFull } from '@/utils/screenShell'
 import { usePluginsStore } from '../stores/plugins'
 
 const props = defineProps<{
@@ -93,6 +98,7 @@ onMounted(async () => {
 const loading = ref(false)
 const previewLoading = ref(false)
 const previewHtml = ref('')
+const previewTarget = ref<RenderTarget>({ model: DEFAULT_MODEL, palette: DEFAULT_PALETTE })
 const previewData = ref<any>(null)
 const previewError = ref('')
 const showPreview = ref(false)
@@ -436,12 +442,8 @@ function cancel() {
           <VWindow v-model="previewTab">
             <VWindowItem value="rendered">
               <div v-if="previewHtml" class="mt-4">
-                <iframe
-                  :srcdoc="previewHtml"
-                  width="800"
-                  height="480"
-                  style="border: 1px solid #ccc;"
-                />
+                <RenderTargetPicker v-model="previewTarget" class="mb-3" />
+                <ScreenFrame :body="viewFull(previewHtml)" :target="previewTarget" />
               </div>
             </VWindowItem>
             <VWindowItem value="data">

--- a/packages/ui/src/views/VirtualDeviceView.vue
+++ b/packages/ui/src/views/VirtualDeviceView.vue
@@ -4,6 +4,7 @@ import { computed, ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import { VAlert, VAutocomplete, VBtn, VCard, VCardText, VCardTitle, VCol, VContainer, VDivider, VExpansionPanel, VExpansionPanels, VExpansionPanelText, VExpansionPanelTitle, VForm, VImg, VRow, VTab, VTabs, VTextField, VWindow, VWindowItem } from 'vuetify/components'
 import { useDeviceStore } from '@/stores/device'
+import { deviceRenderSize } from '@/utils/deviceRenderSize'
 import { getRandomMac, isValidMac } from '@/utils/getRandomMac'
 
 const mac = ref('')
@@ -85,6 +86,10 @@ function generateMac() {
 }
 
 const deviceStore = useDeviceStore()
+const displayAspectRatio = computed(() => {
+  const { width, height } = deviceRenderSize(deviceStore.devices.find(d => d.mac === mac.value))
+  return width / height
+})
 const route = useRoute()
 
 const currentMac = computed(() => {
@@ -214,7 +219,7 @@ watch(mac, () => {
               </VExpansionPanel>
             </VExpansionPanels>
             <div v-if="displayImageUrl" class="mt-4">
-              <VImg :src="displayImageUrl" aspect-ratio="800/480" alt="Virtual device screen preview" />
+              <VImg :src="displayImageUrl" :aspect-ratio="displayAspectRatio" alt="Virtual device screen preview" />
             </div>
           </VCardText>
         </VCard>


### PR DESCRIPTION
## Summary

Second of three stacked PRs for multi-size TRMNL support. Stacked on #739 (merged) — now based on `main`.

This is the visible win: HTML screens, plugins and mashups are now rendered **at the device model's native pixel size** inside the real TRMNL screen shell, instead of an 800×480 canvas that ImageMagick upscaled and letterboxed.

### API
- `device-models/screen-shell.ts`: `wrapInScreenShell(target, body)` builds `<div class="screen <model css classes> <palette framework class> screen--landscape|portrait" style="<model css vars>">…</div>` in the framework document; `viewFull()` wraps plugin/HTML content in `.view.view--full`.
- `DeviceDisplayService.renderBodyToScreenPng`: puppeteer viewport = model width×height (the framework's `.screen { transform: scale(var(--pixel-ratio)) }` does the rest), then convert at model size.
- **Cache semantics fixed**: `cachedPluginOutput` is now device-independent body markup (bare liquid output for plugins, the `.mashup` element for mashups), wrapped per device at render time. Previously the scheduler cached bare output while on-demand rendering cached a full document — screens re-rendered from a scheduler-refreshed cache had *no framework CSS at all*. `renderForDisplay` is gone; `POST /plugins/preview` returns the inner HTML.
- Migration `1787070000000-ResetCachedPluginOutput` nulls existing caches so they regenerate in the new form.

### UI
- `utils/screenShell.ts` mirrors the API helper; `utils/renderTarget.ts` resolves a device's model+palette with the same fallbacks (`og_plus`, richest palette, built-in default while the store loads).
- `ScreenFrame.vue`: iframe at model size, CSS-scaled to fit its container. Used by AddScreenCard / ScreenListCard previews (device's model) and, with the new `RenderTargetPicker.vue`, by the HTML playground and plugin create/edit previews (defaults to TRMNL OG).
- Virtual device image keeps the device's aspect ratio.

## Test plan
- [x] lint, API 391 / UI 82 tests, build
- [ ] On a real X: HTML/plugin/mashup screens come out 1872×1404 and sharp (no letterbox), OG output unchanged
- [ ] After deploy, plugin screens rendered from the scheduler cache have TRMNL styling