### PR TITLE
fix(device-models): time out TRMNL sync fetches and coalesce concurrent runs

### DIFF
--- a/packages/api/src/device-models/__test__/device-model-sync.service.spec.ts
+++ b/packages/api/src/device-models/__test__/device-model-sync.service.spec.ts
@@ -80,8 +80,8 @@ describe('deviceModelSyncService', () => {
 
       const result = await service.sync()
 
-      expect(mockFetch).toHaveBeenCalledWith('https://usetrmnl.com/api/palettes')
-      expect(mockFetch).toHaveBeenCalledWith('https://usetrmnl.com/api/models')
+      expect(mockFetch).toHaveBeenCalledWith('https://usetrmnl.com/api/palettes', { signal: expect.any(AbortSignal) })
+      expect(mockFetch).toHaveBeenCalledWith('https://usetrmnl.com/api/models', { signal: expect.any(AbortSignal) })
       expect(paletteRepo.upsert).toHaveBeenCalledWith(
         [expect.objectContaining({ id: 'bw', deprecated: false }), expect.objectContaining({ id: 'gray-4', deprecated: false })],
         ['id'],
@@ -124,6 +124,28 @@ describe('deviceModelSyncService', () => {
     it('throws when the response has no data array', async () => {
       mockFetch.mockResolvedValue({ ok: true, status: 200, statusText: 'OK', json: async () => ({ nope: [] }) })
       await expect(service.sync()).rejects.toThrow(/no data array/)
+    })
+
+    it('surfaces a clear error when a fetch times out', async () => {
+      mockFetch.mockImplementation(async () => {
+        throw new DOMException('The operation was aborted due to timeout', 'TimeoutError')
+      })
+      await expect(service.sync()).rejects.toThrow(/request timed out/)
+    })
+
+    it('coalesces concurrent sync() calls into a single run', async () => {
+      mockFetch.mockImplementation(async (url: string) =>
+        url.endsWith('/palettes') ? jsonResponse([paletteA]) : jsonResponse([modelA]))
+      paletteRepo.find.mockResolvedValue([])
+      modelRepo.find.mockResolvedValue([])
+
+      const [first, second] = await Promise.all([service.sync(), service.sync()])
+
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+      expect(first).toBe(second)
+
+      await service.sync()
+      expect(mockFetch).toHaveBeenCalledTimes(4)
     })
   })
 })

--- a/packages/api/src/device-models/device-model-sync.service.ts
+++ b/packages/api/src/device-models/device-model-sync.service.ts
@@ -17,10 +17,12 @@ export interface DeviceModelSyncResult {
 }
 
 const DAILY_AT_4AM = '0 4 * * *'
+const TRMNL_FETCH_TIMEOUT_MS = 15_000
 
 @Injectable()
 export class DeviceModelSyncService implements OnApplicationBootstrap {
   private readonly logger = new Logger(DeviceModelSyncService.name)
+  private syncing: Promise<DeviceModelSyncResult> | null = null
 
   constructor(
     @InjectRepository(DeviceModel)
@@ -61,8 +63,17 @@ export class DeviceModelSyncService implements OnApplicationBootstrap {
   /**
    * Upserts the live TRMNL model and palette lists. Rows that disappeared
    * upstream are flagged deprecated but kept, so no device loses its model.
+   * A scheduled run and a manual sync request share the same in-flight
+   * promise instead of racing on the same upsert.
    */
-  async sync(): Promise<DeviceModelSyncResult> {
+  sync(): Promise<DeviceModelSyncResult> {
+    this.syncing ??= this.runSync().finally(() => {
+      this.syncing = null
+    })
+    return this.syncing
+  }
+
+  private async runSync(): Promise<DeviceModelSyncResult> {
     this.logger.log('Syncing device models from TRMNL')
     const [palettes, models] = await Promise.all([
       this.fetchList<TrmnlPalettePayload>('palettes'),
@@ -81,7 +92,15 @@ export class DeviceModelSyncService implements OnApplicationBootstrap {
   }
 
   private async fetchList<T>(endpoint: string): Promise<T[]> {
-    const res = await fetch(`${TRMNL_API_URL}/${endpoint}`)
+    let res: Response
+    try {
+      res = await fetch(`${TRMNL_API_URL}/${endpoint}`, { signal: AbortSignal.timeout(TRMNL_FETCH_TIMEOUT_MS) })
+    }
+    catch (err) {
+      if (err instanceof Error && err.name === 'TimeoutError')
+        throw new Error(`TRMNL ${endpoint} request timed out`)
+      throw err
+    }
     if (!res.ok)
       throw new Error(`TRMNL ${endpoint} request failed: ${res.status} ${res.statusText}`)
     const body = await res.json()


### PR DESCRIPTION
## Summary
- `DeviceModelSyncService.fetchList()` had no timeout, so a hung upstream TRMNL connection left `POST /device-models/sync` pending indefinitely and could pile up cron runs.
- `fetch()` now passes `AbortSignal.timeout(15_000)`, mapping a timeout to a clear `TRMNL <endpoint> request timed out` error.
- `sync()` now memoizes its in-flight promise so a scheduled run and a manual sync request share one run instead of racing on the same upsert.

## Test plan
- [x] `pnpm vitest run src/device-models/__test__/device-model-sync.service.spec.ts` — added cases for the timeout error mapping and for concurrent `sync()` calls sharing one run (fetch called exactly twice, not four times).
- [x] `pnpm vitest run` (full `packages/api` suite) — 52 files / 407 passed.
- [x] `eslint` clean on changed files.

Closes #754

https://claude.ai/code/session_01EJi8JqVCUMrVyQdGdibAwy