### PR TITLE
fix(ui): cache-bust screen preview image URLs after reconversion

### DIFF
--- a/packages/ui/src/components/ScreenListCard.vue
+++ b/packages/ui/src/components/ScreenListCard.vue
@@ -7,6 +7,7 @@ import ScreenFrame from '@/components/ScreenFrame.vue'
 import { useDeviceRenderTarget } from '@/composeables/useDeviceRenderTarget'
 import { useDeviceStore } from '@/stores/device.ts'
 import { useScreensStore } from '@/stores/screens'
+import { cacheBustedUrl } from '@/utils/cacheBustedUrl'
 import { viewFull } from '@/utils/screenShell'
 
 const props = defineProps<{ deviceId: string }>()
@@ -327,7 +328,7 @@ function previewScreen(screen: Screen) {
           <!-- Image screens -->
           <div v-else>
             <img
-              :src="`/screens/devices/${device?.id}/${selectedPreviewScreen.id}.png?v=${encodeURIComponent(selectedPreviewScreen.generatedAt ?? '')}`"
+              :src="cacheBustedUrl(`/screens/devices/${device?.id}/${selectedPreviewScreen.id}.png`, selectedPreviewScreen.generatedAt)"
               style="max-width: 100%; height: auto; border: 1px solid #ccc;"
               alt="Screen preview"
               @error="($event.target as HTMLImageElement).src = '/screens/error.png'"

--- a/packages/ui/src/components/ScreenListCard.vue
+++ b/packages/ui/src/components/ScreenListCard.vue
@@ -327,7 +327,7 @@ function previewScreen(screen: Screen) {
           <!-- Image screens -->
           <div v-else>
             <img
-              :src="`/screens/devices/${device?.id}/${selectedPreviewScreen.id}.png`"
+              :src="`/screens/devices/${device?.id}/${selectedPreviewScreen.id}.png?v=${encodeURIComponent(selectedPreviewScreen.generatedAt ?? '')}`"
               style="max-width: 100%; height: auto; border: 1px solid #ccc;"
               alt="Screen preview"
               @error="($event.target as HTMLImageElement).src = '/screens/error.png'"

--- a/packages/ui/src/components/ScreenPreviewCard.vue
+++ b/packages/ui/src/components/ScreenPreviewCard.vue
@@ -20,6 +20,9 @@ onMounted(async () => {
   await screensStore.fetchCurrentScreenForDevice(device.value.mac, device.value.apikey)
 })
 const screen = computed(() => screensStore.currentScreen)
+const cacheBustedImageUrl = computed(() => screen.value?.rendered_at
+  ? `${screen.value.image_url}?v=${encodeURIComponent(screen.value.rendered_at)}`
+  : screen.value?.image_url)
 </script>
 
 <template>
@@ -29,7 +32,7 @@ const screen = computed(() => screensStore.currentScreen)
     <VCardText>
       <template v-if="screen">
         <VImg
-          :src="screen.image_url"
+          :src="cacheBustedImageUrl"
           :aspect-ratio="renderSize.width / renderSize.height"
           alt="Current device screen display"
           data-test-id="screen-image"

--- a/packages/ui/src/components/ScreenPreviewCard.vue
+++ b/packages/ui/src/components/ScreenPreviewCard.vue
@@ -3,6 +3,7 @@ import { computed, onMounted } from 'vue'
 import { VCard, VCardText, VCardTitle, VDivider, VImg } from 'vuetify/components'
 import { useDeviceStore } from '@/stores/device.ts'
 import { useScreensStore } from '@/stores/screens.ts'
+import { cacheBustedUrl } from '@/utils/cacheBustedUrl'
 import { deviceRenderSize } from '@/utils/deviceRenderSize'
 import { formatDate } from '@/utils/formatDate'
 
@@ -20,9 +21,7 @@ onMounted(async () => {
   await screensStore.fetchCurrentScreenForDevice(device.value.mac, device.value.apikey)
 })
 const screen = computed(() => screensStore.currentScreen)
-const cacheBustedImageUrl = computed(() => screen.value?.rendered_at
-  ? `${screen.value.image_url}?v=${encodeURIComponent(screen.value.rendered_at)}`
-  : screen.value?.image_url)
+const cacheBustedImageUrl = computed(() => screen.value ? cacheBustedUrl(screen.value.image_url, screen.value.rendered_at) : undefined)
 </script>
 
 <template>

--- a/packages/ui/src/components/__test__/ScreenListCard.spec.ts
+++ b/packages/ui/src/components/__test__/ScreenListCard.spec.ts
@@ -137,6 +137,34 @@ describe('screenListCard', () => {
     wrapper.unmount()
   })
 
+  it('cache-busts the image preview src with the screen generatedAt', async () => {
+    screensStoreMock.screens = [
+      { id: 'screen1', filename: 'file1', externalLink: null, isActive: true, device: 'device1', fetchManual: false, html: '', generatedAt: '2024-01-01T00:00:00Z' },
+    ]
+    const wrapper = mount(ScreenListCard, {
+      props: { deviceId: 'device1' },
+      global: {
+        plugins: [createPinia(), vuetify],
+      },
+      attachTo: document.body,
+    })
+
+    const previewBtn = wrapper.findAll('button').find(b => b.attributes('aria-label') === 'Preview screen')
+    expect(previewBtn).toBeDefined()
+    await previewBtn?.trigger('click')
+    await wrapper.vm.$nextTick()
+    await wrapper.vm.$nextTick()
+
+    expect((wrapper.vm as any).showScreenPreview).toBe(true)
+    expect((wrapper.vm as any).previewMode).toBe('image')
+
+    const img = document.body.querySelector('img[alt="Screen preview"]')
+    expect(img).not.toBeNull()
+    expect(img?.getAttribute('src')).toBe(`/screens/devices/device1/screen1.png?v=${encodeURIComponent('2024-01-01T00:00:00Z')}`)
+
+    wrapper.unmount()
+  })
+
   it('moving a screen down with the button calls reorderScreens with the swapped id order', async () => {
     screensStoreMock.screens = [
       { id: 'screen1', filename: 'file1', externalLink: null, isActive: true, device: 'device1', fetchManual: false, html: '' },

--- a/packages/ui/src/components/__test__/ScreenPreviewCard.spec.ts
+++ b/packages/ui/src/components/__test__/ScreenPreviewCard.spec.ts
@@ -59,7 +59,9 @@ describe('screenPreviewCard', () => {
     })
     expect(wrapper.exists()).toBe(true)
     expect(wrapper.find('[data-test-id="screen-image"]').exists()).toBe(true)
-    expect(wrapper.findComponent({ name: 'VImg' }).props('src')).toBe('http://example.com/image.png')
+    const src = wrapper.findComponent({ name: 'VImg' }).props('src') as string
+    expect(src).toContain('http://example.com/image.png')
+    expect(src).toContain(encodeURIComponent('2024-01-01T00:00:00Z'))
     expect(wrapper.find('[data-test-id="screen-rendered-date"]').exists()).toBe(true)
     expect(wrapper.find('[data-test-id="screen-rendered-date"]').text()).toContain('formatted: 2024-01-01T00:00:00Z')
   })

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -78,6 +78,7 @@ export interface Screen {
   cachedPluginOutput?: string | null
   mashupConfiguration?: { id: string, layout: string }
   order?: number
+  generatedAt?: string
 }
 
 export interface CurrentScreen {

--- a/packages/ui/src/utils/__test__/cacheBustedUrl.spec.ts
+++ b/packages/ui/src/utils/__test__/cacheBustedUrl.spec.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { cacheBustedUrl } from '../cacheBustedUrl'
+
+describe('cacheBustedUrl', () => {
+  it('appends the version as a query param', () => {
+    expect(cacheBustedUrl('http://example.com/image.png', '2024-01-01T00:00:00Z')).toBe(
+      `http://example.com/image.png?v=${encodeURIComponent('2024-01-01T00:00:00Z')}`,
+    )
+  })
+
+  it('returns the plain url when the version is missing', () => {
+    expect(cacheBustedUrl('http://example.com/image.png', undefined)).toBe('http://example.com/image.png')
+    expect(cacheBustedUrl('http://example.com/image.png', null)).toBe('http://example.com/image.png')
+  })
+})

--- a/packages/ui/src/utils/cacheBustedUrl.ts
+++ b/packages/ui/src/utils/cacheBustedUrl.ts
@@ -1,0 +1,3 @@
+export function cacheBustedUrl(url: string, version: string | null | undefined) {
+  return version ? `${url}?v=${encodeURIComponent(version)}` : url
+}


### PR DESCRIPTION
## Summary
- Model/palette changes rewrite a screen's PNG in place at the same URL (`DevicesService.update` -> `ScreensService.reconvertImageScreens`), so the `<img>`/`<VImg>` `src` stayed byte-identical after a save and the browser kept showing the stale bitmap until a hard reload.
- `ScreenPreviewCard.vue` now appends the current screen's `rendered_at` as a `?v=` query param; `ScreenListCard.vue`'s image preview does the same with the screen's `generatedAt` (added to the `Screen` type — the API entity already had it).
- Extracted the shared `?v=<version>` logic into `packages/ui/src/utils/cacheBustedUrl.ts` so both call sites use one fallback behavior instead of two slightly different ones.
- Verified `DeviceDetailsView.vue`'s existing `watch(device, …)` already refetches screens after `saveDevice()` resolves (via `updateDevice` -> `fetchDevices()` producing a new device reference) — no change needed there.
- No `mirror.png` screen preview exists in the UI, so that part of the issue is not applicable.

## Test plan
- [x] `pnpm vitest run` (`packages/ui`) — 20 files / 92 passed, including new/updated specs asserting the cache-busted `src` on `ScreenPreviewCard` and `ScreenListCard`, and a unit test for `cacheBustedUrl`.
- [x] `pnpm run -r test` (full monorepo) — `packages/api` 52 files/409 passed, `packages/ui` 20 files/92 passed.
- [x] `pnpm run type-check` and `pnpm lint` clean on changed files.

Closes #752