### PR TITLE
fix(device-models): make dimension-based model fallback deterministic

### DIFF
--- a/packages/api/src/device-models/__test__/device-models.service.spec.ts
+++ b/packages/api/src/device-models/__test__/device-models.service.spec.ts
@@ -5,6 +5,9 @@ import { BW, GRAY_4, GRAY_16, OG_PLUS, V2 } from './mockDeviceModelsService'
 const SEEED_E1003 = { ...V2, name: 'seeed_e1003', label: 'reTerminal E1003', kind: 'byod' }
 const COLOR_6A = { ...BW, id: 'color-6a', name: 'Color (6 colors)', grays: 2, colors: ['#FF0000', '#00FF00', '#0000FF', '#FFFF00', '#000000', '#FFFFFF'], frameworkClass: 'screen--color-6a', grayscaleBitDepth: 1 }
 const SEEED_E1002 = { ...OG_PLUS, name: 'seeed_e1002', label: 'reTerminal E1002', kind: 'byod', paletteIds: ['color-6a', 'bw'] }
+const OG_BWRY = { ...OG_PLUS, name: 'og_bwry', label: 'TRMNL OG (colour)', kind: 'trmnl' }
+const OG_PNG = { ...OG_PLUS, name: 'og_png', label: 'TRMNL OG (1-bit)', kind: 'trmnl' }
+const ONYX_BOOX_NOVA_AIR_C = { ...V2, name: 'onxy_boox_nova_air_c', label: 'Onyx Boox Nova Air C', kind: 'byod' }
 
 function createMockRepo() {
   return {
@@ -18,7 +21,7 @@ describe('deviceModelsService', () => {
   let modelRepo: ReturnType<typeof createMockRepo>
   let paletteRepo: ReturnType<typeof createMockRepo>
 
-  const models = [OG_PLUS, V2, SEEED_E1003, SEEED_E1002]
+  const models = [OG_PLUS, V2, SEEED_E1003, SEEED_E1002, OG_BWRY, OG_PNG, ONYX_BOOX_NOVA_AIR_C]
   const palettes = [BW, GRAY_4, GRAY_16, COLOR_6A]
 
   beforeEach(() => {
@@ -44,12 +47,12 @@ describe('deviceModelsService', () => {
     })
 
     it('resolves nothing for an unknown name without dimensions', async () => {
-      await expect(service.resolve({ reportedModel: 'waveshare' })).resolves.toBeNull()
+      await expect(service.resolve({ reportedModel: 'unknown_board' })).resolves.toBeNull()
       await expect(service.resolve({})).resolves.toBeNull()
     })
 
     it('matches an unknown name on dimensions, preferring TRMNL hardware', async () => {
-      await expect(service.resolve({ reportedModel: 'lilygo', width: 1872, height: 1404 })).resolves.toBe(V2)
+      await expect(service.resolve({ reportedModel: 'unknown_x_class', width: 1872, height: 1404 })).resolves.toBe(V2)
     })
 
     it('matches on dimensions when no name is reported at all', async () => {
@@ -58,6 +61,16 @@ describe('deviceModelsService', () => {
 
     it('falls back to the OG model when nothing matches', async () => {
       await expect(service.resolve({ reportedModel: 'waveshare_397', width: 480, height: 800 })).resolves.toBe(OG_PLUS)
+    })
+
+    it('deterministically prefers the fallback model over other TRMNL hardware at the same dimensions, regardless of DB order', async () => {
+      modelRepo.find.mockResolvedValueOnce([OG_BWRY, OG_PNG, OG_PLUS])
+      await expect(service.resolve({ reportedModel: 'unknown_800x480_board', width: 800, height: 480 })).resolves.toBe(OG_PLUS)
+    })
+
+    it('deterministically prefers TRMNL hardware over BYOD at the same dimensions, regardless of DB order', async () => {
+      modelRepo.find.mockResolvedValueOnce([ONYX_BOOX_NOVA_AIR_C, V2])
+      await expect(service.resolve({ reportedModel: 'unknown_x_class', width: 1872, height: 1404 })).resolves.toBe(V2)
     })
   })
 
@@ -85,7 +98,7 @@ describe('deviceModelsService', () => {
     })
 
     it('leaves the device untouched when nothing resolves', async () => {
-      const device = { reportedModel: 'waveshare' } as any
+      const device = { reportedModel: 'unknown_board' } as any
       await expect(service.assignResolvedModel(device)).resolves.toBeNull()
       expect(device.deviceModel).toBeUndefined()
       expect(device.palette).toBeUndefined()

--- a/packages/api/src/device-models/device-models.service.ts
+++ b/packages/api/src/device-models/device-models.service.ts
@@ -134,8 +134,8 @@ export class DeviceModelsService {
   }
 
   private async resolveByDimensions(width: number, height: number): Promise<DeviceModel | null> {
-    const candidates = await this.deviceModelRepository.find({ where: { width, height, deprecated: false } })
-    return candidates.find(c => c.kind === 'trmnl') ?? candidates[0] ?? null
+    const candidates = await this.deviceModelRepository.find({ where: { width, height, deprecated: false }, order: { name: 'ASC' } })
+    return candidates.find(c => c.name === FALLBACK_MODEL_NAME) ?? candidates.find(c => c.kind === 'trmnl') ?? candidates[0] ?? null
   }
 
   private fallbackModelFromSnapshot(): DeviceModel {

--- a/packages/api/src/device-models/firmware-model-names.ts
+++ b/packages/api/src/device-models/firmware-model-names.ts
@@ -3,19 +3,29 @@
  * (`DEVICE_MODEL` in the firmware's config.h) to the model names used by
  * usetrmnl.com/api/models. Boards without a clear upstream counterpart are
  * left out on purpose and fall back to a dimension match.
+ *
+ * `trmnl_4clr` (the colour OG kit) also reports `Model: og`, same as the
+ * monochrome OG, so it resolves here to `og_plus` like every other `og`
+ * board and must be switched to `og_bwry` manually in the UI (Terminus has
+ * the same limitation).
  */
 export const FIRMWARE_MODEL_NAMES: Record<string, string> = {
-  og: 'og_plus',
-  og_gen2: 'og_plus',
-  x: 'v2',
-  paper_s3: 'm5_paper_s3',
-  reterminal_e1001: 'seeed_e1001',
-  reterminal_e1002: 'seeed_e1002',
-  reterminal_e1003: 'seeed_e1003',
-  seeed_esp32c3: 'seeed_e1001',
-  seeed_esp32s3: 'seeed_e1002',
-  xiao_epaper_display: 'og_plus',
-  xteink_x4: 'xteink_x4',
+  'og': 'og_plus',
+  'og_gen2': 'og_plus',
+  'x': 'v2',
+  'paper_s3': 'm5_paper_s3',
+  'reterminal_e1001': 'seeed_e1001',
+  'reterminal_e1002': 'seeed_e1002',
+  'reterminal_e1003': 'seeed_e1003',
+  'seeed_esp32c3': 'seeed_e1001',
+  'seeed_esp32s3': 'seeed_e1002',
+  'xiao_epaper_display': 'og_plus',
+  'xteink_x4': 'xteink_x4',
+  'sensoria_c5': 'v2',
+  'sensoria_s3': 'v2',
+  'lilygo': 'v2',
+  'waveshare': 'og_plus',
+  'gen-2': 'og_plus',
 }
 
 export const FALLBACK_MODEL_NAME = 'og_plus'


### PR DESCRIPTION
## Summary
- `DeviceModelsService.resolveByDimensions()` picked whichever `kind: 'trmnl'` candidate the DB query happened to return first, with no `order`. For 800x480 there are three TRMNL models (`og_png` 1-bit, `og_plus` 2-bit, `og_bwry` colour), so a generic/unknown board could be silently assigned `og_png` or `og_bwry` instead of the intended `og_plus` — and since model assignment is one-shot, the wrong pick sticks.
- `resolveByDimensions` now prefers, in order: `FALLBACK_MODEL_NAME` (`og_plus`) → any `kind: 'trmnl'` candidate → the first candidate in a stable `name ASC` order.
- Extended `FIRMWARE_MODEL_NAMES` with board names that have an obvious upstream counterpart: `sensoria_c5`/`sensoria_s3`/`lilygo` -> `v2` (TRMNL X-class), `waveshare`/`gen-2` -> `og_plus` (OG DIY kits).
- Documented the `trmnl_4clr` caveat (reports `Model: og`, must be switched to `og_bwry` manually) as a doc comment on `FIRMWARE_MODEL_NAMES` — there's no device-models-specific README to put it in.

## Test plan
- [x] Added specs asserting `og_plus` wins over `[og_bwry, og_png, og_plus]` and `v2` wins over `[onxy_boox_nova_air_c, v2]`, regardless of DB return order.
- [x] Updated existing specs that used `waveshare`/`lilygo` as "unknown name" examples, since those are now mapped in `FIRMWARE_MODEL_NAMES`.
- [x] `pnpm vitest run` (full `packages/api` suite) — 52 files / 409 passed.
- [x] `eslint` clean on changed files.

Closes #746

https://claude.ai/code/session_01EJi8JqVCUMrVyQdGdibAwy