### PR TITLE
fix(ui): give RenderTargetPicker a real modelValue prop

### DIFF
--- a/packages/ui/src/components/RenderTargetPicker.vue
+++ b/packages/ui/src/components/RenderTargetPicker.vue
@@ -3,14 +3,14 @@ import type { RenderTarget } from '@/utils/screenShell'
 import { computed, onMounted, ref, watch } from 'vue'
 import { VCol, VRow, VSelect } from 'vuetify/components'
 import { useDeviceModelsStore } from '@/stores/deviceModels'
-import { DEFAULT_MODEL, DEFAULT_MODEL_NAME, DEFAULT_PALETTE, richestPalette } from '@/utils/renderTarget'
+import { DEFAULT_MODEL, renderTargetFor } from '@/utils/renderTarget'
 
-const emit = defineEmits<{ 'update:modelValue': [target: RenderTarget] }>()
+const target = defineModel<RenderTarget>({ required: true })
 
 const deviceModelsStore = useDeviceModelsStore()
 
-const selectedModelName = ref(DEFAULT_MODEL_NAME)
-const selectedPaletteId = ref<string | null>(null)
+const selectedModelName = ref(target.value.model.name)
+const selectedPaletteId = ref<string | null>(target.value.palette.id)
 
 onMounted(() => deviceModelsStore.ensureLoaded())
 
@@ -22,18 +22,16 @@ const modelOptions = computed(() => deviceModelsStore.activeModels.map(model => 
 const selectedModel = computed(() => deviceModelsStore.getByName(selectedModelName.value) ?? DEFAULT_MODEL)
 const allowedPalettes = computed(() => deviceModelsStore.palettesFor(selectedModel.value))
 const paletteOptions = computed(() => allowedPalettes.value.map(palette => ({ title: palette.name, value: palette.id })))
-
-const target = computed<RenderTarget>(() => ({
-  model: selectedModel.value,
-  palette: allowedPalettes.value.find(p => p.id === selectedPaletteId.value) ?? richestPalette(allowedPalettes.value) ?? DEFAULT_PALETTE,
-}))
+const selectedPalette = computed(() => allowedPalettes.value.find(p => p.id === selectedPaletteId.value) ?? null)
 
 watch(selectedModel, (model) => {
   if (selectedPaletteId.value && !model.paletteIds.includes(selectedPaletteId.value))
     selectedPaletteId.value = null
 })
 
-watch(target, value => emit('update:modelValue', value), { immediate: true })
+watch([selectedModel, selectedPalette], ([model, palette]) => {
+  target.value = renderTargetFor({ deviceModel: model, palette }, deviceModelsStore)
+}, { immediate: true })
 </script>
 
 <template>

--- a/packages/ui/src/components/__test__/RenderTargetPicker.spec.ts
+++ b/packages/ui/src/components/__test__/RenderTargetPicker.spec.ts
@@ -2,6 +2,7 @@ import { mount } from '@vue/test-utils'
 import { createPinia } from 'pinia'
 import rop from 'resize-observer-polyfill'
 import { describe, expect, it, vi } from 'vitest'
+import { defineComponent, ref } from 'vue'
 import vuetify from '../../plugins/vuetify'
 import RenderTargetPicker from '../RenderTargetPicker.vue'
 
@@ -22,15 +23,22 @@ vi.mock('@/stores/deviceModels', () => ({
 
 globalThis.ResizeObserver = rop
 
+function mountPicker(modelValue: any) {
+  return mount(RenderTargetPicker, {
+    props: { modelValue },
+    global: { plugins: [createPinia(), vuetify] },
+  })
+}
+
 describe('renderTargetPicker', () => {
   it('emits the OG model with its richest palette by default', () => {
-    const wrapper = mount(RenderTargetPicker, { global: { plugins: [createPinia(), vuetify] } })
+    const wrapper = mountPicker({ model: OG, palette: GRAY_4 })
     const emitted = wrapper.emitted('update:modelValue')!
     expect(emitted[0][0]).toEqual({ model: OG, palette: GRAY_4 })
   })
 
   it('re-emits with the new model and drops a palette it does not support', async () => {
-    const wrapper = mount(RenderTargetPicker, { global: { plugins: [createPinia(), vuetify] } })
+    const wrapper = mountPicker({ model: OG, palette: GRAY_4 })
     const vm = wrapper.vm as any
     vm.selectedPaletteId = 'gray-4'
     await wrapper.vm.$nextTick()
@@ -40,5 +48,53 @@ describe('renderTargetPicker', () => {
     const emitted = wrapper.emitted('update:modelValue')!
     expect(emitted.at(-1)![0]).toEqual({ model: V2, palette: GRAY_16 })
     expect(vm.selectedPaletteId).toBeNull()
+  })
+
+  it('does not leak a modelvalue attribute onto the root element', () => {
+    const wrapper = mountPicker({ model: OG, palette: GRAY_4 })
+    expect(wrapper.attributes('modelvalue')).toBeUndefined()
+    expect(wrapper.html()).not.toContain('modelvalue')
+  })
+
+  it('seeds its selection from an incoming modelValue, shown in the selects', () => {
+    const wrapper = mountPicker({ model: V2, palette: GRAY_16 })
+    const vm = wrapper.vm as any
+    expect(vm.selectedModelName).toBe('v2')
+    expect(vm.selectedPaletteId).toBe('gray-16')
+    expect(wrapper.get('[data-test-id="render-target-model"]').text()).toContain('TRMNL X')
+    expect(wrapper.get('[data-test-id="render-target-palette"]').text()).toContain('g16')
+  })
+
+  it('keeps the parent-held target after being toggled out and back with v-if', async () => {
+    const Host = defineComponent({
+      components: { RenderTargetPicker },
+      setup() {
+        const target = ref({ model: OG, palette: GRAY_4 })
+        const shown = ref(true)
+        return { target, shown }
+      },
+      template: `
+        <RenderTargetPicker v-if="shown" v-model="target" />
+      `,
+    })
+
+    const wrapper = mount(Host, { global: { plugins: [createPinia(), vuetify] } })
+    const picker = () => wrapper.findComponent(RenderTargetPicker).vm as any
+    picker().selectedModelName = 'v2'
+    await wrapper.vm.$nextTick()
+    await wrapper.vm.$nextTick()
+    const targetAfterEdit = (wrapper.vm as any).target
+    expect(targetAfterEdit).toEqual({ model: V2, palette: GRAY_16 })
+
+    ;(wrapper.vm as any).shown = false
+    await wrapper.vm.$nextTick()
+    expect(wrapper.findComponent(RenderTargetPicker).exists()).toBe(false)
+
+    ;(wrapper.vm as any).shown = true
+    await wrapper.vm.$nextTick()
+
+    expect((wrapper.vm as any).target).toEqual(targetAfterEdit)
+    expect(picker().selectedModelName).toBe('v2')
+    expect(picker().selectedPaletteId).toBe('gray-16')
   })
 })


### PR DESCRIPTION
## Summary
- `RenderTargetPicker.vue` was used with `v-model` in `HtmlPreviewView`, `PluginCreateView`, and `PluginEditView`, but only declared the `update:modelValue` emit — no `modelValue` prop. The incoming value fell through to `$attrs` as a stray `modelvalue="[object Object]"` DOM attribute, the picker was write-only (parents couldn't seed it), and a `v-if` toggle reset it back to the default target instead of preserving the parent's held value.
- Switches to Vue 3.5's `defineModel<RenderTarget>({ required: true })`, seeding the local `selectedModelName`/`selectedPaletteId` from the incoming value.
- Reuses `renderTargetFor()` from `utils/renderTarget.ts` for the "explicit selection, else richest palette, else default" precedence instead of re-implementing it inline.

Fixes #750

## Test plan
- [x] `RenderTargetPicker.spec.ts`: no `modelvalue` DOM attribute leak
- [x] `RenderTargetPicker.spec.ts`: mounting with a `v2`/`gray-16` modelValue seeds selection (asserted both in internal state and rendered `VSelect` text)
- [x] `RenderTargetPicker.spec.ts`: toggling with a real `v-if` in a host component preserves the parent's target across unmount/remount
- [x] Full UI test suite (86 tests) passes
- [x] `vue-tsc --noEmit` and `eslint` pass

https://claude.ai/code/session_01EJi8JqVCUMrVyQdGdibAwy