### PR TITLE
fix(device-models): validate synced model/palette payloads and drop shell exec

### DIFF
--- a/packages/api/src/device-models/__test__/device-model-sync.service.spec.ts
+++ b/packages/api/src/device-models/__test__/device-model-sync.service.spec.ts
@@ -1,3 +1,4 @@
+import { Logger } from '@nestjs/common'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { TRMNL_MODELS_SNAPSHOT, TRMNL_PALETTES_SNAPSHOT } from '../data/trmnl-snapshot'
 import { DeviceModelSyncService } from '../device-model-sync.service'
@@ -131,6 +132,38 @@ describe('deviceModelSyncService', () => {
         throw new DOMException('The operation was aborted due to timeout', 'TimeoutError')
       })
       await expect(service.sync()).rejects.toThrow(/request timed out/)
+    })
+
+    it('skips a palette with an invalid colour and logs it, without dropping other valid palettes', async () => {
+      const warnSpy = vi.spyOn(Logger.prototype, 'warn').mockImplementation(() => {})
+      const badPalette = { ...paletteB, id: 'gray-8', colors: ['#zzzzzz'] }
+      mockFetch.mockImplementation(async (url: string) =>
+        url.endsWith('/palettes') ? jsonResponse([paletteA, badPalette]) : jsonResponse([modelA]))
+      paletteRepo.find.mockResolvedValue([])
+      modelRepo.find.mockResolvedValue([])
+
+      const result = await service.sync()
+
+      expect(paletteRepo.upsert).toHaveBeenCalledWith([expect.objectContaining({ id: 'bw' })], ['id'])
+      expect(result.palettes).toBe(1)
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Skipping invalid palette'))
+      warnSpy.mockRestore()
+    })
+
+    it('skips a model with an invalid id and logs it, without dropping other valid models', async () => {
+      const warnSpy = vi.spyOn(Logger.prototype, 'warn').mockImplementation(() => {})
+      const badModel = { ...modelA, name: '../evil' }
+      mockFetch.mockImplementation(async (url: string) =>
+        url.endsWith('/palettes') ? jsonResponse([paletteA]) : jsonResponse([modelA, badModel]))
+      paletteRepo.find.mockResolvedValue([])
+      modelRepo.find.mockResolvedValue([])
+
+      const result = await service.sync()
+
+      expect(modelRepo.upsert).toHaveBeenCalledWith([expect.objectContaining({ name: 'og_plus' })], ['name'])
+      expect(result.models).toBe(1)
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Skipping invalid model'))
+      warnSpy.mockRestore()
     })
 
     it('coalesces concurrent sync() calls into a single run', async () => {

--- a/packages/api/src/device-models/__test__/trmnl-payloads.spec.ts
+++ b/packages/api/src/device-models/__test__/trmnl-payloads.spec.ts
@@ -1,0 +1,70 @@
+import type { TrmnlModelPayload, TrmnlPalettePayload } from '../trmnl-payloads'
+import { describe, expect, it } from 'vitest'
+import { validateModelPayload, validatePalettePayload } from '../trmnl-payloads'
+
+function model(overrides: Partial<TrmnlModelPayload> = {}): TrmnlModelPayload {
+  return {
+    name: 'og_plus',
+    label: 'TRMNL OG (2-bit)',
+    width: 800,
+    height: 480,
+    colors: 4,
+    bit_depth: 2,
+    scale_factor: 1,
+    rotation: 0,
+    mime_type: 'image/png',
+    offset_x: 0,
+    offset_y: 0,
+    kind: 'trmnl',
+    palette_ids: ['bw', 'gray-4'],
+    css: { classes: { device: 'screen--og_plus', size: 'screen--md' }, variables: [] },
+    ...overrides,
+  }
+}
+
+function palette(overrides: Partial<TrmnlPalettePayload> = {}): TrmnlPalettePayload {
+  return {
+    id: 'gray-4',
+    name: '4 Grays (2-bit)',
+    grays: 4,
+    colors: ['#000000', '#ffffff'],
+    framework_class: 'screen--2bit',
+    ...overrides,
+  }
+}
+
+describe('validateModelPayload', () => {
+  it('accepts a well-formed payload', () => {
+    expect(validateModelPayload(model())).toBeNull()
+  })
+
+  it('rejects a name that would escape a filesystem path', () => {
+    expect(validateModelPayload(model({ name: '../../etc/passwd' }))).toMatch(/name/)
+  })
+
+  it('rejects an invalid palette id', () => {
+    expect(validateModelPayload(model({ palette_ids: ['bw', '../evil'] }))).toMatch(/palette id/)
+  })
+
+  it.each(['width', 'height', 'colors', 'bit_depth', 'scale_factor', 'rotation', 'offset_x', 'offset_y'] as const)('rejects a non-finite %s', (field) => {
+    expect(validateModelPayload(model({ [field]: Number.NaN }))).toMatch(new RegExp(field))
+  })
+
+  it('rejects a css class that would break the stylesheet', () => {
+    expect(validateModelPayload(model({ css: { classes: { device: 'screen--og_plus; DROP TABLE' } } }))).toMatch(/css class/)
+  })
+})
+
+describe('validatePalettePayload', () => {
+  it('accepts a well-formed payload', () => {
+    expect(validatePalettePayload(palette())).toBeNull()
+  })
+
+  it('rejects an id that would escape a shell string or filesystem path', () => {
+    expect(validatePalettePayload(palette({ id: '$(rm -rf /)' }))).toMatch(/palette id/)
+  })
+
+  it('rejects a colour that is not a plain hex value', () => {
+    expect(validatePalettePayload(palette({ colors: ['#ffffff', '"; rm -rf / #'] }))).toMatch(/colour/)
+  })
+})

--- a/packages/api/src/device-models/device-model-sync.service.ts
+++ b/packages/api/src/device-models/device-model-sync.service.ts
@@ -6,7 +6,7 @@ import { In, Repository } from 'typeorm'
 import { TRMNL_MODELS_SNAPSHOT, TRMNL_PALETTES_SNAPSHOT } from './data/trmnl-snapshot'
 import { DeviceModel } from './entities/device-model.entity'
 import { Palette } from './entities/palette.entity'
-import { toDeviceModelAttributes, toPaletteAttributes, TRMNL_API_URL, TrmnlModelPayload, TrmnlPalettePayload } from './trmnl-payloads'
+import { toDeviceModelAttributes, toPaletteAttributes, TRMNL_API_URL, TrmnlModelPayload, TrmnlPalettePayload, validateModelPayload, validatePalettePayload } from './trmnl-payloads'
 
 export interface DeviceModelSyncResult {
   models: number
@@ -45,13 +45,15 @@ export class DeviceModelSyncService implements OnApplicationBootstrap {
    * a live sync) are left untouched.
    */
   async seedFromSnapshot(): Promise<{ models: number, palettes: number }> {
+    const validPalettes = this.filterValid(TRMNL_PALETTES_SNAPSHOT, validatePalettePayload, 'palette')
     const existingPalettes = new Set((await this.paletteRepository.find({ select: { id: true } })).map(p => p.id))
-    const missingPalettes = TRMNL_PALETTES_SNAPSHOT.filter(p => !existingPalettes.has(p.id)).map(toPaletteAttributes)
+    const missingPalettes = validPalettes.filter(p => !existingPalettes.has(p.id)).map(toPaletteAttributes)
     if (missingPalettes.length > 0)
       await this.paletteRepository.insert(missingPalettes)
 
+    const validModels = this.filterValid(TRMNL_MODELS_SNAPSHOT, validateModelPayload, 'model')
     const existingModels = new Set((await this.deviceModelRepository.find({ select: { name: true } })).map(m => m.name))
-    const missingModels = TRMNL_MODELS_SNAPSHOT.filter(m => !existingModels.has(m.name)).map(toDeviceModelAttributes)
+    const missingModels = validModels.filter(m => !existingModels.has(m.name)).map(toDeviceModelAttributes)
     if (missingModels.length > 0)
       await this.deviceModelRepository.insert(missingModels)
 
@@ -75,10 +77,12 @@ export class DeviceModelSyncService implements OnApplicationBootstrap {
 
   private async runSync(): Promise<DeviceModelSyncResult> {
     this.logger.log('Syncing device models from TRMNL')
-    const [palettes, models] = await Promise.all([
+    const [rawPalettes, rawModels] = await Promise.all([
       this.fetchList<TrmnlPalettePayload>('palettes'),
       this.fetchList<TrmnlModelPayload>('models'),
     ])
+    const palettes = this.filterValid(rawPalettes, validatePalettePayload, 'palette')
+    const models = this.filterValid(rawModels, validateModelPayload, 'model')
     const syncedAt = new Date()
 
     await this.paletteRepository.upsert(palettes.map(p => ({ ...toPaletteAttributes(p), deprecated: false, syncedAt })), ['id'])
@@ -89,6 +93,16 @@ export class DeviceModelSyncService implements OnApplicationBootstrap {
 
     this.logger.log(`Synced ${models.length} device models and ${palettes.length} palettes (${deprecatedModels} models, ${deprecatedPalettes} palettes deprecated)`)
     return { models: models.length, palettes: palettes.length, deprecatedModels, deprecatedPalettes, syncedAt }
+  }
+
+  /** Drops payload entries that fail validation, logging each so a bad upstream response is visible without failing the whole sync. */
+  private filterValid<T>(items: T[], validate: (item: T) => string | null, kind: string): T[] {
+    return items.filter((item) => {
+      const reason = validate(item)
+      if (reason)
+        this.logger.warn(`Skipping invalid ${kind}: ${reason}`)
+      return !reason
+    })
   }
 
   private async fetchList<T>(endpoint: string): Promise<T[]> {

--- a/packages/api/src/device-models/trmnl-payloads.ts
+++ b/packages/api/src/device-models/trmnl-payloads.ts
@@ -37,6 +37,49 @@ export interface TrmnlPalettePayload {
 export type DeviceModelAttributes = Omit<DeviceModel, 'deprecated' | 'syncedAt'>
 export type PaletteAttributes = Omit<Palette, 'deprecated' | 'syncedAt'>
 
+const ID_PATTERN = /^[\w.-]+$/
+const HEX_COLOR_PATTERN = /^#[0-9a-f]{6}$/i
+const CSS_CLASS_PATTERN = /^[\w-]+$/
+const MODEL_NUMERIC_FIELDS = ['width', 'height', 'colors', 'bit_depth', 'scale_factor', 'rotation', 'offset_x', 'offset_y'] as const
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value)
+}
+
+/**
+ * Rejects a synced model payload whose values would otherwise flow unescaped
+ * into shell commands (ImageMagick) or filesystem paths (colormap/fallback
+ * screen caches). Returns a human-readable reason, or null if the payload is safe.
+ */
+export function validateModelPayload(payload: TrmnlModelPayload): string | null {
+  if (!ID_PATTERN.test(payload.name))
+    return `model name "${payload.name}" contains invalid characters`
+  for (const id of payload.palette_ids ?? []) {
+    if (!ID_PATTERN.test(id))
+      return `model "${payload.name}" has invalid palette id "${id}"`
+  }
+  for (const field of MODEL_NUMERIC_FIELDS) {
+    if (!isFiniteNumber(payload[field]))
+      return `model "${payload.name}" has a non-finite ${field}`
+  }
+  for (const cssClass of Object.values(payload.css?.classes ?? {})) {
+    if (!CSS_CLASS_PATTERN.test(cssClass))
+      return `model "${payload.name}" has invalid css class "${cssClass}"`
+  }
+  return null
+}
+
+/** Rejects a synced palette payload whose id or colours would otherwise flow unescaped into shell commands or filesystem paths. */
+export function validatePalettePayload(payload: TrmnlPalettePayload): string | null {
+  if (!ID_PATTERN.test(payload.id))
+    return `palette id "${payload.id}" contains invalid characters`
+  for (const color of payload.colors ?? []) {
+    if (!HEX_COLOR_PATTERN.test(color))
+      return `palette "${payload.id}" has invalid colour "${color}"`
+  }
+  return null
+}
+
 export function toDeviceModelAttributes(payload: TrmnlModelPayload): DeviceModelAttributes {
   return {
     name: payload.name,

--- a/packages/api/src/utils/__test__/imageUtils.spec.ts
+++ b/packages/api/src/utils/__test__/imageUtils.spec.ts
@@ -3,7 +3,7 @@ import { Buffer } from 'node:buffer'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { convertToPng, downloadImage, paletteConversion } from '../imageUtils'
 
-const mockExec = vi.fn()
+const mockExecFile = vi.fn()
 const mockFd = {
   read: vi.fn().mockImplementation((buf: any) => {
     buf[0] = 0xFF
@@ -23,8 +23,8 @@ const mockFs = vi.hoisted(() => ({
 }))
 
 vi.mock('node:child_process', () => ({
-  exec: (cmd: string, callback: (error: Error | null, stdout: string, stderr: string) => void) => {
-    mockExec(cmd, callback)
+  execFile: (file: string, args: string[], callback: (error: Error | null, stdout: string, stderr: string) => void) => {
+    mockExecFile(file, args, callback)
   },
 }))
 
@@ -64,7 +64,7 @@ describe('imageUtils', () => {
   const COLOR_24 = { id: 'color-24bit', grays: 2, colors: null, frameworkClass: 'screen--color-full' } as any
 
   function magickSucceeds() {
-    mockExec.mockImplementation((cmd: string, callback: any) => {
+    mockExecFile.mockImplementation((_file: string, _args: string[], callback: any) => {
       callback(null, '', '')
     })
   }
@@ -91,9 +91,9 @@ describe('imageUtils', () => {
       await convertToPng('/input.jpg', '/output.png', { model: OG_PLUS, palette: GRAY_4 }, mockLogger)
 
       expect(mockFs.promises.mkdir).toHaveBeenCalled()
-      expect(mockExec).toHaveBeenCalledTimes(2)
-      expect(mockExec.mock.calls[0][0]).toContain('xc:"#000000" xc:"#555555" xc:"#aaaaaa" xc:"#ffffff" +append -type Palette')
-      expect(mockExec.mock.calls[0][0]).toContain('colormaps/gray-4.png')
+      expect(mockExecFile).toHaveBeenCalledTimes(2)
+      expect(mockExecFile.mock.calls[0][0]).toBe('magick')
+      expect(mockExecFile.mock.calls[0][1]).toEqual(['-size', '1x1', 'xc:#000000', 'xc:#555555', 'xc:#aaaaaa', 'xc:#ffffff', '+append', '-type', 'Palette', expect.stringContaining('colormaps/gray-4.png')])
     })
 
     it('creates a colormap from the palette colours for colour panels', async () => {
@@ -102,12 +102,11 @@ describe('imageUtils', () => {
 
       await convertToPng('/input.jpg', '/output.png', { model: OG_PLUS, palette: COLOR_6A }, mockLogger)
 
-      expect(mockExec.mock.calls[0][0]).toContain('xc:"#FF0000" xc:"#00FF00" xc:"#0000FF" xc:"#FFFF00" xc:"#000000" xc:"#FFFFFF" +append')
-      expect(mockExec.mock.calls[0][0]).toContain('colormaps/color-6a.png')
-      const cmd = mockExec.mock.calls[1][0]
-      expect(cmd).toContain('-remap')
-      expect(cmd).toContain('-define png:color-type=3')
-      expect(cmd).not.toContain('-colorspace Gray')
+      expect(mockExecFile.mock.calls[0][1]).toEqual(['-size', '1x1', 'xc:#FF0000', 'xc:#00FF00', 'xc:#0000FF', 'xc:#FFFF00', 'xc:#000000', 'xc:#FFFFFF', '+append', '-type', 'Palette', expect.stringContaining('colormaps/color-6a.png')])
+      const args = mockExecFile.mock.calls[1][1]
+      expect(args).toContain('-remap')
+      expect(args).toEqual(expect.arrayContaining(['-define', 'png:color-type=3']))
+      expect(args).not.toContain('-colorspace')
     })
 
     it('skips colormap creation if it already exists', async () => {
@@ -116,7 +115,7 @@ describe('imageUtils', () => {
 
       await convertToPng('/input.jpg', '/output.png', { model: OG_PLUS, palette: GRAY_4 }, mockLogger)
 
-      expect(mockExec).toHaveBeenCalledTimes(1)
+      expect(mockExecFile).toHaveBeenCalledTimes(1)
     })
 
     it('calls ImageMagick with 2-bit gray parameters for the 4-gray palette', async () => {
@@ -125,16 +124,18 @@ describe('imageUtils', () => {
 
       await convertToPng('/input.jpg', '/output.png', { model: OG_PLUS, palette: GRAY_4 }, mockLogger)
 
-      const cmd = mockExec.mock.calls[0][0]
-      expect(cmd).toContain('magick "JPEG:/input.jpg"')
-      expect(cmd).toContain('-background white -alpha remove -alpha off')
-      expect(cmd).toContain('-resize 800x480 -gravity Center -extent 800x480')
-      expect(cmd).toContain('-colorspace Gray -dither FloydSteinberg -remap')
-      expect(cmd).toContain('colormaps/gray-4.png')
-      expect(cmd).toContain('-define png:bit-depth=2 -define png:color-type=0')
-      expect(cmd).toContain('-strip png:"/output.png"')
-      expect(cmd).not.toContain('-rotate')
-      expect(cmd).not.toContain('-crop')
+      expect(mockExecFile.mock.calls[0][0]).toBe('magick')
+      const args = mockExecFile.mock.calls[0][1]
+      expect(args[0]).toBe('JPEG:/input.jpg')
+      expect(args).toEqual(expect.arrayContaining(['-background', 'white', '-alpha', 'remove', '-alpha', 'off']))
+      expect(args).toEqual(expect.arrayContaining(['-resize', '800x480', '-gravity', 'Center', '-extent', '800x480']))
+      expect(args).toEqual(expect.arrayContaining(['-colorspace', 'Gray', '-dither', 'FloydSteinberg', '-remap']))
+      expect(args.some((a: string) => a.includes('colormaps/gray-4.png'))).toBe(true)
+      expect(args).toEqual(expect.arrayContaining(['-define', 'png:bit-depth=2', '-define', 'png:color-type=0']))
+      expect(args[args.length - 2]).toBe('-strip')
+      expect(args[args.length - 1]).toBe('png:/output.png')
+      expect(args).not.toContain('-rotate')
+      expect(args).not.toContain('-crop')
     })
 
     it('uses 1-bit and 4-bit output for the bw and 16-gray palettes', async () => {
@@ -142,9 +143,9 @@ describe('imageUtils', () => {
       magickSucceeds()
 
       await convertToPng('/input.jpg', '/output.png', { model: OG_PLUS, palette: BW }, mockLogger)
-      expect(mockExec.mock.calls[0][0]).toContain('-define png:bit-depth=1')
+      expect(mockExecFile.mock.calls[0][1]).toContain('png:bit-depth=1')
       await convertToPng('/input.jpg', '/output.png', { model: OG_PLUS, palette: GRAY_16 }, mockLogger)
-      expect(mockExec.mock.calls[1][0]).toContain('-define png:bit-depth=4')
+      expect(mockExecFile.mock.calls[1][1]).toContain('png:bit-depth=4')
     })
 
     it('keeps full colour for full-colour palettes without remapping', async () => {
@@ -152,10 +153,10 @@ describe('imageUtils', () => {
 
       await convertToPng('/input.jpg', '/output.png', { model: OG_PLUS, palette: COLOR_24 }, mockLogger)
 
-      expect(mockExec).toHaveBeenCalledTimes(1)
-      const cmd = mockExec.mock.calls[0][0]
-      expect(cmd).toContain('-colorspace sRGB -define png:color-type=2')
-      expect(cmd).not.toContain('-remap')
+      expect(mockExecFile).toHaveBeenCalledTimes(1)
+      const args = mockExecFile.mock.calls[0][1]
+      expect(args).toEqual(expect.arrayContaining(['-colorspace', 'sRGB', '-define', 'png:color-type=2']))
+      expect(args).not.toContain('-remap')
     })
 
     it('fits to the model size, then rotates and trims offsets', async () => {
@@ -165,14 +166,14 @@ describe('imageUtils', () => {
 
       await convertToPng('/input.jpg', '/output.png', { model: kindle, palette: GRAY_4 }, mockLogger)
 
-      const cmd = mockExec.mock.calls[0][0]
-      expect(cmd).toContain('-resize 1400x840 -gravity Center -extent 1400x840 -rotate 90 -crop +75+25 +repage -colorspace Gray')
+      const args = mockExecFile.mock.calls[0][1]
+      expect(args).toEqual(expect.arrayContaining(['-resize', '1400x840', '-gravity', 'Center', '-extent', '1400x840', '-rotate', '90', '-crop', '+75+25', '+repage']))
     })
 
     it('handles ImageMagick errors during colormap creation', async () => {
       mockFs.existsSync.mockReturnValue(false)
-      mockExec.mockImplementation((cmd: string, callback: any) => {
-        if (cmd.includes('colormap')) {
+      mockExecFile.mockImplementation((_file: string, args: string[], callback: any) => {
+        if (args.some(a => a.includes('colormap'))) {
           callback(new Error('ImageMagick failed'), '', 'ImageMagick error')
         }
       })
@@ -186,7 +187,7 @@ describe('imageUtils', () => {
 
     it('handles ImageMagick errors during conversion', async () => {
       mockFs.existsSync.mockReturnValue(true)
-      mockExec.mockImplementation((cmd: string, callback: any) => {
+      mockExecFile.mockImplementation((_file: string, _args: string[], callback: any) => {
         callback(new Error('Conversion failed'), '', 'conversion stderr')
       })
 

--- a/packages/api/src/utils/imageUtils.ts
+++ b/packages/api/src/utils/imageUtils.ts
@@ -2,7 +2,7 @@ import type { Logger } from '@nestjs/common'
 import type { DeviceRenderTarget } from '../device-models/device-models.service'
 import type { Palette } from '../device-models/entities/palette.entity'
 import buffer from 'node:buffer'
-import { exec } from 'node:child_process'
+import { execFile } from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'
 import { resolveAppPath } from './pathHelper'
@@ -62,10 +62,10 @@ function grayLevelsHex(levels: number): string[] {
   })
 }
 
-function runMagick(cmd: string, logger: Logger): Promise<void> {
-  logger.log(`Running ImageMagick: ${cmd}`)
+function runMagick(args: string[], logger: Logger): Promise<void> {
+  logger.log(`Running ImageMagick: magick ${args.join(' ')}`)
   return new Promise<void>((resolve, reject) => {
-    exec(cmd, (error, stdout, stderr) => {
+    execFile('magick', args, (error, stdout, stderr) => {
       if (error) {
         logger.error(`ImageMagick error: ${stderr}`)
         reject(error)
@@ -84,24 +84,24 @@ async function ensureColormap(paletteId: string, colors: string[], logger: Logge
     return colormapPath
   logger.log(`Creating colormap for palette ${paletteId} at ${colormapPath}`)
   await fs.promises.mkdir(path.dirname(colormapPath), { recursive: true })
-  const swatches = colors.map(color => `xc:"${color}"`).join(' ')
-  await runMagick(`magick -size 1x1 ${swatches} +append -type Palette "${colormapPath}"`, logger)
+  const swatches = colors.map(color => `xc:${color}`)
+  await runMagick(['-size', '1x1', ...swatches, '+append', '-type', 'Palette', colormapPath], logger)
   return colormapPath
 }
 
-async function paletteOperators(palette: Palette, logger: Logger): Promise<string> {
+async function paletteOperators(palette: Palette, logger: Logger): Promise<string[]> {
   const conversion = paletteConversion(palette)
   switch (conversion.kind) {
     case 'gray': {
       const colormap = await ensureColormap(palette.id, grayLevelsHex(conversion.levels), logger)
-      return `-colorspace Gray -dither FloydSteinberg -remap "${colormap}" -define png:bit-depth=${conversion.bitDepth} -define png:color-type=0`
+      return ['-colorspace', 'Gray', '-dither', 'FloydSteinberg', '-remap', colormap, '-define', `png:bit-depth=${conversion.bitDepth}`, '-define', 'png:color-type=0']
     }
     case 'color': {
       const colormap = await ensureColormap(palette.id, conversion.colors, logger)
-      return `-dither FloydSteinberg -remap "${colormap}" -define png:color-type=3`
+      return ['-dither', 'FloydSteinberg', '-remap', colormap, '-define', 'png:color-type=3']
     }
     case 'full-color':
-      return '-colorspace sRGB -define png:color-type=2'
+      return ['-colorspace', 'sRGB', '-define', 'png:color-type=2']
   }
 }
 
@@ -110,14 +110,14 @@ async function paletteOperators(palette: Palette, logger: Logger): Promise<strin
  * white), rotate to the panel's orientation, then trim the model's offsets
  * from the top-left edge.
  */
-function geometryOperators({ model }: DeviceRenderTarget): string {
+function geometryOperators({ model }: DeviceRenderTarget): string[] {
   const size = `${model.width}x${model.height}`
-  const ops = [`-resize ${size}`, '-gravity Center', `-extent ${size}`]
+  const ops = ['-resize', size, '-gravity', 'Center', '-extent', size]
   if (model.rotation !== 0)
-    ops.push(`-rotate ${model.rotation}`)
+    ops.push('-rotate', String(model.rotation))
   if (model.offsetX !== 0 || model.offsetY !== 0)
-    ops.push(`-crop +${model.offsetX}+${model.offsetY} +repage`)
-  return ops.join(' ')
+    ops.push('-crop', `+${model.offsetX}+${model.offsetY}`, '+repage')
+  return ops
 }
 
 /** Converts any supported raster image into the PNG a device with the given render target expects. */
@@ -133,6 +133,18 @@ export async function convertToPng(inputPath: string, outputPath: string, target
   const format = detectImageFormat(header)
   const palette = await paletteOperators(target.palette, logger)
 
-  const cmd = `magick "${format}:${inputPath}" -background white -alpha remove -alpha off ${geometryOperators(target)} ${palette} -strip png:"${outputPath}"`
-  await runMagick(cmd, logger)
+  const args = [
+    `${format}:${inputPath}`,
+    '-background',
+    'white',
+    '-alpha',
+    'remove',
+    '-alpha',
+    'off',
+    ...geometryOperators(target),
+    ...palette,
+    '-strip',
+    `png:${outputPath}`,
+  ]
+  await runMagick(args, logger)
 }


### PR DESCRIPTION
## Summary
- Rejects synced TRMNL model/palette entries whose `name`/`palette_ids`/`id`, colours, css classes, or numeric fields fall outside a safe character set/type before they reach the sync tables, logging and skipping bad entries instead of failing the whole sync (`DeviceModelSyncService.sync()` and `seedFromSnapshot()`).
- Switches `runMagick` from `child_process.exec()` on an interpolated command string to `execFile('magick', args)` with an argument array, so ImageMagick invocations never go through a shell regardless of what data reaches them. `paletteOperators`/`geometryOperators` now build `string[]` instead of a joined string.

## Test plan
- [x] `vitest run` — full API suite passes (427 passed, 5 skipped)
- [x] New specs cover: bad palette colour skipped+logged, bad model id skipped+logged, validator unit tests for both payload types
- [x] `imageUtils.spec.ts` updated to assert on the `execFile` args array; behaviour for valid data unchanged (same operators, same output geometry)
- [x] `eslint` clean on all touched files

Closes #748

Claude-Session: https://claude.ai/code/session_01EJi8JqVCUMrVyQdGdibAwy