### PR TITLE
fix(screens): set Screen.type on create and backfill existing rows

### DIFF
--- a/packages/api/src/migrations/1787080000000-BackfillScreenType.ts
+++ b/packages/api/src/migrations/1787080000000-BackfillScreenType.ts
@@ -1,0 +1,35 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm'
+
+/**
+ * ScreensService.add() and PluginsService.assignToDevice() never set
+ * Screen.type, so every external/html/plugin screen created after the
+ * one-off backfill in AddMashupSupport was stored as the 'file' default.
+ * Re-applies that same backfill now that both call sites set type correctly.
+ */
+export class BackfillScreenType1787080000000 implements MigrationInterface {
+  name = 'BackfillScreenType1787080000000'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      UPDATE "screen"
+      SET "type" = 'plugin'
+      WHERE "pluginId" IS NOT NULL AND "type" != 'plugin'
+    `)
+
+    await queryRunner.query(`
+      UPDATE "screen"
+      SET "type" = 'html'
+      WHERE "html" IS NOT NULL AND "pluginId" IS NULL AND "type" != 'html'
+    `)
+
+    await queryRunner.query(`
+      UPDATE "screen"
+      SET "type" = 'external'
+      WHERE "externalLink" IS NOT NULL AND "html" IS NULL AND "pluginId" IS NULL AND "type" != 'external'
+    `)
+  }
+
+  public async down(): Promise<void> {
+    // Data-only migration; original 'file' values are not recoverable.
+  }
+}

--- a/packages/api/src/plugins/__test__/plugins.service.spec.ts
+++ b/packages/api/src/plugins/__test__/plugins.service.spec.ts
@@ -307,7 +307,7 @@ describe('pluginsService', () => {
 
     expect(devicePluginRepo.create).toHaveBeenCalled()
     expect(devicePluginRepo.save).toHaveBeenCalled()
-    expect(screenRepo.create).toHaveBeenCalled()
+    expect(screenRepo.create).toHaveBeenCalledWith(expect.objectContaining({ type: 'plugin' }))
     expect(screenRepo.save).toHaveBeenCalled()
     expect(result).toBe(devicePlugin)
   })

--- a/packages/api/src/plugins/plugins.service.ts
+++ b/packages/api/src/plugins/plugins.service.ts
@@ -105,6 +105,7 @@ export class PluginsService implements OnModuleInit {
     // Create a Screen entity for this plugin assignment
     const maxOrder = await this.screenRepository.maximum('order', { device: { id: assignData.deviceId } }) || 0
     const screen = this.screenRepository.create({
+      type: 'plugin',
       device: { id: assignData.deviceId } as any,
       plugin: { id: pluginId } as Plugin,
       devicePluginId: saved.id,

--- a/packages/api/src/screens/__test__/screens.service.spec.ts
+++ b/packages/api/src/screens/__test__/screens.service.spec.ts
@@ -91,6 +91,19 @@ describe('screensService', () => {
     expect(writeFileMock).toHaveBeenCalledWith(expect.stringContaining('public/screens/devices/dev/1.original'), file.buffer)
     expect(unlinkMock).not.toHaveBeenCalled()
     expect(screensRepo.save).toHaveBeenCalledWith(screen)
+    expect(screensRepo.create).toHaveBeenCalledWith(expect.objectContaining({ type: 'file' }))
+  })
+
+  it('add creates a screen with html', async () => {
+    const device = { id: 'dev', screens: [], width: 100, height: 100 } as Device
+    devicesRepo.findOne.mockResolvedValue(device)
+    const screen = { id: '1', html: '<div>hi</div>', device, order: 1, isActive: false } as Screen
+    screensRepo.create.mockReturnValue(screen)
+    screensRepo.save.mockResolvedValue(screen)
+    screensRepo.update.mockResolvedValue(undefined)
+    const result = await service.add({ filename: 'file', deviceId: 'dev', fetchManual: false, html: '<div>hi</div>' }, undefined)
+    expect(result).toBe(screen)
+    expect(screensRepo.create).toHaveBeenCalledWith(expect.objectContaining({ type: 'html' }))
   })
 
   it('add creates a screen with externalLink and fetchManual', async () => {
@@ -110,6 +123,7 @@ describe('screensService', () => {
     const result = await service.add(dto, undefined)
     expect(result).toBe(screen)
     expect(screensRepo.save).toHaveBeenCalledWith(screen)
+    expect(screensRepo.create).toHaveBeenCalledWith(expect.objectContaining({ type: 'external' }))
   })
 
   it('getByDevice returns screens for a device', async () => {
@@ -153,6 +167,7 @@ describe('screensService', () => {
         { id: 'cached', type: 'external', fetchManual: true },
         { id: 'live', type: 'external', fetchManual: false },
         { id: 'plugin', type: 'plugin' },
+        { id: 'markup', type: 'html' },
       ])
       fileExistsMock.mockImplementation(async (p: string) => !p.endsWith('legacy.original'))
       const renameMock = vi.spyOn(fs.promises, 'rename').mockResolvedValue(undefined)
@@ -165,6 +180,8 @@ describe('screensService', () => {
       expect(renameMock).toHaveBeenCalledWith(expect.stringContaining('tmp-upload.png'), expect.stringContaining('/upload.png'))
       expect(screensRepo.update).toHaveBeenCalledWith({ id: 'upload' }, { generatedAt: expect.any(Date) })
       expect(screensRepo.update).not.toHaveBeenCalledWith({ id: 'live' }, expect.anything())
+      expect(screensRepo.update).not.toHaveBeenCalledWith({ id: 'plugin' }, expect.anything())
+      expect(screensRepo.update).not.toHaveBeenCalledWith({ id: 'markup' }, expect.anything())
     })
 
     it('keeps going when one screen fails to convert', async () => {

--- a/packages/api/src/screens/screens.service.ts
+++ b/packages/api/src/screens/screens.service.ts
@@ -42,6 +42,7 @@ export class ScreensService {
       throw new NotFoundException('Device not found')
     }
     const newScreen = this.screensRepository.create({
+      type: body.externalLink ? 'external' : body.html ? 'html' : 'file',
       filename: body.filename,
       externalLink: body.externalLink,
       device,


### PR DESCRIPTION
## Summary
- `ScreensService.add()` now sets `type` (`external`/`html`/`file`) instead of leaving every screen at the DB default of `'file'`.
- `PluginsService.assignToDevice()` now sets `type: 'plugin'` on the screens it creates.
- Added a data-only migration (`BackfillScreenType`) that back-fills existing rows using the same `pluginId`/`html`/`externalLink` precedence `AddMashupSupport` used originally.
- `reconvertImageScreens()`'s existing type filter is now correct: HTML, plugin and auto-fetched external screens are properly skipped instead of accidentally re-dithered from themselves.

## Test plan
- [x] `pnpm exec vitest run` for `screens.service.spec.ts` and `plugins.service.spec.ts` — added cases asserting `type` on screen creation, and extended `reconvertImageScreens` coverage with `html`/`plugin` screens to assert they're not reconverted.
- [x] `pnpm run -r test` — full monorepo suite green (410 API + 92 UI tests).
- [x] `pnpm exec eslint` on all changed files — clean.

Fixes #747

https://claude.ai/code/session_01EJi8JqVCUMrVyQdGdibAwy