### PR TITLE
feat: palette-, rotation- and offset-aware image conversion with retained originals and per-model fallback screens (3/3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ If you enable mirroring and provide the MAC and apikey, Kuroshiro fetches the cu
 Images are generated for the device's **Device Model** (panel size, colour depth, rotation), which Kuroshiro resolves from what the firmware reports (`Model` header, then reported width×height) and which you can override per device under *Advanced*. The model list is synced from the official TRMNL server (`/api/models`) on startup and daily, with a bundled snapshot as offline fallback — see *Maintenance → Device Models*. Devices without a resolved model render as a TRMNL OG (800×480).
 
 #### Uploaded Screens
-Upload a file and Kuroshiro uses Imagemagick to fit, fill, and convert it to black and white. Stored locally, ready to go.
+Upload a file and Kuroshiro uses ImageMagick to fit it onto the device's panel (letterboxed, rotated if the model needs it) and dither it to the device's palette — 1-bit, 4 or 16 grays, or the colours of a colour panel. The original is kept, so switching a device's model or palette re-generates the image from the source.
 
 #### External Link Screens
 Provide a URL and Kuroshiro fetches, converts, and serves it. Cache it for speed, or fetch fresh every time—your choice!

--- a/packages/api/src/device-models/__test__/device-models.service.spec.ts
+++ b/packages/api/src/device-models/__test__/device-models.service.spec.ts
@@ -103,7 +103,6 @@ describe('deviceModelsService', () => {
 
     it('renders unassigned devices as an OG with 4 grays', async () => {
       await expect(service.renderTargetFor({})).resolves.toEqual({ model: OG_PLUS, palette: GRAY_4 })
-      await expect(service.outputSizeFor({})).resolves.toEqual({ width: 800, height: 480 })
     })
 
     it('falls back to the bundled snapshot when the reference table is empty', async () => {

--- a/packages/api/src/device-models/__test__/fallback-screens.service.spec.ts
+++ b/packages/api/src/device-models/__test__/fallback-screens.service.spec.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { FallbackScreensService } from '../fallback-screens.service'
+import { GRAY_16, V2 } from './mockDeviceModelsService'
+
+const { statMock, mkdirMock, convertToPng } = vi.hoisted(() => ({
+  statMock: vi.fn(),
+  mkdirMock: vi.fn(),
+  convertToPng: vi.fn(),
+}))
+
+vi.mock('node:fs', () => ({
+  promises: { stat: statMock, mkdir: mkdirMock },
+}))
+
+vi.mock('../../utils/imageUtils', () => ({ convertToPng }))
+
+vi.mock('../../utils/pathHelper', () => ({
+  resolveAppPath: (...segments: string[]) => `/app/${segments.join('/')}`,
+}))
+
+describe('fallbackScreensService', () => {
+  let service: FallbackScreensService
+  const target = { model: V2, palette: GRAY_16 }
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+    service = new FallbackScreensService({ get: () => 'http://api' } as any)
+  })
+
+  it('generates the placeholder for the target when it does not exist yet', async () => {
+    statMock.mockRejectedValue(new Error('ENOENT'))
+    convertToPng.mockResolvedValue(undefined)
+
+    const url = await service.urlFor('noScreen', target)
+
+    expect(mkdirMock).toHaveBeenCalledWith('/app/public/screens/fallback/v2-gray-16', { recursive: true })
+    expect(convertToPng).toHaveBeenCalledWith('/app/public/screens/noScreen.png', '/app/public/screens/fallback/v2-gray-16/noScreen.png', target, expect.any(Object))
+    expect(url).toBe('http://api/screens/fallback/v2-gray-16/noScreen.png')
+  })
+
+  it('reuses an existing placeholder that is newer than the source image', async () => {
+    statMock.mockImplementation(async (p: string) => ({ mtimeMs: p.endsWith('/error.png') && !p.includes('fallback') ? 100 : 200 }))
+
+    const url = await service.urlFor('error', target)
+
+    expect(convertToPng).not.toHaveBeenCalled()
+    expect(url).toBe('http://api/screens/fallback/v2-gray-16/error.png')
+  })
+
+  it('regenerates when the source image is newer than the cached placeholder', async () => {
+    statMock.mockImplementation(async (p: string) => ({ mtimeMs: p.includes('fallback') ? 100 : 200 }))
+    convertToPng.mockResolvedValue(undefined)
+
+    await service.urlFor('welcome', target)
+
+    expect(convertToPng).toHaveBeenCalled()
+  })
+
+  it('falls back to the static image when conversion fails', async () => {
+    statMock.mockRejectedValue(new Error('ENOENT'))
+    convertToPng.mockRejectedValue(new Error('magick exploded'))
+
+    await expect(service.urlFor('error', target)).resolves.toBe('http://api/screens/error.png')
+  })
+})

--- a/packages/api/src/device-models/__test__/mockDeviceModelsService.ts
+++ b/packages/api/src/device-models/__test__/mockDeviceModelsService.ts
@@ -53,7 +53,6 @@ export function createMockDeviceModelsService() {
     resolve: vi.fn(),
     assignResolvedModel: vi.fn(),
     renderTargetFor: vi.fn(),
-    outputSizeFor: vi.fn(),
   }
 }
 
@@ -62,8 +61,18 @@ export type MockDeviceModelsService = ReturnType<typeof createMockDeviceModelsSe
 /** Default behaviour after `vi.resetAllMocks()`: everything renders as an OG with 4 grays. */
 export function primeMockDeviceModelsService(mock: MockDeviceModelsService) {
   mock.renderTargetFor.mockResolvedValue({ model: OG_PLUS, palette: GRAY_4 })
-  mock.outputSizeFor.mockResolvedValue({ width: OG_PLUS.width, height: OG_PLUS.height })
   mock.defaultPaletteFor.mockResolvedValue(GRAY_4)
   mock.resolve.mockResolvedValue(null)
   mock.assignResolvedModel.mockResolvedValue(null)
+}
+
+export function createMockFallbackScreensService() {
+  return { urlFor: vi.fn() }
+}
+
+export type MockFallbackScreensService = ReturnType<typeof createMockFallbackScreensService>
+
+/** Default behaviour after `vi.resetAllMocks()`: static placeholder URLs under http://api. */
+export function primeMockFallbackScreensService(mock: MockFallbackScreensService) {
+  mock.urlFor.mockImplementation(async (kind: string) => `http://api/screens/${kind}.png`)
 }

--- a/packages/api/src/device-models/device-models.module.ts
+++ b/packages/api/src/device-models/device-models.module.ts
@@ -1,15 +1,17 @@
 import { Module } from '@nestjs/common'
+import { ConfigModule } from '@nestjs/config'
 import { TypeOrmModule } from '@nestjs/typeorm'
 import { DeviceModelSyncService } from './device-model-sync.service'
 import { DeviceModelsController } from './device-models.controller'
 import { DeviceModelsService } from './device-models.service'
 import { DeviceModel } from './entities/device-model.entity'
 import { Palette } from './entities/palette.entity'
+import { FallbackScreensService } from './fallback-screens.service'
 
 @Module({
-  imports: [TypeOrmModule.forFeature([DeviceModel, Palette])],
+  imports: [TypeOrmModule.forFeature([DeviceModel, Palette]), ConfigModule],
   controllers: [DeviceModelsController],
-  providers: [DeviceModelsService, DeviceModelSyncService],
-  exports: [DeviceModelsService],
+  providers: [DeviceModelsService, DeviceModelSyncService, FallbackScreensService],
+  exports: [DeviceModelsService, FallbackScreensService],
 })
 export class DeviceModelsModule {}

--- a/packages/api/src/device-models/device-models.service.ts
+++ b/packages/api/src/device-models/device-models.service.ts
@@ -126,11 +126,6 @@ export class DeviceModelsService {
     return { model, palette }
   }
 
-  async outputSizeFor(device: DeviceLike): Promise<{ width: number, height: number }> {
-    const { model } = await this.renderTargetFor(device)
-    return { width: model.width, height: model.height }
-  }
-
   private async resolveByName(reportedModel?: string | null): Promise<DeviceModel | null> {
     if (!reportedModel)
       return null

--- a/packages/api/src/device-models/fallback-screens.service.ts
+++ b/packages/api/src/device-models/fallback-screens.service.ts
@@ -1,0 +1,52 @@
+import type { DeviceRenderTarget } from './device-models.service'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { Injectable, Logger } from '@nestjs/common'
+import { ConfigService } from '@nestjs/config'
+import { convertToPng } from '../utils/imageUtils'
+import { resolveAppPath } from '../utils/pathHelper'
+
+export type FallbackScreenKind = 'noScreen' | 'error' | 'welcome'
+
+/**
+ * Serves the built-in placeholder screens (no screen, error, welcome) converted
+ * for a render target, generated on first use and cached under
+ * `public/screens/fallback/<model>-<palette>/`.
+ */
+@Injectable()
+export class FallbackScreensService {
+  private readonly logger = new Logger(FallbackScreensService.name)
+
+  constructor(private readonly configService: ConfigService) {}
+
+  async urlFor(kind: FallbackScreenKind, target: DeviceRenderTarget): Promise<string> {
+    const relativePath = ['screens', 'fallback', `${target.model.name}-${target.palette.id}`, `${kind}.png`]
+    const sourcePath = resolveAppPath('public', 'screens', `${kind}.png`)
+    const outputPath = resolveAppPath('public', ...relativePath)
+    try {
+      if (await this.isStale(sourcePath, outputPath)) {
+        await fs.promises.mkdir(path.dirname(outputPath), { recursive: true })
+        await convertToPng(sourcePath, outputPath, target, this.logger)
+      }
+      return `${this.apiUrl()}/${relativePath.join('/')}`
+    }
+    catch (err) {
+      this.logger.error(`Could not generate ${kind} screen for ${target.model.name}/${target.palette.id}, serving the static image: ${err.message}`)
+      return `${this.apiUrl()}/screens/${kind}.png`
+    }
+  }
+
+  private async isStale(sourcePath: string, outputPath: string): Promise<boolean> {
+    try {
+      const [source, output] = await Promise.all([fs.promises.stat(sourcePath), fs.promises.stat(outputPath)])
+      return source.mtimeMs > output.mtimeMs
+    }
+    catch {
+      return true
+    }
+  }
+
+  private apiUrl(): string {
+    return this.configService.get<string>('api_url')
+  }
+}

--- a/packages/api/src/devices/__test__/devices.service.spec.ts
+++ b/packages/api/src/devices/__test__/devices.service.spec.ts
@@ -28,11 +28,13 @@ describe('devicesService', () => {
   let service: DevicesService
   let repo: MockRepository
   let deviceModels: MockDeviceModelsService
+  let screensService: { reconvertImageScreens: ReturnType<typeof vi.fn> }
 
   beforeEach(() => {
     repo = createMockRepository()
     deviceModels = createMockDeviceModelsService()
-    service = new DevicesService(repo as unknown as Repository<Device>, deviceModels as any)
+    screensService = { reconvertImageScreens: vi.fn().mockResolvedValue(0) }
+    service = new DevicesService(repo as unknown as Repository<Device>, deviceModels as any, screensService as any)
   })
 
   const baseDevice = {
@@ -111,6 +113,7 @@ describe('devicesService', () => {
       expect(deviceModels.findByName).toHaveBeenCalledWith('v2')
       expect(result.deviceModel).toBe(V2)
       expect(result.palette).toBe(GRAY_16)
+      expect(screensService.reconvertImageScreens).toHaveBeenCalledWith(result)
     })
 
     it('assigns a new model together with an explicitly chosen palette', async () => {
@@ -130,6 +133,14 @@ describe('devicesService', () => {
       expect(deviceModels.findByName).not.toHaveBeenCalled()
       expect(result.deviceModel).toBe(OG_PLUS)
       expect(result.palette).toBe(BW)
+      expect(screensService.reconvertImageScreens).toHaveBeenCalledWith(result)
+    })
+
+    it('does not reconvert images when neither model nor palette changed', async () => {
+      repo.findOneBy.mockResolvedValue({ ...baseDevice, deviceModel: OG_PLUS, palette: GRAY_4 })
+      deviceModels.findPalette.mockResolvedValue(GRAY_4)
+      await service.update('1', { name: 'renamed', deviceModelName: 'og_plus', paletteId: 'gray-4' } as any)
+      expect(screensService.reconvertImageScreens).not.toHaveBeenCalled()
     })
 
     it('rejects an unknown model', async () => {

--- a/packages/api/src/devices/__test__/display.service.spec.ts
+++ b/packages/api/src/devices/__test__/display.service.spec.ts
@@ -1,8 +1,8 @@
-import type { MockDeviceModelsService } from '../../device-models/__test__/mockDeviceModelsService'
+import type { MockDeviceModelsService, MockFallbackScreensService } from '../../device-models/__test__/mockDeviceModelsService'
 import { promises as fs } from 'node:fs'
 import { NotFoundException, UnauthorizedException } from '@nestjs/common'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { createMockDeviceModelsService, GRAY_16, OG_PLUS, primeMockDeviceModelsService, V2 } from '../../device-models/__test__/mockDeviceModelsService'
+import { createMockDeviceModelsService, createMockFallbackScreensService, GRAY_4, GRAY_16, OG_PLUS, primeMockDeviceModelsService, primeMockFallbackScreensService, V2 } from '../../device-models/__test__/mockDeviceModelsService'
 import { Display } from '../display'
 import { DeviceDisplayService } from '../display.service'
 import { DisplayScreen } from '../displayScreen'
@@ -63,20 +63,24 @@ describe('deviceDisplayService', () => {
   let screenRepo: ReturnType<typeof createMockRepo>
   let configService: { get: ReturnType<typeof vi.fn> }
   let deviceModels: MockDeviceModelsService
+  let fallbackScreens: MockFallbackScreensService
 
   beforeEach(() => {
     deviceRepo = createMockRepo()
     screenRepo = createMockRepo()
     configService = { get: vi.fn() }
     deviceModels = createMockDeviceModelsService()
+    fallbackScreens = createMockFallbackScreensService()
     service = new DeviceDisplayService(
       deviceRepo as any,
       screenRepo as any,
       configService as any,
       deviceModels as any,
+      fallbackScreens as any,
     )
     vi.resetAllMocks()
     primeMockDeviceModelsService(deviceModels)
+    primeMockFallbackScreensService(fallbackScreens)
     primePuppeteer()
   })
 
@@ -165,7 +169,7 @@ describe('deviceDisplayService', () => {
       expect(html).toContain('--screen-w: 1040px;')
       expect(html).toContain('<div class="view view--full"><p>hi</p></div>')
       const { convertToPng } = await import('../../utils/imageUtils')
-      expect(convertToPng).toHaveBeenCalledWith(expect.any(String), expect.stringContaining('screen2.png'), 1872, 1404, expect.any(Object))
+      expect(convertToPng).toHaveBeenCalledWith(expect.any(String), expect.stringContaining('screen2.png'), { model: V2, palette: GRAY_16 }, expect.any(Object))
       expect(result.image_url).toBe('http://api/screens/devices/1/screen2.png')
     })
 
@@ -308,7 +312,7 @@ describe('deviceDisplayService', () => {
     expect(result.refresh_rate).toBe(30)
     expect(result.firmware_url).toBe('http://example.com/firmware')
     expect(downloadImage).toHaveBeenCalledWith('http://example.com/image.jpg', expect.any(String), expect.any(Object))
-    expect(convertToPng).toHaveBeenCalledWith(expect.any(String), expect.stringContaining('mirror.png'), 800, 480, expect.any(Object))
+    expect(convertToPng).toHaveBeenCalledWith(expect.any(String), expect.stringContaining('mirror.png'), { model: OG_PLUS, palette: GRAY_4 }, expect.any(Object))
     expect(fs.unlink).toHaveBeenCalled()
   })
 
@@ -347,7 +351,7 @@ describe('deviceDisplayService', () => {
     expect(result.image_url).toContain('mirror.png')
     expect(result.refresh_rate).toBe(device.refreshRate)
     expect(downloadImage).toHaveBeenCalledWith('http://example.com/image.jpg', expect.any(String), expect.any(Object))
-    expect(convertToPng).toHaveBeenCalledWith(expect.any(String), expect.stringContaining('mirror.png'), 800, 480, expect.any(Object))
+    expect(convertToPng).toHaveBeenCalledWith(expect.any(String), expect.stringContaining('mirror.png'), { model: OG_PLUS, palette: GRAY_4 }, expect.any(Object))
     expect(fs.unlink).toHaveBeenCalled()
   })
 
@@ -413,7 +417,7 @@ describe('deviceDisplayService', () => {
         headers: { 'access-token': 'mirror-token', 'ID': 'different-mac' },
       })
       expect(downloadImage).toHaveBeenCalledWith('http://example.com/image.jpg', expect.any(String), expect.any(Object))
-      expect(convertToPng).toHaveBeenCalledWith(expect.any(String), expect.stringContaining('mirror.png'), 800, 480, expect.any(Object))
+      expect(convertToPng).toHaveBeenCalledWith(expect.any(String), expect.stringContaining('mirror.png'), { model: OG_PLUS, palette: GRAY_4 }, expect.any(Object))
       expect(result).toBeInstanceOf(DisplayScreen)
       expect(result.filename).toContain('mirror')
       expect(result.image_url).toBe('http://api/screens/devices/1/mirror.png')
@@ -475,7 +479,7 @@ describe('deviceDisplayService', () => {
 
       const result = await service.getCurrentImageWithoutProgressing(headers)
       expect(downloadImage).toHaveBeenCalledWith('http://example.com/image.jpg', expect.any(String), expect.any(Object))
-      expect(convertToPng).toHaveBeenCalledWith(expect.any(String), expect.stringContaining('screen1.png'), 800, 480, expect.any(Object))
+      expect(convertToPng).toHaveBeenCalledWith(expect.any(String), expect.stringContaining('screen1.png'), { model: OG_PLUS, palette: GRAY_4 }, expect.any(Object))
       expect(result).toBeInstanceOf(DisplayScreen)
       expect(result.image_url).toBe('http://api/screens/devices/1/screen1.png')
     })

--- a/packages/api/src/devices/__test__/setup.service.spec.ts
+++ b/packages/api/src/devices/__test__/setup.service.spec.ts
@@ -1,7 +1,7 @@
-import type { MockDeviceModelsService } from '../../device-models/__test__/mockDeviceModelsService'
+import type { MockDeviceModelsService, MockFallbackScreensService } from '../../device-models/__test__/mockDeviceModelsService'
 import type { Device } from '../devices.entity'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { createMockDeviceModelsService, OG_PLUS, primeMockDeviceModelsService } from '../../device-models/__test__/mockDeviceModelsService'
+import { createMockDeviceModelsService, createMockFallbackScreensService, OG_PLUS, primeMockDeviceModelsService, primeMockFallbackScreensService, V2 } from '../../device-models/__test__/mockDeviceModelsService'
 import { DeviceSetupService } from '../setup.service'
 
 vi.mock('../../utils/generateApikey', () => ({
@@ -22,20 +22,21 @@ function createMockRepo() {
 describe('deviceSetupService', () => {
   let service: DeviceSetupService
   let deviceRepo: ReturnType<typeof createMockRepo>
-  let configService: { get: ReturnType<typeof vi.fn> }
   let deviceModels: MockDeviceModelsService
+  let fallbackScreens: MockFallbackScreensService
 
   beforeEach(() => {
     deviceRepo = createMockRepo()
-    configService = { get: vi.fn() }
     deviceModels = createMockDeviceModelsService()
+    fallbackScreens = createMockFallbackScreensService()
     service = new DeviceSetupService(
       deviceRepo as any,
-      configService as any,
       deviceModels as any,
+      fallbackScreens as any,
     )
     vi.resetAllMocks()
     primeMockDeviceModelsService(deviceModels)
+    primeMockFallbackScreensService(fallbackScreens)
   })
 
   const headers = { id: 'mac' }
@@ -43,7 +44,6 @@ describe('deviceSetupService', () => {
   it('returns existing credentials if device exists', async () => {
     const device = { apikey: 'existing-key', friendlyId: 'existing-id' } as Device
     deviceRepo.findOneBy.mockResolvedValue(device)
-    configService.get.mockReturnValue('http://api')
     const result = await service.setupDevice(headers)
     expect(result.api_key).toBe('existing-key')
     expect(result.friendly_id).toBe('existing-id')
@@ -57,7 +57,6 @@ describe('deviceSetupService', () => {
     deviceRepo.findOneBy.mockResolvedValue(null)
     deviceRepo.create.mockReturnValue(newDevice)
     deviceRepo.save.mockResolvedValue(newDevice)
-    configService.get.mockReturnValue('http://api')
 
     const result = await service.setupDevice(headers)
 
@@ -76,20 +75,20 @@ describe('deviceSetupService', () => {
     expect(result.message).toBe('Welcome to Kuroshiro')
   })
 
-  it('calls config service to get API URL', async () => {
-    deviceRepo.findOneBy.mockResolvedValue({ apikey: 'key', friendlyId: 'id' } as Device)
-    configService.get.mockReturnValue('https://custom-api.com')
+  it('serves the welcome image converted for the device render target', async () => {
+    deviceRepo.findOneBy.mockResolvedValue({ apikey: 'key', friendlyId: 'id', deviceModel: V2 } as unknown as Device)
+    deviceModels.renderTargetFor.mockResolvedValue({ model: V2, palette: OG_PLUS })
+    fallbackScreens.urlFor.mockResolvedValue('http://api/screens/fallback/v2-gray-16/welcome.png')
 
     const result = await service.setupDevice(headers)
 
-    expect(configService.get).toHaveBeenCalledWith('api_url')
-    expect(result.image_url).toBe('https://custom-api.com/screens/welcome.png')
+    expect(fallbackScreens.urlFor).toHaveBeenCalledWith('welcome', { model: V2, palette: OG_PLUS })
+    expect(result.image_url).toBe('http://api/screens/fallback/v2-gray-16/welcome.png')
   })
 
   it('records the reported firmware version and model, and resolves a model when none is assigned', async () => {
     const device = { apikey: 'key', friendlyId: 'id', deviceModel: null } as unknown as Device
     deviceRepo.findOneBy.mockResolvedValue(device)
-    configService.get.mockReturnValue('http://api')
     deviceModels.assignResolvedModel.mockResolvedValue(OG_PLUS)
 
     await service.setupDevice({ 'id': 'mac', 'fw-version': '1.6.0', 'model': 'og' })
@@ -101,7 +100,6 @@ describe('deviceSetupService', () => {
   it('leaves an already assigned model alone', async () => {
     const device = { apikey: 'key', friendlyId: 'id', deviceModel: OG_PLUS } as unknown as Device
     deviceRepo.findOneBy.mockResolvedValue(device)
-    configService.get.mockReturnValue('http://api')
 
     await service.setupDevice({ id: 'mac', model: 'x' })
 

--- a/packages/api/src/devices/devices.module.ts
+++ b/packages/api/src/devices/devices.module.ts
@@ -5,6 +5,7 @@ import { DeviceModelsModule } from '../device-models/device-models.module'
 import { LogEntry } from '../logs/logs.entity'
 import { PluginsModule } from '../plugins/plugins.module'
 import { Screen } from '../screens/screens.entity'
+import { ScreensModule } from '../screens/screens.module'
 import { DevicesController } from './devices.controller'
 import { Device } from './devices.entity'
 import { DevicesService } from './devices.service'
@@ -14,7 +15,7 @@ import { SetupController } from './setup.controller'
 import { DeviceSetupService } from './setup.service'
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Device, Screen, LogEntry]), ConfigModule, PluginsModule, DeviceModelsModule],
+  imports: [TypeOrmModule.forFeature([Device, Screen, LogEntry]), ConfigModule, PluginsModule, DeviceModelsModule, ScreensModule],
   controllers: [DevicesController, DisplayController, SetupController],
   providers: [DevicesService, DeviceDisplayService, DeviceSetupService],
   exports: [DevicesService],

--- a/packages/api/src/devices/devices.service.ts
+++ b/packages/api/src/devices/devices.service.ts
@@ -3,6 +3,7 @@ import type { UpdateDeviceDto } from './dto/update-device.dto'
 import { BadRequestException, Injectable } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
 import { DeviceModelsService } from '../device-models/device-models.service'
+import { ScreensService } from '../screens/screens.service'
 import generateApikey from '../utils/generateApikey'
 import generateFriendlyName from '../utils/generateFriendlyName'
 import { Device } from './devices.entity'
@@ -14,6 +15,7 @@ export class DevicesService {
     @InjectRepository(Device)
     private deviceRepository: Repository<Device>,
     private deviceModels: DeviceModelsService,
+    private screensService: ScreensService,
   ) {}
 
   async findAll(): Promise<Device[]> {
@@ -37,8 +39,12 @@ export class DevicesService {
       return null
     const { deviceModelName, paletteId, ...attributes } = changes
     Object.assign(dbDevice, attributes)
+    const before = { model: dbDevice.deviceModel?.name, palette: dbDevice.palette?.id }
     await this.applyModelChanges(dbDevice, deviceModelName, paletteId)
-    return this.deviceRepository.save(dbDevice)
+    const saved = await this.deviceRepository.save(dbDevice)
+    if (before.model !== saved.deviceModel?.name || before.palette !== saved.palette?.id)
+      await this.screensService.reconvertImageScreens(saved)
+    return saved
   }
 
   async remove(id: string): Promise<boolean> {

--- a/packages/api/src/devices/display.service.ts
+++ b/packages/api/src/devices/display.service.ts
@@ -10,6 +10,7 @@ import { InjectRepository } from '@nestjs/typeorm'
 import puppeteer from 'puppeteer'
 import { Repository } from 'typeorm'
 import { DeviceModelsService } from '../device-models/device-models.service'
+import { FallbackScreensService } from '../device-models/fallback-screens.service'
 import { viewFull, wrapInScreenShell } from '../device-models/screen-shell'
 import { PluginDataFetcherService } from '../plugins/services/plugin-data-fetcher.service'
 import { PluginRendererService } from '../plugins/services/plugin-renderer.service'
@@ -45,6 +46,7 @@ export class DeviceDisplayService {
     private screenRepository: Repository<Screen>,
     private configService: ConfigService,
     private deviceModels: DeviceModelsService,
+    private fallbackScreens: FallbackScreensService,
     private pluginDataFetcher: PluginDataFetcherService,
     private pluginRenderer: PluginRendererService,
     private pluginTransformer: PluginTransformService,
@@ -102,7 +104,7 @@ export class DeviceDisplayService {
       return new Display({
         filename: 'noScreen.png',
         firmware_url: '',
-        image_url: `${this.configService.get<string>('api_url')}/screens/noScreen.png`,
+        image_url: await this.fallbackImageUrl('noScreen', device),
         refresh_rate: device.refreshRate,
         reset_firmware: resetDevice,
         special_function: device.specialFunction,
@@ -145,7 +147,7 @@ export class DeviceDisplayService {
       }
       let refreshRate = device.refreshRate
       let filename = 'error.png'
-      let localImageUrl = `${this.configService.get<string>('api_url')}/screens/error.png`
+      let localImageUrl = await this.fallbackImageUrl('error', device)
       let firmwareUrl = null
       let resetFirmware = false
       let specialFunction = device.specialFunction
@@ -194,12 +196,12 @@ export class DeviceDisplayService {
       this.logger.log('No screen found returning default no screen image')
       return new DisplayScreen({
         filename: 'noScreen.png',
-        image_url: `${this.configService.get<string>('api_url')}/screens/noScreen.png`,
+        image_url: await this.fallbackImageUrl('noScreen', device),
         refresh_rate: device.refreshRate,
         rendered_at: new Date(),
       })
     }
-    let imgUrl = `${this.configService.get<string>('api_url')}/screens/error.png`
+    let imgUrl = await this.fallbackImageUrl('error', device)
     if (device.mirrorEnabled) {
       this.logger.log(`Mirroring enabled for device ${device.id}, checking for image...`)
       if (await fileExists(resolveAppPath('public', 'screens', 'devices', device.id, 'mirror.png'))) {
@@ -252,8 +254,7 @@ export class DeviceDisplayService {
     const outputPath = path.join(destDir, pngFilename)
 
     await downloadImage(response.image_url, inputPath, this.logger)
-    const { width, height } = await this.deviceModels.outputSizeFor(device)
-    await convertToPng(inputPath, outputPath, width, height, this.logger)
+    await convertToPng(inputPath, outputPath, await this.deviceModels.renderTargetFor(device), this.logger)
     await fs.promises.unlink(inputPath)
     this.logger.log(`Deleted original image: ${inputPath}`)
 
@@ -299,7 +300,7 @@ export class DeviceDisplayService {
       }
       catch (err) {
         this.logger.error(`Failed to render mashup: ${err.message}`)
-        imgUrl = this.errorImageUrl()
+        imgUrl = await this.fallbackImageUrl('error', device)
       }
     }
     // Handle plugin screen
@@ -321,7 +322,7 @@ export class DeviceDisplayService {
           }
           catch (err) {
             this.logger.error(`Failed to render cached plugin output: ${err.message}`)
-            imgUrl = this.errorImageUrl()
+            imgUrl = await this.fallbackImageUrl('error', device)
           }
         }
         // Fallback: fetch and render on-demand
@@ -333,7 +334,7 @@ export class DeviceDisplayService {
           }
           catch (err) {
             this.logger.error(`Failed to render plugin: ${err.message}`)
-            imgUrl = this.errorImageUrl()
+            imgUrl = await this.fallbackImageUrl('error', device)
           }
         }
       }
@@ -347,8 +348,7 @@ export class DeviceDisplayService {
       const inputPath = path.join(resolveAppPath('public', 'screens', 'devices', device.id), 'tmp-source')
       try {
         await downloadImage(screen.externalLink, inputPath, this.logger)
-        const { width, height } = await this.deviceModels.outputSizeFor(device)
-        await convertToPng(inputPath, this.screenImagePath(device, screen), width, height, this.logger)
+        await convertToPng(inputPath, this.screenImagePath(device, screen), await this.deviceModels.renderTargetFor(device), this.logger)
         this.logger.log('Updating generation date on screen')
         screen.generatedAt = new Date()
         await this.screenRepository.save(screen)
@@ -357,7 +357,7 @@ export class DeviceDisplayService {
       }
       catch (err) {
         this.logger.error(`Failed to process image: ${err.message}`)
-        imgUrl = this.errorImageUrl()
+        imgUrl = await this.fallbackImageUrl('error', device)
       }
     }
     if (imgUrl !== null)
@@ -366,7 +366,7 @@ export class DeviceDisplayService {
     // No rendering source (e.g. uploaded file screens) — serve the stored image if present
     return await fileExists(this.screenImagePath(device, screen))
       ? this.screenImageUrl(device, screen)
-      : this.errorImageUrl()
+      : await this.fallbackImageUrl('error', device)
   }
 
   private async renderPluginHtml(plugin: Plugin, screen: Screen): Promise<string | null> {
@@ -434,7 +434,7 @@ export class DeviceDisplayService {
       const inputPath = path.join(destDir, 'tmp-source')
       await fs.promises.mkdir(destDir, { recursive: true })
       await fs.promises.writeFile(inputPath, buffer.Buffer.from(image))
-      await convertToPng(inputPath, this.screenImagePath(device, screen), target.model.width, target.model.height, this.logger)
+      await convertToPng(inputPath, this.screenImagePath(device, screen), target, this.logger)
       return this.screenImageUrl(device, screen)
     }
     finally {
@@ -456,7 +456,7 @@ export class DeviceDisplayService {
     return `${this.configService.get<string>('api_url')}/screens/devices/${device.id}/${screen.id}.png`
   }
 
-  private errorImageUrl(): string {
-    return `${this.configService.get<string>('api_url')}/screens/error.png`
+  private async fallbackImageUrl(kind: 'noScreen' | 'error', device: Device): Promise<string> {
+    return this.fallbackScreens.urlFor(kind, await this.deviceModels.renderTargetFor(device))
   }
 }

--- a/packages/api/src/devices/setup.service.ts
+++ b/packages/api/src/devices/setup.service.ts
@@ -1,9 +1,9 @@
 import type { SetupRequestHeadersDto } from './dto/setup-request-headers.dto'
 import { Injectable, Logger } from '@nestjs/common'
-import { ConfigService } from '@nestjs/config'
 import { InjectRepository } from '@nestjs/typeorm'
 import { Repository } from 'typeorm'
 import { DeviceModelsService } from '../device-models/device-models.service'
+import { FallbackScreensService } from '../device-models/fallback-screens.service'
 import generateApikey from '../utils/generateApikey'
 import generateFriendlyName from '../utils/generateFriendlyName'
 import { Device } from './devices.entity'
@@ -22,18 +22,12 @@ export class DeviceSetupService {
   constructor(
     @InjectRepository(Device)
     private deviceRepository: Repository<Device>,
-    private configService: ConfigService,
     private deviceModels: DeviceModelsService,
+    private fallbackScreens: FallbackScreensService,
   ) {}
 
   async setupDevice(headers: SetupRequestHeadersDto): Promise<SetupResponse> {
     this.logger.log(`Setup request for MAC: ${headers.id}`)
-    const baseSetupResponse = {
-      status: 200 as const,
-      image_url: `${this.configService.get<string>('api_url')}/screens/welcome.png`,
-      message: 'Welcome to Kuroshiro',
-    }
-
     const existing = await this.deviceRepository.findOneBy({ mac: headers.id })
     const device = existing ?? this.createDevice(headers.id)
     this.logger.log(existing
@@ -49,7 +43,9 @@ export class DeviceSetupService {
       this.logger.log(`New device created with id: ${device.id}`)
 
     const setupResponse: SetupResponse = {
-      ...baseSetupResponse,
+      status: 200,
+      image_url: await this.fallbackScreens.urlFor('welcome', await this.deviceModels.renderTargetFor(device)),
+      message: 'Welcome to Kuroshiro',
       friendly_id: device.friendlyId,
       api_key: device.apikey,
     }

--- a/packages/api/src/maintenance/__test__/maintenance.service.spec.ts
+++ b/packages/api/src/maintenance/__test__/maintenance.service.spec.ts
@@ -85,6 +85,30 @@ describe('maintenanceService', () => {
       })
     })
 
+    it('treats retained originals like screen images: orphaned without a screen, kept with one', async () => {
+      const device = { id: 'device-1' } as Device
+      deviceRepo.find.mockResolvedValue([device])
+      screenRepo.find.mockResolvedValue([{ id: 'kept', type: 'file', device } as any])
+
+      vi.spyOn(fs.promises, 'stat').mockImplementation(async (path: any) => {
+        if (path === '/mock/public/screens/devices' || path === '/mock/public/screens/devices/device-1')
+          return { isDirectory: () => true } as any
+        return { isDirectory: () => false, size: 10, mtimeMs: Date.now() } as any
+      })
+      vi.spyOn(fs.promises, 'readdir').mockImplementation(async (path: any) => {
+        if (path === '/mock/public/screens/devices')
+          return ['device-1'] as any
+        if (path === '/mock/public/screens/devices/device-1')
+          return ['kept.png', 'kept.original', 'gone.original'] as any
+        return [] as any
+      })
+
+      const result = await service.scan()
+
+      expect(result.orphanedScreenFiles.map(f => f.path)).toEqual(['/mock/public/screens/devices/device-1/gone.original'])
+      expect(result.orphanedScreenFiles[0].screenId).toBe('gone')
+    })
+
     it('detects orphaned device directories', async () => {
       deviceRepo.find.mockResolvedValue([])
       screenRepo.find.mockResolvedValue([])

--- a/packages/api/src/maintenance/maintenance.service.ts
+++ b/packages/api/src/maintenance/maintenance.service.ts
@@ -133,10 +133,10 @@ export class MaintenanceService {
             continue
           }
 
-          const screenId = file.replace('.png', '')
+          const screenId = file.replace(/\.(png|original)$/, '')
           const screen = screens.find(s => s.id === screenId && s.device.id === deviceDir)
 
-          if (!screen && file.endsWith('.png')) {
+          if (!screen && (file.endsWith('.png') || file.endsWith('.original'))) {
             orphanedScreenFiles.push({
               deviceId: deviceDir,
               screenId,

--- a/packages/api/src/screens/__test__/screens.service.spec.ts
+++ b/packages/api/src/screens/__test__/screens.service.spec.ts
@@ -9,10 +9,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createMockDeviceModelsService, primeMockDeviceModelsService } from '../../device-models/__test__/mockDeviceModelsService'
 import { ScreensService } from '../screens.service'
 
+const { fileExistsMock } = vi.hoisted(() => ({ fileExistsMock: vi.fn() }))
+
 vi.mock('../../utils/imageUtils', () => ({
   downloadImage: vi.fn().mockResolvedValue(undefined),
   convertToPng: vi.fn().mockResolvedValue(undefined),
 }))
+
+vi.mock('../../utils/fileExists', () => ({ fileExists: fileExistsMock }))
 
 function createMockRepo() {
   const repo: any = {
@@ -80,8 +84,12 @@ describe('screensService', () => {
     screensRepo.save.mockResolvedValue(screen)
     screensRepo.update.mockResolvedValue(undefined)
     const file = { buffer: buffer.Buffer.from('data') }
+    const writeFileMock = vi.spyOn(fs.promises, 'writeFile').mockResolvedValue(undefined)
+    vi.spyOn(fs.promises, 'mkdir').mockResolvedValue(undefined)
     const result = await service.add({ filename: 'file', deviceId: 'dev', fetchManual: false, html: '' }, file)
     expect(result).toBe(screen)
+    expect(writeFileMock).toHaveBeenCalledWith(expect.stringContaining('public/screens/devices/dev/1.original'), file.buffer)
+    expect(unlinkMock).not.toHaveBeenCalled()
     expect(screensRepo.save).toHaveBeenCalledWith(screen)
   })
 
@@ -122,13 +130,52 @@ describe('screensService', () => {
     expect(screensRepo.delete).toHaveBeenCalledWith('1')
     expect(screensRepo.save).toHaveBeenCalled()
     expect(unlinkMock).toHaveBeenCalledWith(expect.stringContaining('public/screens/devices/dev/1.png'))
+    expect(unlinkMock).toHaveBeenCalledWith(expect.stringContaining('public/screens/devices/dev/1.original'))
   })
 
-  it('updateExternalScreen refetches and converts image', async () => {
+  it('updateExternalScreen refetches into the retained original and converts it', async () => {
     const device = { id: 'dev', width: 100, height: 100 } as Device
     const screen = { id: '1', device, externalLink: 'url', fetchManual: true } as Screen
     screensRepo.findOne.mockResolvedValue(screen)
     await expect(service.updateExternalScreen('1')).resolves.toBeUndefined()
+    const { downloadImage, convertToPng } = await import('../../utils/imageUtils')
+    expect(downloadImage).toHaveBeenCalledWith('url', expect.stringContaining('public/screens/devices/dev/1.original'), expect.any(Object))
+    expect(convertToPng).toHaveBeenCalledWith(expect.stringContaining('1.original'), expect.stringContaining('1.png'), expect.anything(), expect.any(Object))
+  })
+
+  describe('reconvertImageScreens', () => {
+    const device = { id: 'dev' } as Device
+
+    it('reconverts uploads and cached external images from their original, or from the PNG when none is retained', async () => {
+      screensRepo.find.mockResolvedValue([
+        { id: 'upload', type: 'file' },
+        { id: 'legacy', type: 'file' },
+        { id: 'cached', type: 'external', fetchManual: true },
+        { id: 'live', type: 'external', fetchManual: false },
+        { id: 'plugin', type: 'plugin' },
+      ])
+      fileExistsMock.mockImplementation(async (p: string) => !p.endsWith('legacy.original'))
+      const renameMock = vi.spyOn(fs.promises, 'rename').mockResolvedValue(undefined)
+      const { convertToPng } = await import('../../utils/imageUtils')
+
+      await expect(service.reconvertImageScreens(device)).resolves.toBe(3)
+
+      const sources = vi.mocked(convertToPng).mock.calls.map(call => call[0].split('/').pop())
+      expect(sources).toEqual(['upload.original', 'legacy.png', 'cached.original'])
+      expect(renameMock).toHaveBeenCalledWith(expect.stringContaining('tmp-upload.png'), expect.stringContaining('/upload.png'))
+      expect(screensRepo.update).toHaveBeenCalledWith({ id: 'upload' }, { generatedAt: expect.any(Date) })
+      expect(screensRepo.update).not.toHaveBeenCalledWith({ id: 'live' }, expect.anything())
+    })
+
+    it('keeps going when one screen fails to convert', async () => {
+      screensRepo.find.mockResolvedValue([{ id: 'a', type: 'file' }, { id: 'b', type: 'file' }])
+      fileExistsMock.mockResolvedValue(true)
+      vi.spyOn(fs.promises, 'rename').mockResolvedValue(undefined)
+      const { convertToPng } = await import('../../utils/imageUtils')
+      vi.mocked(convertToPng).mockRejectedValueOnce(new Error('boom')).mockResolvedValueOnce(undefined)
+
+      await expect(service.reconvertImageScreens(device)).resolves.toBe(1)
+    })
   })
 
   it('updateExternalScreen throws if not found', async () => {

--- a/packages/api/src/screens/screens.module.ts
+++ b/packages/api/src/screens/screens.module.ts
@@ -11,5 +11,6 @@ import { ScreensService } from './screens.service'
   imports: [TypeOrmModule.forFeature([Screen, Device]), ConfigModule, DeviceModelsModule],
   controllers: [ScreensController],
   providers: [ScreensService],
+  exports: [ScreensService],
 })
 export class ScreensModule {}

--- a/packages/api/src/screens/screens.service.ts
+++ b/packages/api/src/screens/screens.service.ts
@@ -6,6 +6,7 @@ import { InjectRepository } from '@nestjs/typeorm'
 import { EntityManager, Repository } from 'typeorm'
 import { DeviceModelsService } from '../device-models/device-models.service'
 import { Device } from '../devices/devices.entity'
+import { fileExists } from '../utils/fileExists'
 import { convertToPng, downloadImage } from '../utils/imageUtils'
 import { resolveAppPath } from '../utils/pathHelper'
 import { assertPublicUrl } from '../utils/ssrfGuard'
@@ -57,16 +58,13 @@ export class ScreensService {
     if (body.externalLink && body.fetchManual) {
       if (this.configService.get<boolean>('demo_mode'))
         assertPublicUrl(body.externalLink)
-      const destDir = resolveAppPath('public', 'screens', 'devices', device.id)
-      const inputPath = path.join(destDir, 'tmp-source')
-      const pngFilename = `${saved.id}.png`
-      const outputPath = path.join(destDir, pngFilename)
+      const inputPath = this.originalImagePath(device.id, saved.id)
+      const outputPath = this.screenImagePath(device.id, saved.id)
       this.logger.debug(`Input path: ${inputPath}`)
       this.logger.debug(`Planned output path: ${outputPath}`)
       try {
         await downloadImage(body.externalLink, inputPath, this.logger)
-        const { width, height } = await this.deviceModels.outputSizeFor(device)
-        await convertToPng(inputPath, outputPath, width, height, this.logger)
+        await convertToPng(inputPath, outputPath, await this.deviceModels.renderTargetFor(device), this.logger)
         this.logger.log('Download and conversion successful')
       }
       catch (err) {
@@ -79,18 +77,14 @@ export class ScreensService {
     // Handle file upload and conversion
     else if (file) {
       try {
-        const destDir = resolveAppPath('public', 'screens', 'devices', device.id)
-        await fs.promises.mkdir(destDir, { recursive: true })
-        const inputPath = path.join(destDir, `${saved.id}-source`)
-        const pngFilename = `${saved.id}.png`
-        const outputPath = path.join(destDir, pngFilename)
+        const inputPath = this.originalImagePath(device.id, saved.id)
+        const outputPath = this.screenImagePath(device.id, saved.id)
+        await fs.promises.mkdir(path.dirname(inputPath), { recursive: true })
         this.logger.debug(`Input path: ${inputPath}`)
         this.logger.debug(`Planned output path: ${outputPath}`)
         await fs.promises.writeFile(inputPath, file.buffer)
         this.logger.log(`Uploaded file saved to ${inputPath}`)
-        const { width, height } = await this.deviceModels.outputSizeFor(device)
-        await convertToPng(inputPath, outputPath, width, height, this.logger)
-        await fs.promises.unlink(inputPath)
+        await convertToPng(inputPath, outputPath, await this.deviceModels.renderTargetFor(device), this.logger)
         this.logger.log(`Converted and saved PNG to ${outputPath}`)
       }
       catch {
@@ -123,20 +117,8 @@ export class ScreensService {
       throw new NotFoundException('Screen not found')
     }
     const deviceId = screen.device.id
-    // Delete PNG file if it exists
-    const pngPath = resolveAppPath('public', 'screens', 'devices', deviceId, `${id}.png`)
-    try {
-      await fs.promises.unlink(pngPath)
-      this.logger.log(`Deleted PNG file: ${pngPath}`)
-    }
-    catch (err) {
-      if (err.code === 'ENOENT') {
-        this.logger.warn(`PNG file not found for deletion: ${pngPath}`)
-      }
-      else {
-        this.logger.error(`Failed to delete PNG file: ${pngPath} - ${err.message}`)
-      }
-    }
+    await this.deleteFileIfExists(this.screenImagePath(deviceId, id))
+    await this.deleteFileIfExists(this.originalImagePath(deviceId, id))
     await this.screensRepository.delete(id)
     this.logger.log(`Screen deleted: ${id}`)
     // Reindex order for remaining screens, closing the gap left by the deleted screen
@@ -206,14 +188,11 @@ export class ScreensService {
     }
     if (this.configService.get<boolean>('demo_mode'))
       assertPublicUrl(screen.externalLink)
-    const destDir = resolveAppPath('public', 'screens', 'devices', screen.device.id)
-    const inputPath = path.join(destDir, 'tmp-source')
-    const pngFilename = `${screen.id}.png`
-    const outputPath = path.join(destDir, pngFilename)
+    const inputPath = this.originalImagePath(screen.device.id, screen.id)
+    const outputPath = this.screenImagePath(screen.device.id, screen.id)
     try {
       await downloadImage(screen.externalLink, inputPath, this.logger)
-      const { width, height } = await this.deviceModels.outputSizeFor(screen.device)
-      await convertToPng(inputPath, outputPath, width, height, this.logger)
+      await convertToPng(inputPath, outputPath, await this.deviceModels.renderTargetFor(screen.device), this.logger)
       this.logger.log('Updating generation date on screen')
       screen.generatedAt = new Date()
       await this.screensRepository.save(screen)
@@ -222,6 +201,59 @@ export class ScreensService {
     catch (err) {
       this.logger.error(`Failed to process image: ${err.message}. Removing screen again.`)
       throw new InternalServerErrorException('Error processing image')
+    }
+  }
+
+  /**
+   * Regenerates every stored image of a device (uploads and cached external
+   * images) for its current model and palette, from the retained original
+   * where one exists and from the previous PNG otherwise.
+   */
+  async reconvertImageScreens(device: Device): Promise<number> {
+    const screens = await this.screensRepository.find({ where: { device: { id: device.id } } })
+    const target = await this.deviceModels.renderTargetFor(device)
+    let converted = 0
+    for (const screen of screens.filter(s => s.type === 'file' || (s.type === 'external' && s.fetchManual))) {
+      const outputPath = this.screenImagePath(device.id, screen.id)
+      const originalPath = this.originalImagePath(device.id, screen.id)
+      const sourcePath = await fileExists(originalPath) ? originalPath : outputPath
+      if (!await fileExists(sourcePath)) {
+        this.logger.warn(`No image to reconvert for screen ${screen.id}`)
+        continue
+      }
+      try {
+        const tempPath = path.join(path.dirname(outputPath), `tmp-${screen.id}.png`)
+        await convertToPng(sourcePath, tempPath, target, this.logger)
+        await fs.promises.rename(tempPath, outputPath)
+        await this.screensRepository.update({ id: screen.id }, { generatedAt: new Date() })
+        converted++
+      }
+      catch (err) {
+        this.logger.error(`Failed to reconvert screen ${screen.id}: ${err.message}`)
+      }
+    }
+    this.logger.log(`Reconverted ${converted} image screen(s) for device ${device.id} as ${target.model.name}/${target.palette.id}`)
+    return converted
+  }
+
+  private screenImagePath(deviceId: string, screenId: string): string {
+    return resolveAppPath('public', 'screens', 'devices', deviceId, `${screenId}.png`)
+  }
+
+  private originalImagePath(deviceId: string, screenId: string): string {
+    return resolveAppPath('public', 'screens', 'devices', deviceId, `${screenId}.original`)
+  }
+
+  private async deleteFileIfExists(filePath: string): Promise<void> {
+    try {
+      await fs.promises.unlink(filePath)
+      this.logger.log(`Deleted file: ${filePath}`)
+    }
+    catch (err) {
+      if (err.code === 'ENOENT')
+        this.logger.warn(`File not found for deletion: ${filePath}`)
+      else
+        this.logger.error(`Failed to delete file: ${filePath} - ${err.message}`)
     }
   }
 }

--- a/packages/api/src/utils/__test__/imageUtils.spec.ts
+++ b/packages/api/src/utils/__test__/imageUtils.spec.ts
@@ -1,7 +1,7 @@
 import type { Logger } from '@nestjs/common'
 import { Buffer } from 'node:buffer'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { convertToPng, downloadImage } from '../imageUtils'
+import { convertToPng, downloadImage, paletteConversion } from '../imageUtils'
 
 const mockExec = vi.fn()
 const mockFd = {
@@ -56,70 +56,117 @@ describe('imageUtils', () => {
     vi.resetAllMocks()
   })
 
+  const OG_PLUS = { name: 'og_plus', width: 800, height: 480, rotation: 0, offsetX: 0, offsetY: 0 } as any
+  const GRAY_4 = { id: 'gray-4', grays: 4, colors: null, frameworkClass: 'screen--2bit' } as any
+  const BW = { id: 'bw', grays: 2, colors: null, frameworkClass: 'screen--1bit' } as any
+  const GRAY_16 = { id: 'gray-16', grays: 16, colors: null, frameworkClass: 'screen--4bit' } as any
+  const COLOR_6A = { id: 'color-6a', grays: 2, colors: ['#FF0000', '#00FF00', '#0000FF', '#FFFF00', '#000000', '#FFFFFF'], frameworkClass: 'screen--color-6a' } as any
+  const COLOR_24 = { id: 'color-24bit', grays: 2, colors: null, frameworkClass: 'screen--color-full' } as any
+
+  function magickSucceeds() {
+    mockExec.mockImplementation((cmd: string, callback: any) => {
+      callback(null, '', '')
+    })
+  }
+
+  describe('paletteConversion', () => {
+    it('maps gray palettes to a bit depth', () => {
+      expect(paletteConversion(BW)).toEqual({ kind: 'gray', levels: 2, bitDepth: 1 })
+      expect(paletteConversion(GRAY_4)).toEqual({ kind: 'gray', levels: 4, bitDepth: 2 })
+      expect(paletteConversion(GRAY_16)).toEqual({ kind: 'gray', levels: 16, bitDepth: 4 })
+      expect(paletteConversion({ id: 'gray-256', grays: 256, colors: null, frameworkClass: 'screen--4bit' } as any)).toEqual({ kind: 'gray', levels: 256, bitDepth: 8 })
+    })
+
+    it('maps colour palettes to their colour list and full-colour palettes to untouched colour', () => {
+      expect(paletteConversion(COLOR_6A)).toEqual({ kind: 'color', colors: COLOR_6A.colors })
+      expect(paletteConversion(COLOR_24)).toEqual({ kind: 'full-color' })
+    })
+  })
+
   describe('convertToPng', () => {
-    it('creates colormap if it does not exist', async () => {
+    it('creates the gray colormap for the palette if it does not exist', async () => {
       mockFs.existsSync.mockReturnValue(false)
-      mockExec.mockImplementation((cmd: string, callback: any) => {
-        callback(null, '', '')
-      })
+      magickSucceeds()
 
-      await convertToPng('/input.jpg', '/output.png', 800, 480, mockLogger)
+      await convertToPng('/input.jpg', '/output.png', { model: OG_PLUS, palette: GRAY_4 }, mockLogger)
 
-      expect(mockFs.existsSync)
-        .toHaveBeenCalled()
       expect(mockFs.promises.mkdir).toHaveBeenCalled()
       expect(mockExec).toHaveBeenCalledTimes(2)
-      expect(mockExec.mock.calls[0][0]).toContain('xc:#000000 xc:#555555 xc:#aaaaaa xc:#ffffff')
-      expect(mockExec.mock.calls[0][0]).toContain('+append -type Palette')
+      expect(mockExec.mock.calls[0][0]).toContain('xc:"#000000" xc:"#555555" xc:"#aaaaaa" xc:"#ffffff" +append -type Palette')
+      expect(mockExec.mock.calls[0][0]).toContain('colormaps/gray-4.png')
+    })
+
+    it('creates a colormap from the palette colours for colour panels', async () => {
+      mockFs.existsSync.mockReturnValue(false)
+      magickSucceeds()
+
+      await convertToPng('/input.jpg', '/output.png', { model: OG_PLUS, palette: COLOR_6A }, mockLogger)
+
+      expect(mockExec.mock.calls[0][0]).toContain('xc:"#FF0000" xc:"#00FF00" xc:"#0000FF" xc:"#FFFF00" xc:"#000000" xc:"#FFFFFF" +append')
+      expect(mockExec.mock.calls[0][0]).toContain('colormaps/color-6a.png')
+      const cmd = mockExec.mock.calls[1][0]
+      expect(cmd).toContain('-remap')
+      expect(cmd).toContain('-define png:color-type=3')
+      expect(cmd).not.toContain('-colorspace Gray')
     })
 
     it('skips colormap creation if it already exists', async () => {
       mockFs.existsSync.mockReturnValue(true)
-      mockExec.mockImplementation((cmd: string, callback: any) => {
-        callback(null, '', '')
-      })
+      magickSucceeds()
 
-      await convertToPng('/input.jpg', '/output.png', 800, 480, mockLogger)
+      await convertToPng('/input.jpg', '/output.png', { model: OG_PLUS, palette: GRAY_4 }, mockLogger)
 
-      expect(mockFs.existsSync)
-        .toHaveBeenCalled()
-      expect(mockFs.promises.mkdir).not.toHaveBeenCalled()
       expect(mockExec).toHaveBeenCalledTimes(1)
     })
 
-    it('calls ImageMagick with correct 2-bit PNG parameters', async () => {
+    it('calls ImageMagick with 2-bit gray parameters for the 4-gray palette', async () => {
       mockFs.existsSync.mockReturnValue(true)
-      mockExec.mockImplementation((cmd: string, callback: any) => {
-        callback(null, '', '')
-      })
+      magickSucceeds()
 
-      await convertToPng('/input.jpg', '/output.png', 800, 480, mockLogger)
+      await convertToPng('/input.jpg', '/output.png', { model: OG_PLUS, palette: GRAY_4 }, mockLogger)
+
+      const cmd = mockExec.mock.calls[0][0]
+      expect(cmd).toContain('magick "JPEG:/input.jpg"')
+      expect(cmd).toContain('-background white -alpha remove -alpha off')
+      expect(cmd).toContain('-resize 800x480 -gravity Center -extent 800x480')
+      expect(cmd).toContain('-colorspace Gray -dither FloydSteinberg -remap')
+      expect(cmd).toContain('colormaps/gray-4.png')
+      expect(cmd).toContain('-define png:bit-depth=2 -define png:color-type=0')
+      expect(cmd).toContain('-strip png:"/output.png"')
+      expect(cmd).not.toContain('-rotate')
+      expect(cmd).not.toContain('-crop')
+    })
+
+    it('uses 1-bit and 4-bit output for the bw and 16-gray palettes', async () => {
+      mockFs.existsSync.mockReturnValue(true)
+      magickSucceeds()
+
+      await convertToPng('/input.jpg', '/output.png', { model: OG_PLUS, palette: BW }, mockLogger)
+      expect(mockExec.mock.calls[0][0]).toContain('-define png:bit-depth=1')
+      await convertToPng('/input.jpg', '/output.png', { model: OG_PLUS, palette: GRAY_16 }, mockLogger)
+      expect(mockExec.mock.calls[1][0]).toContain('-define png:bit-depth=4')
+    })
+
+    it('keeps full colour for full-colour palettes without remapping', async () => {
+      magickSucceeds()
+
+      await convertToPng('/input.jpg', '/output.png', { model: OG_PLUS, palette: COLOR_24 }, mockLogger)
 
       expect(mockExec).toHaveBeenCalledTimes(1)
       const cmd = mockExec.mock.calls[0][0]
-      expect(cmd).toContain('-resize 800x480')
-      expect(cmd).toContain('-gravity Center')
-      expect(cmd).toContain('-extent 800x480')
-      expect(cmd).toContain('-dither FloydSteinberg')
-      expect(cmd).toContain('-remap')
-      expect(cmd).toContain('colormap-2bit.png')
-      expect(cmd).toContain('-define png:bit-depth=2')
-      expect(cmd).toContain('-define png:color-type=0')
-      expect(cmd).toContain('-strip')
-      expect(cmd).toContain('png:"/output.png"')
+      expect(cmd).toContain('-colorspace sRGB -define png:color-type=2')
+      expect(cmd).not.toContain('-remap')
     })
 
-    it('respects dynamic width and height parameters', async () => {
+    it('fits to the model size, then rotates and trims offsets', async () => {
       mockFs.existsSync.mockReturnValue(true)
-      mockExec.mockImplementation((cmd: string, callback: any) => {
-        callback(null, '', '')
-      })
+      magickSucceeds()
+      const kindle = { ...OG_PLUS, name: 'kindle', width: 1400, height: 840, rotation: 90, offsetX: 75, offsetY: 25 }
 
-      await convertToPng('/input.jpg', '/output.png', 640, 384, mockLogger)
+      await convertToPng('/input.jpg', '/output.png', { model: kindle, palette: GRAY_4 }, mockLogger)
 
       const cmd = mockExec.mock.calls[0][0]
-      expect(cmd).toContain('-resize 640x384')
-      expect(cmd).toContain('-extent 640x384')
+      expect(cmd).toContain('-resize 1400x840 -gravity Center -extent 1400x840 -rotate 90 -crop +75+25 +repage -colorspace Gray')
     })
 
     it('handles ImageMagick errors during colormap creation', async () => {
@@ -130,7 +177,7 @@ describe('imageUtils', () => {
         }
       })
 
-      await expect(convertToPng('/input.jpg', '/output.png', 800, 480, mockLogger))
+      await expect(convertToPng('/input.jpg', '/output.png', { model: OG_PLUS, palette: GRAY_4 }, mockLogger))
         .rejects
         .toThrow('ImageMagick failed')
 
@@ -140,26 +187,23 @@ describe('imageUtils', () => {
     it('handles ImageMagick errors during conversion', async () => {
       mockFs.existsSync.mockReturnValue(true)
       mockExec.mockImplementation((cmd: string, callback: any) => {
-        callback(new Error('Conversion failed'), '', 'Conversion error')
+        callback(new Error('Conversion failed'), '', 'conversion stderr')
       })
 
-      await expect(convertToPng('/input.jpg', '/output.png', 800, 480, mockLogger))
+      await expect(convertToPng('/input.jpg', '/output.png', { model: OG_PLUS, palette: GRAY_4 }, mockLogger))
         .rejects
         .toThrow('Conversion failed')
-
-      expect(mockLogger.error).toHaveBeenCalledWith('ImageMagick error: Conversion error')
     })
 
-    it('logs conversion progress', async () => {
-      mockFs.existsSync.mockReturnValue(true)
-      mockExec.mockImplementation((cmd: string, callback: any) => {
-        callback(null, 'success', '')
+    it('rejects unknown image formats', async () => {
+      mockFd.read.mockImplementation((buf: any) => {
+        buf[0] = 0x00
+        buf[1] = 0x01
+        return Promise.resolve()
       })
-
-      await convertToPng('/input.jpg', '/output.png', 800, 480, mockLogger)
-
-      expect(mockLogger.log).toHaveBeenCalledWith(expect.stringContaining('Running ImageMagick:'))
-      expect(mockLogger.log).toHaveBeenCalledWith('ImageMagick output: success')
+      await expect(convertToPng('/input.bin', '/output.png', { model: OG_PLUS, palette: GRAY_4 }, mockLogger))
+        .rejects
+        .toThrow('Unsupported or unrecognised image format')
     })
   })
 

--- a/packages/api/src/utils/imageUtils.ts
+++ b/packages/api/src/utils/imageUtils.ts
@@ -1,9 +1,11 @@
 import type { Logger } from '@nestjs/common'
+import type { DeviceRenderTarget } from '../device-models/device-models.service'
+import type { Palette } from '../device-models/entities/palette.entity'
 import buffer from 'node:buffer'
 import { exec } from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'
-import process from 'node:process'
+import { resolveAppPath } from './pathHelper'
 
 // Maps magic-byte signatures to the ImageMagick format prefix used when invoking magick.
 // Only raster image formats that make sense on an e-ink display are permitted.
@@ -16,6 +18,8 @@ const MAGIC_BYTES: Array<{ bytes: number[], format: string }> = [
   { bytes: [0x4D, 0x4D, 0x00, 0x2A], format: 'TIFF' },
   { bytes: [0x52, 0x49, 0x46, 0x46], format: 'WEBP' },
 ]
+
+const FULL_COLOR_FRAMEWORK_CLASS = 'screen--color-full'
 
 function detectImageFormat(buf: buffer.Buffer): string {
   for (const { bytes, format } of MAGIC_BYTES) {
@@ -36,48 +40,31 @@ export async function downloadImage(url: string, dest: string, logger: Logger) {
   logger.log(`Image downloaded to ${dest}`)
 }
 
-async function ensureColormapExists(colormapPath: string, logger: Logger): Promise<void> {
-  if (fs.existsSync(colormapPath)) {
-    logger.log(`Colormap already exists at ${colormapPath}`)
-    return
-  }
+export type PaletteConversion
+  = | { kind: 'gray', levels: number, bitDepth: number }
+    | { kind: 'color', colors: string[] }
+    | { kind: 'full-color' }
 
-  logger.log(`Creating 2-bit colormap at ${colormapPath}`)
-  await fs.promises.mkdir(path.dirname(colormapPath), { recursive: true })
+/** How a palette maps onto ImageMagick's output: quantised grays, a fixed colour set, or untouched colour. */
+export function paletteConversion(palette: Pick<Palette, 'grays' | 'colors' | 'frameworkClass'>): PaletteConversion {
+  if (palette.frameworkClass === FULL_COLOR_FRAMEWORK_CLASS)
+    return { kind: 'full-color' }
+  if (palette.colors && palette.colors.length > 0)
+    return { kind: 'color', colors: palette.colors }
+  const levels = Math.max(2, palette.grays)
+  return { kind: 'gray', levels, bitDepth: Math.max(1, Math.ceil(Math.log2(levels))) }
+}
 
-  return new Promise<void>((resolve, reject) => {
-    const cmd = `magick -size 4x1 xc:#000000 xc:#555555 xc:#aaaaaa xc:#ffffff +append -type Palette "${colormapPath}"`
-    logger.log(`Running ImageMagick: ${cmd}`)
-    exec(cmd, (error, stdout, stderr) => {
-      if (error) {
-        logger.error(`ImageMagick error: ${stderr}`)
-        reject(error)
-      }
-      else {
-        logger.log(`Colormap created successfully`)
-        resolve()
-      }
-    })
+function grayLevelsHex(levels: number): string[] {
+  return Array.from({ length: levels }, (_, i) => {
+    const value = Math.round((i * 255) / (levels - 1)).toString(16).padStart(2, '0')
+    return `#${value}${value}${value}`
   })
 }
 
-export async function convertToPng(inputPath: string, outputPath: string, width: number, height: number, logger: Logger) {
-  const header = buffer.Buffer.allocUnsafe(8)
-  const fd = await fs.promises.open(inputPath, 'r')
-  try {
-    await fd.read(header, 0, 8, 0)
-  }
-  finally {
-    await fd.close()
-  }
-  const format = detectImageFormat(header)
-
-  const colormapPath = path.join(process.cwd(), 'public/colormap-2bit.png')
-  await ensureColormapExists(colormapPath, logger)
-
+function runMagick(cmd: string, logger: Logger): Promise<void> {
+  logger.log(`Running ImageMagick: ${cmd}`)
   return new Promise<void>((resolve, reject) => {
-    const cmd = `magick "${format}:${inputPath}" -resize ${width}x${height} -gravity Center -extent ${width}x${height} -dither FloydSteinberg -remap "${colormapPath}" -define png:bit-depth=2 -define png:color-type=0 -strip png:"${outputPath}"`
-    logger.log(`Running ImageMagick: ${cmd}`)
     exec(cmd, (error, stdout, stderr) => {
       if (error) {
         logger.error(`ImageMagick error: ${stderr}`)
@@ -89,4 +76,63 @@ export async function convertToPng(inputPath: string, outputPath: string, width:
       }
     })
   })
+}
+
+async function ensureColormap(paletteId: string, colors: string[], logger: Logger): Promise<string> {
+  const colormapPath = resolveAppPath('public', 'colormaps', `${paletteId}.png`)
+  if (fs.existsSync(colormapPath))
+    return colormapPath
+  logger.log(`Creating colormap for palette ${paletteId} at ${colormapPath}`)
+  await fs.promises.mkdir(path.dirname(colormapPath), { recursive: true })
+  const swatches = colors.map(color => `xc:"${color}"`).join(' ')
+  await runMagick(`magick -size 1x1 ${swatches} +append -type Palette "${colormapPath}"`, logger)
+  return colormapPath
+}
+
+async function paletteOperators(palette: Palette, logger: Logger): Promise<string> {
+  const conversion = paletteConversion(palette)
+  switch (conversion.kind) {
+    case 'gray': {
+      const colormap = await ensureColormap(palette.id, grayLevelsHex(conversion.levels), logger)
+      return `-colorspace Gray -dither FloydSteinberg -remap "${colormap}" -define png:bit-depth=${conversion.bitDepth} -define png:color-type=0`
+    }
+    case 'color': {
+      const colormap = await ensureColormap(palette.id, conversion.colors, logger)
+      return `-dither FloydSteinberg -remap "${colormap}" -define png:color-type=3`
+    }
+    case 'full-color':
+      return '-colorspace sRGB -define png:color-type=2'
+  }
+}
+
+/**
+ * Geometry for a render target: fit into the model's canvas (letterboxed on
+ * white), rotate to the panel's orientation, then trim the model's offsets
+ * from the top-left edge.
+ */
+function geometryOperators({ model }: DeviceRenderTarget): string {
+  const size = `${model.width}x${model.height}`
+  const ops = [`-resize ${size}`, '-gravity Center', `-extent ${size}`]
+  if (model.rotation !== 0)
+    ops.push(`-rotate ${model.rotation}`)
+  if (model.offsetX !== 0 || model.offsetY !== 0)
+    ops.push(`-crop +${model.offsetX}+${model.offsetY} +repage`)
+  return ops.join(' ')
+}
+
+/** Converts any supported raster image into the PNG a device with the given render target expects. */
+export async function convertToPng(inputPath: string, outputPath: string, target: DeviceRenderTarget, logger: Logger) {
+  const header = buffer.Buffer.allocUnsafe(8)
+  const fd = await fs.promises.open(inputPath, 'r')
+  try {
+    await fd.read(header, 0, 8, 0)
+  }
+  finally {
+    await fd.close()
+  }
+  const format = detectImageFormat(header)
+  const palette = await paletteOperators(target.palette, logger)
+
+  const cmd = `magick "${format}:${inputPath}" -background white -alpha remove -alpha off ${geometryOperators(target)} ${palette} -strip png:"${outputPath}"`
+  await runMagick(cmd, logger)
 }


### PR DESCRIPTION
## Summary

Third of three stacked PRs for multi-size TRMNL support. Stacked on #739 and #740 (both merged) — now based on `main`.

### Conversion (`utils/imageUtils.ts`)
`convertToPng(input, output, target, logger)` now takes the device's render target and runs one ImageMagick pipeline:

`-background white -alpha remove -alpha off` → `-resize WxH -gravity Center -extent WxH` (letterbox, unchanged) → `-rotate <model.rotation>` → `-crop +offsetX+offsetY +repage` → palette ops → `-strip png:`

Palette ops from `paletteConversion(palette)`:
- gray palettes (`bw`, `gray-4`, `gray-16`, `gray-256`) → `-colorspace Gray -dither FloydSteinberg -remap <colormap>` with `png:bit-depth = log2(grays)` and `color-type=0` (OG stays 2-bit/4-gray as today; X gets true 4-bit/16 grays)
- colour palettes (`color-3bwr`, `color-4bwry`, `color-6a`, `color-7a`) → remap to the palette's colour list, indexed PNG (`color-type=3`) — what the firmware's `png_draw_6clr/4clr` decode
- full-colour palettes → sRGB truecolor, no remap

Colormaps are generated on demand per palette under `public/colormaps/<palette>.png` (replaces the single hardcoded 2-bit map).

Note on rotation: terminus rotates and then stretches back to the pre-rotation size (its own spec asserts 800×480 after a 90° rotate), which can't be intended; here 90° yields a height×width image, which is also what the firmware's `png_to_epd` auto-detects as portrait. Offsets trim from the top-left edge, matching terminus's observable result.

### Source retention & re-conversion
- Uploads and cached external images keep their original as `<screenId>.original` (uploads used to delete the source; external fetches went through `tmp-source`). Deleting a screen removes it; the maintenance scan treats `.original` like the screen PNG (orphaned when its screen is gone).
- `ScreensService.reconvertImageScreens(device)` re-generates every upload / cached-external image from the original (or the old PNG for legacy screens) and bumps `generatedAt` so devices refetch. `DevicesService.update` triggers it when the model or palette actually changed.

### Fallback screens
`FallbackScreensService.urlFor(kind, target)` converts `noScreen`/`error`/`welcome` per model+palette on first use into `public/screens/fallback/<model>-<palette>/`, regenerating if the source PNG is newer; falls back to the static file if ImageMagick fails. Used by `/display`, `/current_screen` and `/setup`.

## Test plan
- [x] lint, API 404 / UI 82 tests, build, migrations typecheck
- [ ] TRMNL X with `gray-16`: uploaded photo shows 16 grays, is 1872×1404; switch the device to `bw` and confirm the image is re-dithered from the original
- [ ] OG unchanged visually (2-bit, `colormaps/gray-4.png` = old `colormap-2bit.png` values)
- [ ] `/setup` on an X returns a 1872×1404 welcome image; a device with no screens gets a full-size noScreen
- [ ] Colour panel (reTerminal E1002 / OG 4CLR) if available: indexed PNG renders in colour