### PR TITLE
fix(ui): dedupe deviceModels fetches and surface HTTP errors

### DIFF
--- a/packages/ui/src/stores/__test__/deviceModels.spec.ts
+++ b/packages/ui/src/stores/__test__/deviceModels.spec.ts
@@ -8,7 +8,7 @@ const BW = { id: 'bw', name: 'Black & White (1-bit)', grays: 2 }
 const GRAY_4 = { id: 'gray-4', name: '4 Grays (2-bit)', grays: 4 }
 
 function jsonResponse(body: unknown, ok = true) {
-  return { ok, statusText: ok ? 'OK' : 'Service Unavailable', json: async () => body }
+  return { ok, status: ok ? 200 : 503, statusText: ok ? 'OK' : 'Service Unavailable', json: async () => body }
 }
 
 describe('deviceModels store', () => {
@@ -28,12 +28,41 @@ describe('deviceModels store', () => {
     expect(store.loaded).toBe(true)
   })
 
-  it('ensureLoaded fetches once', async () => {
+  it('ensureLoaded only fetches on the first call once loaded', async () => {
     ;(globalThis.fetch as any).mockResolvedValue(jsonResponse([]))
     const store = useDeviceModelsStore()
     await store.ensureLoaded()
     await store.ensureLoaded()
     expect(globalThis.fetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('ensureLoaded dedupes concurrent calls into a single fetchAll', async () => {
+    ;(globalThis.fetch as any).mockResolvedValue(jsonResponse([]))
+    const store = useDeviceModelsStore()
+    await Promise.all([store.ensureLoaded(), store.ensureLoaded(), store.ensureLoaded()])
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('fetchAll records the status and statusText when a response is not ok', async () => {
+    ;(globalThis.fetch as any).mockImplementation(async (url: string) =>
+      url.endsWith('/palettes') ? jsonResponse([BW, GRAY_4]) : jsonResponse(null, false))
+    const store = useDeviceModelsStore()
+    await store.fetchAll()
+    expect(store.loaded).toBe(false)
+    expect(store.error).toBe('503 Service Unavailable')
+  })
+
+  it('fetchAll clears a previous error on a later successful load', async () => {
+    const store = useDeviceModelsStore()
+    ;(globalThis.fetch as any).mockResolvedValue(jsonResponse(null, false))
+    await store.fetchAll()
+    expect(store.error).not.toBeNull()
+
+    ;(globalThis.fetch as any).mockImplementation(async (url: string) =>
+      url.endsWith('/palettes') ? jsonResponse([BW]) : jsonResponse([OG_PLUS]))
+    await store.fetchAll()
+    expect(store.error).toBeNull()
+    expect(store.loaded).toBe(true)
   })
 
   it('palettesFor returns the palettes a model allows, in the model order', async () => {

--- a/packages/ui/src/stores/deviceModels.ts
+++ b/packages/ui/src/stores/deviceModels.ts
@@ -11,14 +11,19 @@ export const useDeviceModelsStore = defineStore('deviceModels', () => {
 
   const activeModels = computed(() => models.value.filter(model => !model.deprecated))
 
+  let inFlight: Promise<void> | null = null
+
   async function fetchAll() {
     try {
       const [modelsRes, palettesRes] = await Promise.all([fetch('/api/device-models'), fetch('/api/device-models/palettes')])
-      if (modelsRes.ok)
-        models.value = await modelsRes.json()
-      if (palettesRes.ok)
-        palettes.value = await palettesRes.json()
-      loaded.value = modelsRes.ok && palettesRes.ok
+      if (!modelsRes.ok)
+        throw new Error(`${modelsRes.status} ${modelsRes.statusText}`)
+      if (!palettesRes.ok)
+        throw new Error(`${palettesRes.status} ${palettesRes.statusText}`)
+      models.value = await modelsRes.json()
+      palettes.value = await palettesRes.json()
+      loaded.value = true
+      error.value = null
     }
     catch (err) {
       error.value = err instanceof Error ? err.message : 'Failed to load device models'
@@ -26,9 +31,13 @@ export const useDeviceModelsStore = defineStore('deviceModels', () => {
     }
   }
 
-  async function ensureLoaded() {
-    if (!loaded.value)
-      await fetchAll()
+  function ensureLoaded() {
+    if (loaded.value)
+      return Promise.resolve()
+    inFlight ??= fetchAll().finally(() => {
+      inFlight = null
+    })
+    return inFlight
   }
 
   function getByName(name: string | null | undefined) {

--- a/packages/ui/src/views/MaintenanceView.vue
+++ b/packages/ui/src/views/MaintenanceView.vue
@@ -17,6 +17,10 @@ const lastModelSync = computed(() => {
   return dates.at(-1) ?? null
 })
 
+// A successful sync always wins over a stale/unrelated store error (e.g. a refresh
+// hiccup after the sync itself succeeded), so it never gets masked by an old alert.
+const modelError = computed(() => (syncResult.value ? null : deviceModelsStore.error))
+
 async function handleModelSync() {
   syncResult.value = await deviceModelsStore.sync()
 }
@@ -224,8 +228,8 @@ async function executeCleanup() {
               </span>
               · Last synced: {{ lastModelSync ? formatDate(lastModelSync) : 'never (bundled snapshot)' }}
             </div>
-            <VAlert v-if="deviceModelsStore.error" type="error" variant="tonal" class="mt-3" :icon="mdiAlertCircle">
-              {{ deviceModelsStore.error }}
+            <VAlert v-if="modelError" type="error" variant="tonal" class="mt-3" :icon="mdiAlertCircle">
+              {{ modelError }}
             </VAlert>
             <VAlert v-else-if="syncResult" type="success" variant="tonal" class="mt-3" :icon="mdiCheckCircle" closable @click:close="syncResult = null">
               Synced {{ syncResult.models }} models and {{ syncResult.palettes }} palettes


### PR DESCRIPTION
## Summary
- `ensureLoaded()` now memoises the in-flight `fetchAll()` promise, so concurrent callers on the device details page (`DeviceInformationCard`, `AddScreenCard`, `ScreenListCard`) share one models + one palettes request instead of racing three.
- `fetchAll()` now throws on non-2xx responses (`${status} ${statusText}`) so failures surface in `error` instead of leaving empty arrays with no explanation, and clears a stale `error` on the next successful load.
- `MaintenanceView`'s alert now derives from a `modelError` computed: a successful sync always wins over a stale/unrelated store error (so it can't mask a successful sync whose background refresh hiccuped), while a genuine initial-load failure (from `onMounted`) still surfaces.
- Renamed the misleading `ensureLoaded fetches once` test and added coverage for concurrent dedup and the non-ok error path.

Fixes #753.

## Test plan
- [x] `pnpm run lint` (packages/ui)
- [x] `pnpm run type-check` (packages/ui)
- [x] `pnpm run test` (packages/ui) — 89 passed
- [x] `pnpm run -r test` (full repo) — 405 API + 89 UI passed

https://claude.ai/code/session_01EJi8JqVCUMrVyQdGdibAwy