### PR TITLE
fix(device-models): stop deriving screen orientation class from model.rotation

### DIFF
--- a/packages/api/src/device-models/__test__/screen-shell.spec.ts
+++ b/packages/api/src/device-models/__test__/screen-shell.spec.ts
@@ -3,17 +3,22 @@ import { screenClasses, screenStyle, viewFull, wrapInScreenShell } from '../scre
 import { BW, GRAY_4, GRAY_16, OG_PLUS, V2 } from './mockDeviceModelsService'
 
 describe('screen shell', () => {
-  it('builds the screen class list from model, palette and orientation', () => {
+  it('builds the screen class list from model and palette', () => {
     expect(screenClasses({ model: V2, palette: GRAY_16 })).toEqual([
       'screen',
       'screen--v2',
       'screen--lg',
       'screen--density-2x',
       'screen--4bit',
-      'screen--landscape',
     ])
     expect(screenClasses({ model: OG_PLUS, palette: BW })).toContain('screen--1bit')
-    expect(screenClasses({ model: { ...OG_PLUS, rotation: 90 }, palette: GRAY_4 })).toContain('screen--portrait')
+  })
+
+  it('emits no orientation class regardless of model.rotation', () => {
+    expect(screenClasses({ model: { ...OG_PLUS, rotation: 90 }, palette: GRAY_4 })).not.toContain('screen--portrait')
+    expect(screenClasses({ model: { ...OG_PLUS, rotation: 90 }, palette: GRAY_4 })).not.toContain('screen--landscape')
+    expect(screenClasses({ model: V2, palette: GRAY_16 })).not.toContain('screen--portrait')
+    expect(screenClasses({ model: V2, palette: GRAY_16 })).not.toContain('screen--landscape')
   })
 
   it('serialises the model CSS variables as an inline style', () => {
@@ -30,11 +35,11 @@ describe('screen shell', () => {
     expect(html).toContain('<link rel="stylesheet" href="https://usetrmnl.com/css/latest/plugins.css">')
     expect(html).toContain('<script src="https://usetrmnl.com/js/latest/plugins.js"></script>')
     expect(html).toContain('<body class="environment trmnl">')
-    expect(html).toContain('<div class="screen screen--v2 screen--lg screen--density-2x screen--4bit screen--landscape" style="--screen-w: 1040px; --screen-h: 780px;"><div class="view view--full">hi</div></div>')
+    expect(html).toContain('<div class="screen screen--v2 screen--lg screen--density-2x screen--4bit" style="--screen-w: 1040px; --screen-h: 780px;"><div class="view view--full">hi</div></div>')
   })
 
   it('omits the style attribute when the model has no CSS variables', () => {
     const html = wrapInScreenShell({ model: { ...OG_PLUS, cssVariables: {} }, palette: GRAY_4 }, 'x')
-    expect(html).toContain('<div class="screen screen--og_plus screen--md screen--density-1x screen--2bit screen--landscape">x</div>')
+    expect(html).toContain('<div class="screen screen--og_plus screen--md screen--density-1x screen--2bit">x</div>')
   })
 })

--- a/packages/api/src/device-models/screen-shell.ts
+++ b/packages/api/src/device-models/screen-shell.ts
@@ -5,13 +5,22 @@ export const TRMNL_FRAMEWORK_JS = 'https://usetrmnl.com/js/latest/plugins.js'
 
 /**
  * Class list for the `.screen` element the TRMNL framework sizes and scales:
- * the model's own classes (device, size tier, density), the palette's bit-depth
- * class and the orientation.
+ * the model's own classes (device, size tier, density) and the palette's
+ * bit-depth class. No orientation modifier is emitted here — plugins.css's
+ * `screen--portrait` swaps the device's own w/h variables and is unrelated to
+ * `model.rotation`, which is the post-render image rotation for panels whose
+ * framebuffer is portrait (landscape-classed models can have `rotation: 90`).
  */
 export function screenClasses({ model, palette }: DeviceRenderTarget): string[] {
-  return ['screen', ...model.cssClasses, palette.frameworkClass, model.rotation === 0 ? 'screen--landscape' : 'screen--portrait']
+  return ['screen', ...model.cssClasses, palette.frameworkClass]
 }
 
+/**
+ * Inline fallback for models' CSS variables. Kept as an inline `style` (not
+ * just the model's CSS class) so sizing still works for models missing from
+ * the loaded plugins.css version — but this also means it overrides any
+ * `screen--portrait` swap, since inline styles beat class-based rules.
+ */
 export function screenStyle({ model }: DeviceRenderTarget): string {
   return Object.entries(model.cssVariables).map(([name, value]) => `${name}: ${value};`).join(' ')
 }

--- a/packages/api/src/devices/__test__/display.service.spec.ts
+++ b/packages/api/src/devices/__test__/display.service.spec.ts
@@ -165,7 +165,7 @@ describe('deviceDisplayService', () => {
 
       expect(puppeteerPage.setViewport).toHaveBeenCalledWith({ width: 1872, height: 1404 })
       const html: string = puppeteerPage.setContent.mock.calls[0][0]
-      expect(html).toContain('class="screen screen--v2 screen--lg screen--density-2x screen--4bit screen--landscape"')
+      expect(html).toContain('class="screen screen--v2 screen--lg screen--density-2x screen--4bit"')
       expect(html).toContain('--screen-w: 1040px;')
       expect(html).toContain('<div class="view view--full"><p>hi</p></div>')
       const { convertToPng } = await import('../../utils/imageUtils')
@@ -208,7 +208,7 @@ describe('deviceDisplayService', () => {
       await service.getCurrentImage(headers as any)
 
       const html: string = puppeteerPage.setContent.mock.calls[0][0]
-      expect(html).toMatch(/screen--landscape"[^>]*><div class="mashup mashup--1Lx1R">m<\/div><\/div>/)
+      expect(html).toMatch(/screen--2bit"[^>]*><div class="mashup mashup--1Lx1R">m<\/div><\/div>/)
       expect(html).not.toContain('view--full')
     })
   })

--- a/packages/ui/src/components/__test__/ScreenFrame.spec.ts
+++ b/packages/ui/src/components/__test__/ScreenFrame.spec.ts
@@ -13,7 +13,7 @@ describe('screenFrame', () => {
     const iframe = wrapper.find('iframe')
     expect(iframe.attributes('width')).toBe('1872')
     expect(iframe.attributes('height')).toBe('1404')
-    expect(iframe.attributes('srcdoc')).toContain('class="screen screen--v2 screen--2bit screen--landscape"')
+    expect(iframe.attributes('srcdoc')).toContain('class="screen screen--v2 screen--2bit"')
     expect(iframe.attributes('srcdoc')).toContain('<div class="view view--full">hi</div>')
     expect(iframe.attributes('style')).toContain('transform: scale(1)')
   })

--- a/packages/ui/src/utils/__test__/screenShell.spec.ts
+++ b/packages/ui/src/utils/__test__/screenShell.spec.ts
@@ -24,8 +24,12 @@ const GRAY_16: Palette = { id: 'gray-16', name: '16 Grays (4-bit)', grays: 16, f
 
 describe('screenShell', () => {
   it('builds the same class list as the API', () => {
-    expect(screenClasses({ model: V2, palette: GRAY_16 })).toEqual(['screen', 'screen--v2', 'screen--lg', 'screen--density-2x', 'screen--4bit', 'screen--landscape'])
-    expect(screenClasses({ model: { ...V2, rotation: 90 }, palette: GRAY_16 })).toContain('screen--portrait')
+    expect(screenClasses({ model: V2, palette: GRAY_16 })).toEqual(['screen', 'screen--v2', 'screen--lg', 'screen--density-2x', 'screen--4bit'])
+  })
+
+  it('emits no orientation class regardless of model.rotation', () => {
+    expect(screenClasses({ model: { ...V2, rotation: 90 }, palette: GRAY_16 })).not.toContain('screen--portrait')
+    expect(screenClasses({ model: { ...V2, rotation: 90 }, palette: GRAY_16 })).not.toContain('screen--landscape')
   })
 
   it('serialises css variables', () => {
@@ -36,6 +40,6 @@ describe('screenShell', () => {
     const html = wrapInScreenShell({ model: V2, palette: GRAY_16 }, viewFull('<p>x</p>'))
     expect(html).toContain('href="https://usetrmnl.com/css/latest/plugins.css"')
     expect(html).toContain('<body class="environment trmnl">')
-    expect(html).toContain('<div class="screen screen--v2 screen--lg screen--density-2x screen--4bit screen--landscape" style="--screen-w: 1040px; --screen-h: 780px;"><div class="view view--full"><p>x</p></div></div>')
+    expect(html).toContain('<div class="screen screen--v2 screen--lg screen--density-2x screen--4bit" style="--screen-w: 1040px; --screen-h: 780px;"><div class="view view--full"><p>x</p></div></div>')
   })
 })

--- a/packages/ui/src/utils/screenShell.ts
+++ b/packages/ui/src/utils/screenShell.ts
@@ -8,9 +8,13 @@ export interface RenderTarget {
 export const TRMNL_FRAMEWORK_CSS = 'https://usetrmnl.com/css/latest/plugins.css'
 export const TRMNL_FRAMEWORK_JS = 'https://usetrmnl.com/js/latest/plugins.js'
 
-/** Mirrors the API's `screen-shell.ts` so previews match what the device receives. */
+/**
+ * Mirrors the API's `screen-shell.ts` so previews match what the device
+ * receives. No orientation class here — see the API copy for why
+ * `model.rotation` doesn't map to `screen--portrait`/`screen--landscape`.
+ */
 export function screenClasses({ model, palette }: RenderTarget): string[] {
-  return ['screen', ...model.cssClasses, palette.frameworkClass, model.rotation === 0 ? 'screen--landscape' : 'screen--portrait']
+  return ['screen', ...model.cssClasses, palette.frameworkClass]
 }
 
 export function screenStyle({ model }: RenderTarget): string {


### PR DESCRIPTION
## Summary
- `model.rotation` is the post-render image rotation for panels with a portrait framebuffer, not the plugins.css orientation modifier — `screen--portrait` swaps a device's own w/h vars, and landscape is the implicit default with no matching class.
- Emitting `screen--landscape`/`screen--portrait` from `rotation` flipped `portrait:`/`landscape:` responsive utility variants for models like `amazon_kindle_2024` (rotation 90, landscape vars).

Fixes #745

## Test plan
- [x] `packages/api/src/device-models/__test__/screen-shell.spec.ts` and `packages/api/src/devices/__test__/display.service.spec.ts` (34 tests) pass, re-verified after rebasing onto latest `origin/main`

https://claude.ai/code/session_01EJi8JqVCUMrVyQdGdibAwy