### PR TITLE
fix(ui): fix DEFAULT_MODEL drift from the og_plus snapshot

### DIFF
--- a/packages/ui/src/utils/__test__/renderTarget.spec.ts
+++ b/packages/ui/src/utils/__test__/renderTarget.spec.ts
@@ -1,6 +1,26 @@
 import type { DeviceModel, Palette } from '@/types'
 import { describe, expect, it } from 'vitest'
-import { DEFAULT_MODEL, DEFAULT_PALETTE, renderTargetFor, richestPalette } from '../renderTarget'
+import { DEFAULT_MODEL, DEFAULT_MODEL_NAME, DEFAULT_PALETTE, renderTargetFor, richestPalette } from '../renderTarget'
+
+// This tsconfig has no Node types, so `process` is declared locally rather than
+// pulling in @types/node just for a test-only path.
+declare const process: { cwd: () => string }
+
+// Paths are built at runtime (not string literals) so vue-tsc never resolves these
+// modules into the UI's type-check program — the API package's decorator-based
+// entities aren't valid under the UI's tsconfig and would fail the build.
+const API_DEVICE_MODELS_DIR = `${process.cwd()}/../api/src/device-models`
+const SNAPSHOT_PATH = `${API_DEVICE_MODELS_DIR}/data/trmnl-snapshot`
+const PAYLOADS_PATH = `${API_DEVICE_MODELS_DIR}/trmnl-payloads`
+
+interface TrmnlSnapshotModule {
+  TRMNL_MODELS_SNAPSHOT: Array<Record<string, unknown>>
+  TRMNL_PALETTES_SNAPSHOT: Array<Record<string, unknown>>
+}
+interface TrmnlPayloadsModule {
+  toDeviceModelAttributes: (payload: Record<string, unknown>) => Record<string, unknown>
+  toPaletteAttributes: (payload: Record<string, unknown>) => Record<string, unknown>
+}
 
 const BW: Palette = { id: 'bw', name: 'bw', grays: 2, frameworkClass: 'screen--1bit', deprecated: false }
 const GRAY_4: Palette = { id: 'gray-4', name: 'g4', grays: 4, frameworkClass: 'screen--2bit', deprecated: false }
@@ -31,5 +51,39 @@ describe('renderTarget', () => {
   it('falls back to the loaded OG model for unassigned devices, then to the built-in default', () => {
     expect(renderTargetFor(null, source)).toEqual({ model: OG, palette: GRAY_4 })
     expect(renderTargetFor(null, { getByName: () => undefined, palettesFor: () => [] })).toEqual({ model: DEFAULT_MODEL, palette: DEFAULT_PALETTE })
+  })
+
+  it('matches the real og_plus snapshot entry, so the offline default cannot drift', async () => {
+    const { TRMNL_MODELS_SNAPSHOT, TRMNL_PALETTES_SNAPSHOT } = await import(/* @vite-ignore */ SNAPSHOT_PATH) as TrmnlSnapshotModule
+    const { toDeviceModelAttributes, toPaletteAttributes } = await import(/* @vite-ignore */ PAYLOADS_PATH) as TrmnlPayloadsModule
+
+    const snapshotModel = TRMNL_MODELS_SNAPSHOT.find(model => model.name === DEFAULT_MODEL_NAME)
+    const snapshotPalette = TRMNL_PALETTES_SNAPSHOT.find(palette => palette.id === DEFAULT_PALETTE.id)
+    if (!snapshotModel || !snapshotPalette)
+      throw new Error('og_plus / gray-4 missing from the TRMNL snapshot')
+
+    const mappedModel = toDeviceModelAttributes(snapshotModel)
+    const mappedPalette = toPaletteAttributes(snapshotPalette)
+
+    expect(DEFAULT_MODEL.cssClasses).toEqual(mappedModel.cssClasses)
+    expect(DEFAULT_MODEL.cssVariables).toEqual(mappedModel.cssVariables)
+    expect(DEFAULT_MODEL).toMatchObject({
+      width: mappedModel.width,
+      height: mappedModel.height,
+      colors: mappedModel.colors,
+      bitDepth: mappedModel.bitDepth,
+      scaleFactor: mappedModel.scaleFactor,
+      rotation: mappedModel.rotation,
+      offsetX: mappedModel.offsetX,
+      offsetY: mappedModel.offsetY,
+      mimeType: mappedModel.mimeType,
+      kind: mappedModel.kind,
+      paletteIds: mappedModel.paletteIds,
+    })
+    expect(DEFAULT_PALETTE).toMatchObject({
+      name: mappedPalette.name,
+      grays: mappedPalette.grays,
+      frameworkClass: mappedPalette.frameworkClass,
+    })
   })
 })

--- a/packages/ui/src/utils/renderTarget.ts
+++ b/packages/ui/src/utils/renderTarget.ts
@@ -18,8 +18,15 @@ export const DEFAULT_MODEL: DeviceModel = {
   mimeType: 'image/png',
   kind: 'trmnl',
   paletteIds: ['bw', 'gray-4'],
-  cssClasses: ['screen--og_plus', 'screen--md', 'screen--density-1x'],
-  cssVariables: {},
+  cssClasses: ['screen--ogv2', 'screen--md', 'screen--density-1x'],
+  cssVariables: {
+    '--screen-w': '800px',
+    '--screen-h': '480px',
+    '--pixel-ratio': '1.0',
+    '--dither-pixel-ratio': '1.0',
+    '--device-ui-scale': '1.0',
+    '--gap-scale': '1.0',
+  },
   deprecated: false,
 }
 


### PR DESCRIPTION
## Summary
- `DEFAULT_MODEL` (the offline fallback used by every device-less preview — plugin create/edit, HTML playground — before the device-models store loads, or if it fails to load) used a CSS class (`screen--og_plus`) that doesn't exist in `plugins.css`, and shipped no CSS variables at all.
- Replaced with the real `og_plus` values from `packages/api/src/device-models/data/trmnl-snapshot.ts`: `screen--ogv2` plus its six CSS variables (`--screen-w`, `--screen-h`, `--pixel-ratio`, `--dither-pixel-ratio`, `--device-ui-scale`, `--gap-scale`).
- `DEFAULT_PALETTE` already matched the snapshot's `gray-4` entry, so no change was needed there — the new test covers it too.
- Added a regression test that dynamically imports the API package's snapshot data + `toDeviceModelAttributes`/`toPaletteAttributes` mapping functions at runtime (via computed, non-literal paths) to assert `DEFAULT_MODEL`/`DEFAULT_PALETTE` can't drift from the snapshot again. The dynamic-import indirection is deliberate: a static cross-package import pulls the API's TypeORM-decorated entity files into the UI's `vue-tsc` program and breaks `type-check`, since the UI's tsconfig doesn't enable decorators.

Closes #749

## Test plan
- [x] `pnpm vitest run src/utils/__test__/renderTarget.spec.ts` (packages/ui) — 5/5 passing, including the new drift-guard test
- [x] `pnpm run type-check` (packages/ui) — clean
- [x] `pnpm lint` (packages/ui) — clean
- [x] `pnpm run test` (full monorepo) — 427 api + 93 ui tests passing

https://claude.ai/code/session_01EJi8JqVCUMrVyQdGdibAwy