### PR TITLE
fix(device-models): address small follow-ups from device-model support review

### DIFF
--- a/packages/api/src/device-models/__test__/screen-shell.spec.ts
+++ b/packages/api/src/device-models/__test__/screen-shell.spec.ts
@@ -1,6 +1,10 @@
+import type { DeviceRenderTarget } from '../device-models.service'
 import { describe, expect, it } from 'vitest'
+import { SCREEN_SHELL_FIXTURE_BODY, SCREEN_SHELL_FIXTURE_EXPECTED, SCREEN_SHELL_FIXTURE_MODEL, SCREEN_SHELL_FIXTURE_PALETTE } from '../../../../../test/fixtures/screen-shell.fixture'
 import { screenClasses, screenStyle, viewFull, wrapInScreenShell } from '../screen-shell'
 import { BW, GRAY_4, GRAY_16, OG_PLUS, V2 } from './mockDeviceModelsService'
+
+const fixtureTarget = { model: SCREEN_SHELL_FIXTURE_MODEL, palette: SCREEN_SHELL_FIXTURE_PALETTE } as unknown as DeviceRenderTarget
 
 describe('screen shell', () => {
   it('builds the screen class list from model and palette', () => {
@@ -41,5 +45,11 @@ describe('screen shell', () => {
   it('omits the style attribute when the model has no CSS variables', () => {
     const html = wrapInScreenShell({ model: { ...OG_PLUS, cssVariables: {} }, palette: GRAY_4 }, 'x')
     expect(html).toContain('<div class="screen screen--og_plus screen--md screen--density-1x screen--2bit">x</div>')
+  })
+
+  it('matches the cross-package golden fixture shared with the UI copy', () => {
+    expect(screenClasses(fixtureTarget)).toEqual(SCREEN_SHELL_FIXTURE_EXPECTED.classes)
+    expect(screenStyle(fixtureTarget)).toBe(SCREEN_SHELL_FIXTURE_EXPECTED.style)
+    expect(wrapInScreenShell(fixtureTarget, SCREEN_SHELL_FIXTURE_BODY)).toContain(SCREEN_SHELL_FIXTURE_EXPECTED.wrappedDiv)
   })
 })

--- a/packages/api/src/devices/__test__/devices.service.spec.ts
+++ b/packages/api/src/devices/__test__/devices.service.spec.ts
@@ -157,6 +157,13 @@ describe('devicesService', () => {
       expect(repo.save).not.toHaveBeenCalled()
     })
 
+    it('rejects a palette sent for a device with no assigned device model', async () => {
+      repo.findOneBy.mockResolvedValue({ ...baseDevice, deviceModel: null, palette: null })
+      await expect(service.update('1', { paletteId: 'bw' } as any)).rejects.toThrow(BadRequestException)
+      expect(deviceModels.findPalette).not.toHaveBeenCalled()
+      expect(repo.save).not.toHaveBeenCalled()
+    })
+
     it('fills in the default palette for a device that has a model but no palette', async () => {
       repo.findOneBy.mockResolvedValue({ ...baseDevice, deviceModel: OG_PLUS, palette: null })
       deviceModels.defaultPaletteFor.mockResolvedValue(GRAY_4)

--- a/packages/api/src/devices/__test__/display.service.spec.ts
+++ b/packages/api/src/devices/__test__/display.service.spec.ts
@@ -171,6 +171,7 @@ describe('deviceDisplayService', () => {
       const { convertToPng } = await import('../../utils/imageUtils')
       expect(convertToPng).toHaveBeenCalledWith(expect.any(String), expect.stringContaining('screen2.png'), { model: V2, palette: GRAY_16 }, expect.any(Object))
       expect(result.image_url).toBe('http://api/screens/devices/1/screen2.png')
+      expect(fs.unlink).toHaveBeenCalledWith(expect.stringContaining('tmp-source'))
     })
 
     it('wraps cached plugin output in a full view and the shell', async () => {
@@ -269,6 +270,7 @@ describe('deviceDisplayService', () => {
     const result = await service.getCurrentImage(headers as any)
     expect(result).toBeInstanceOf(Display)
     expect(result.image_url).toBe('http://api/screens/devices/1/screen2.png')
+    expect(fs.unlink).toHaveBeenCalledWith(expect.stringContaining('tmp-source'))
   })
 
   it('handles mirroring with proxy when MACs are identical', async () => {

--- a/packages/api/src/devices/devices.service.ts
+++ b/packages/api/src/devices/devices.service.ts
@@ -63,7 +63,9 @@ export class DevicesService {
       device.deviceModel = model
       device.palette = null
     }
-    if (device.deviceModel && paletteId !== undefined) {
+    if (paletteId !== undefined) {
+      if (!device.deviceModel)
+        throw new BadRequestException('Cannot set a palette on a device with no assigned device model')
       const palette = await this.deviceModels.findPalette(paletteId)
       if (!palette || !device.deviceModel.paletteIds.includes(paletteId))
         throw new BadRequestException(`Palette ${paletteId} is not supported by device model ${device.deviceModel.name}`)

--- a/packages/api/src/devices/display.service.ts
+++ b/packages/api/src/devices/display.service.ts
@@ -359,6 +359,14 @@ export class DeviceDisplayService {
         this.logger.error(`Failed to process image: ${err.message}`)
         imgUrl = await this.fallbackImageUrl('error', device)
       }
+      finally {
+        try {
+          await fs.promises.unlink(inputPath)
+        }
+        catch {
+          // best-effort cleanup
+        }
+      }
     }
     if (imgUrl !== null)
       return imgUrl
@@ -424,14 +432,14 @@ export class DeviceDisplayService {
   private async renderBodyToScreenPng(bodyHtml: string, screen: Screen, device: Device): Promise<string> {
     const target = await this.deviceModels.renderTargetFor(device)
     const browser = await puppeteer.launch({ args: ['--no-sandbox', '--disable-web-security'] })
+    const destDir = resolveAppPath('public', 'screens', 'devices', device.id)
+    const inputPath = path.join(destDir, 'tmp-source')
     try {
       const page = await browser.newPage()
       await page.setViewport({ width: target.model.width, height: target.model.height })
       await page.setContent(wrapInScreenShell(target, bodyHtml), { waitUntil: 'load' })
       const image: Uint8Array = await page.screenshot()
 
-      const destDir = resolveAppPath('public', 'screens', 'devices', device.id)
-      const inputPath = path.join(destDir, 'tmp-source')
       await fs.promises.mkdir(destDir, { recursive: true })
       await fs.promises.writeFile(inputPath, buffer.Buffer.from(image))
       await convertToPng(inputPath, this.screenImagePath(device, screen), target, this.logger)
@@ -439,6 +447,12 @@ export class DeviceDisplayService {
     }
     finally {
       await browser.close()
+      try {
+        await fs.promises.unlink(inputPath)
+      }
+      catch {
+        // best-effort cleanup
+      }
     }
   }
 

--- a/packages/api/src/screens/__test__/screens.service.spec.ts
+++ b/packages/api/src/screens/__test__/screens.service.spec.ts
@@ -184,7 +184,7 @@ describe('screensService', () => {
       expect(screensRepo.update).not.toHaveBeenCalledWith({ id: 'markup' }, expect.anything())
     })
 
-    it('keeps going when one screen fails to convert', async () => {
+    it('keeps going when one screen fails to convert, cleaning up its temp file', async () => {
       screensRepo.find.mockResolvedValue([{ id: 'a', type: 'file' }, { id: 'b', type: 'file' }])
       fileExistsMock.mockResolvedValue(true)
       vi.spyOn(fs.promises, 'rename').mockResolvedValue(undefined)
@@ -192,6 +192,7 @@ describe('screensService', () => {
       vi.mocked(convertToPng).mockRejectedValueOnce(new Error('boom')).mockResolvedValueOnce(undefined)
 
       await expect(service.reconvertImageScreens(device)).resolves.toBe(1)
+      expect(unlinkMock).toHaveBeenCalledWith(expect.stringContaining('tmp-a.png'))
     })
   })
 

--- a/packages/api/src/screens/screens.service.ts
+++ b/packages/api/src/screens/screens.service.ts
@@ -222,8 +222,8 @@ export class ScreensService {
         this.logger.warn(`No image to reconvert for screen ${screen.id}`)
         continue
       }
+      const tempPath = path.join(path.dirname(outputPath), `tmp-${screen.id}.png`)
       try {
-        const tempPath = path.join(path.dirname(outputPath), `tmp-${screen.id}.png`)
         await convertToPng(sourcePath, tempPath, target, this.logger)
         await fs.promises.rename(tempPath, outputPath)
         await this.screensRepository.update({ id: screen.id }, { generatedAt: new Date() })
@@ -231,6 +231,7 @@ export class ScreensService {
       }
       catch (err) {
         this.logger.error(`Failed to reconvert screen ${screen.id}: ${err.message}`)
+        await fs.promises.unlink(tempPath).catch(() => {})
       }
     }
     this.logger.log(`Reconverted ${converted} image screen(s) for device ${device.id} as ${target.model.name}/${target.palette.id}`)

--- a/packages/ui/src/components/AddScreenCard.vue
+++ b/packages/ui/src/components/AddScreenCard.vue
@@ -207,9 +207,7 @@ const { isDemo } = useDemoInfo()
       </VCardText>
     </VCard>
     <VOverlay v-model="showHtmlPreview" class="align-center justify-center">
-      <div :style="{ width: `min(90vw, ${renderTarget.model.width}px)` }">
-        <ScreenFrame v-if="showHtmlPreview" :body="viewFull(renderHtml)" :target="renderTarget" />
-      </div>
+      <ScreenFrame v-if="showHtmlPreview" :body="viewFull(renderHtml)" :target="renderTarget" />
     </VOverlay>
   </template>
 </template>

--- a/packages/ui/src/components/DeviceInformationCard.vue
+++ b/packages/ui/src/components/DeviceInformationCard.vue
@@ -328,7 +328,17 @@ const nameEditing = ref(false)
               {{ modelSummary }}
               <VTooltip v-if="reportMismatch" location="top" text="The device reports a different panel size than its assigned model. Check the model in Advanced.">
                 <template #activator="{ props: tooltipProps }">
-                  <VIcon v-bind="tooltipProps" :icon="mdiAlert" color="warning" size="small" class="ml-1" data-test-id="device-model-mismatch" />
+                  <VIcon
+                    v-bind="tooltipProps"
+                    :icon="mdiAlert"
+                    color="warning"
+                    size="small"
+                    class="ml-1"
+                    tabindex="0"
+                    role="img"
+                    aria-label="The device reports a different panel size than its assigned model. Check the model in Advanced."
+                    data-test-id="device-model-mismatch"
+                  />
                 </template>
               </VTooltip>
             </div>

--- a/packages/ui/src/components/ScreenFrame.vue
+++ b/packages/ui/src/components/ScreenFrame.vue
@@ -17,7 +17,7 @@ const srcdoc = computed(() => wrapInScreenShell(props.target, props.body))
   <div
     ref="container"
     class="screen-frame"
-    :style="{ maxWidth: `${target.model.width}px`, height: `${Math.round(target.model.height * scale)}px` }"
+    :style="{ width: `min(90vw, ${target.model.width}px)`, maxWidth: `min(100%, ${target.model.width}px)`, height: `${Math.round(target.model.height * scale)}px` }"
     data-test-id="screen-frame"
   >
     <iframe
@@ -27,13 +27,13 @@ const srcdoc = computed(() => wrapInScreenShell(props.target, props.body))
       :style="{ transform: `scale(${scale})` }"
       class="screen-frame__iframe"
       title="Screen preview"
+      sandbox="allow-scripts"
     />
   </div>
 </template>
 
 <style scoped>
 .screen-frame {
-  width: 100%;
   overflow: hidden;
   position: relative;
 }

--- a/packages/ui/src/components/ScreenListCard.vue
+++ b/packages/ui/src/components/ScreenListCard.vue
@@ -288,9 +288,7 @@ function previewScreen(screen: Screen) {
       </VCardText>
     </VCard>
     <VOverlay v-model="showHtmlPreview" class="align-center justify-center">
-      <div :style="{ width: `min(90vw, ${renderTarget.model.width}px)` }">
-        <ScreenFrame v-if="showHtmlPreview" :body="viewFull(overlayHtml)" :target="renderTarget" />
-      </div>
+      <ScreenFrame v-if="showHtmlPreview" :body="viewFull(overlayHtml)" :target="renderTarget" />
     </VOverlay>
 
     <VDialog v-model="showScreenPreview" :max-width="`min(90vw, ${Math.max(900, renderTarget.model.width + 48)}px)`">

--- a/packages/ui/src/components/__test__/ScreenFrame.spec.ts
+++ b/packages/ui/src/components/__test__/ScreenFrame.spec.ts
@@ -1,13 +1,18 @@
 import { mount } from '@vue/test-utils'
-import rop from 'resize-observer-polyfill'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
 import { DEFAULT_MODEL, DEFAULT_PALETTE } from '@/utils/renderTarget'
 import ScreenFrame from '../ScreenFrame.vue'
 
-globalThis.ResizeObserver = rop
+const containerWidth = ref(0)
+
+vi.mock('@vueuse/core', () => ({
+  useElementSize: () => ({ width: containerWidth, height: ref(0) }),
+}))
 
 describe('screenFrame', () => {
   it('renders the body inside the model shell at the model size', () => {
+    containerWidth.value = 0
     const model = { ...DEFAULT_MODEL, name: 'v2', width: 1872, height: 1404, cssClasses: ['screen--v2'] }
     const wrapper = mount(ScreenFrame, { props: { body: '<div class="view view--full">hi</div>', target: { model, palette: DEFAULT_PALETTE } } })
     const iframe = wrapper.find('iframe')
@@ -16,5 +21,28 @@ describe('screenFrame', () => {
     expect(iframe.attributes('srcdoc')).toContain('class="screen screen--v2 screen--2bit"')
     expect(iframe.attributes('srcdoc')).toContain('<div class="view view--full">hi</div>')
     expect(iframe.attributes('style')).toContain('transform: scale(1)')
+  })
+
+  it('sandboxes the preview iframe to scripts only', () => {
+    containerWidth.value = 0
+    const model = { ...DEFAULT_MODEL, name: 'v2', width: 1872, height: 1404, cssClasses: ['screen--v2'] }
+    const wrapper = mount(ScreenFrame, { props: { body: '<p>x</p>', target: { model, palette: DEFAULT_PALETTE } } })
+    expect(wrapper.find('iframe').attributes('sandbox')).toBe('allow-scripts')
+  })
+
+  it('scales down to fit a narrower container using Math.min(1, containerWidth / model.width)', () => {
+    containerWidth.value = 1240
+    const model = { ...DEFAULT_MODEL, name: 'v2', width: 2480, height: 1860, cssClasses: ['screen--v2'] }
+    const wrapper = mount(ScreenFrame, { props: { body: '<p>x</p>', target: { model, palette: DEFAULT_PALETTE } } })
+    expect(wrapper.find('iframe').attributes('style')).toContain('transform: scale(0.5)')
+    expect(wrapper.find('[data-test-id="screen-frame"]').attributes('style')).toContain('height: 930px')
+  })
+
+  it('does not scale up when the container is wider than the model', () => {
+    containerWidth.value = 4000
+    const model = { ...DEFAULT_MODEL, name: 'v2', width: 2480, height: 1860, cssClasses: ['screen--v2'] }
+    const wrapper = mount(ScreenFrame, { props: { body: '<p>x</p>', target: { model, palette: DEFAULT_PALETTE } } })
+    expect(wrapper.find('iframe').attributes('style')).toContain('transform: scale(1)')
+    expect(wrapper.find('[data-test-id="screen-frame"]').attributes('style')).toContain('height: 1860px')
   })
 })

--- a/packages/ui/src/utils/__test__/screenShell.spec.ts
+++ b/packages/ui/src/utils/__test__/screenShell.spec.ts
@@ -1,6 +1,10 @@
+import type { RenderTarget } from '../screenShell'
 import type { DeviceModel, Palette } from '@/types'
 import { describe, expect, it } from 'vitest'
+import { SCREEN_SHELL_FIXTURE_BODY, SCREEN_SHELL_FIXTURE_EXPECTED, SCREEN_SHELL_FIXTURE_MODEL, SCREEN_SHELL_FIXTURE_PALETTE } from '../../../../../test/fixtures/screen-shell.fixture'
 import { screenClasses, screenStyle, viewFull, wrapInScreenShell } from '../screenShell'
+
+const fixtureTarget = { model: SCREEN_SHELL_FIXTURE_MODEL, palette: SCREEN_SHELL_FIXTURE_PALETTE } as unknown as RenderTarget
 
 const V2: DeviceModel = {
   name: 'v2',
@@ -41,5 +45,11 @@ describe('screenShell', () => {
     expect(html).toContain('href="https://usetrmnl.com/css/latest/plugins.css"')
     expect(html).toContain('<body class="environment trmnl">')
     expect(html).toContain('<div class="screen screen--v2 screen--lg screen--density-2x screen--4bit" style="--screen-w: 1040px; --screen-h: 780px;"><div class="view view--full"><p>x</p></div></div>')
+  })
+
+  it('matches the cross-package golden fixture shared with the API copy', () => {
+    expect(screenClasses(fixtureTarget)).toEqual(SCREEN_SHELL_FIXTURE_EXPECTED.classes)
+    expect(screenStyle(fixtureTarget)).toBe(SCREEN_SHELL_FIXTURE_EXPECTED.style)
+    expect(wrapInScreenShell(fixtureTarget, SCREEN_SHELL_FIXTURE_BODY)).toContain(SCREEN_SHELL_FIXTURE_EXPECTED.wrappedDiv)
   })
 })

--- a/packages/ui/src/views/HtmlPreviewView.vue
+++ b/packages/ui/src/views/HtmlPreviewView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { RenderTarget } from '@/utils/screenShell'
+import { refDebounced } from '@vueuse/core'
 import { ref } from 'vue'
 import { VCol, VContainer, VRow, VTextarea } from 'vuetify/components'
 import RenderTargetPicker from '@/components/RenderTargetPicker.vue'
@@ -9,6 +10,7 @@ import { DEFAULT_MODEL, DEFAULT_PALETTE } from '@/utils/renderTarget'
 import { viewFull } from '@/utils/screenShell'
 
 const html = ref(exampleHtml)
+const debouncedHtml = refDebounced(html, 300)
 const target = ref<RenderTarget>({ model: DEFAULT_MODEL, palette: DEFAULT_PALETTE })
 </script>
 
@@ -20,7 +22,7 @@ const target = ref<RenderTarget>({ model: DEFAULT_MODEL, palette: DEFAULT_PALETT
       </VCol>
       <VCol cols="12" sm="12" md="12" lg="6">
         <RenderTargetPicker v-model="target" class="mb-3" />
-        <ScreenFrame :body="viewFull(html)" :target="target" />
+        <ScreenFrame :body="viewFull(debouncedHtml)" :target="target" />
       </VCol>
     </VRow>
   </VContainer>

--- a/test/fixtures/screen-shell.fixture.ts
+++ b/test/fixtures/screen-shell.fixture.ts
@@ -1,0 +1,31 @@
+/**
+ * Cross-package golden fixture for the screen-shell helper duplicated at
+ * `packages/api/src/device-models/screen-shell.ts` and
+ * `packages/ui/src/utils/screenShell.ts`. Both packages' spec suites assert
+ * their implementation against this same input/output pair, so the two
+ * copies failing to agree fails a test instead of silently drifting.
+ *
+ * Deliberately untyped against either package's `DeviceModel`/`Palette`
+ * entities (they live in separate TypeORM/Vue type trees) — callers cast to
+ * their own `{ model, palette }` render-target shape.
+ */
+export const SCREEN_SHELL_FIXTURE_MODEL = {
+  name: 'v2',
+  width: 1872,
+  height: 1404,
+  rotation: 90,
+  cssClasses: ['screen--v2', 'screen--lg', 'screen--density-2x'],
+  cssVariables: { '--screen-w': '1040px', '--screen-h': '780px' },
+}
+
+export const SCREEN_SHELL_FIXTURE_PALETTE = {
+  frameworkClass: 'screen--4bit',
+}
+
+export const SCREEN_SHELL_FIXTURE_BODY = '<div class="view view--full"><p>x</p></div>'
+
+export const SCREEN_SHELL_FIXTURE_EXPECTED = {
+  classes: ['screen', 'screen--v2', 'screen--lg', 'screen--density-2x', 'screen--4bit'],
+  style: '--screen-w: 1040px; --screen-h: 780px;',
+  wrappedDiv: '<div class="screen screen--v2 screen--lg screen--density-2x screen--4bit" style="--screen-w: 1040px; --screen-h: 780px;"><div class="view view--full"><p>x</p></div></div>',
+}


### PR DESCRIPTION
## Summary
Closes #757 — a grab-bag of small, independent follow-ups from the #739/#740/#742 device-model support review:

- `ScreenFrame.vue`: sandbox the preview `srcdoc` iframe (`sandbox="allow-scripts"`) — previews now run same-origin plugin/user HTML in an opaque-origin sandbox instead of the admin UI's origin.
- `DeviceInformationCard.vue`: the model-mismatch warning `VIcon` is now keyboard-focusable (`tabindex="0"`) and has an `aria-label`/`role="img"`, instead of being hover-only with no accessible name.
- `ScreenFrame.spec.ts`: stubs `useElementSize` so the test exercises the real `Math.min(1, containerWidth / model.width)` scale and container height, instead of only ever hitting the `containerWidth === 0` fallback path.
- `AddScreenCard.vue` / `ScreenListCard.vue`: the duplicated `<div :style="{ width: min(90vw, model.width) }">` wrapper around `ScreenFrame` is gone — `ScreenFrame` now sizes itself (capped by `max-width: min(100%, model.width)` so it still shrinks correctly inside a narrower grid column, verified live against `/htmlPreview`).
- `HtmlPreviewView.vue`: the `srcdoc` recompute is now debounced 300ms (`refDebounced`) instead of re-fetching `plugins.css` on every keystroke.
- `screens.service.ts` (`reconvertImageScreens`) / `display.service.ts`: `tmp-<screenId>.png` / `tmp-source` are now cleaned up when image conversion fails, instead of being left on disk.
- `devices.service.ts`: sending a `paletteId` for a device with no assigned `deviceModel` now 400s instead of being silently ignored.
- New `test/fixtures/screen-shell.fixture.ts`: a cross-package golden fixture both `packages/api/src/device-models/__test__/screen-shell.spec.ts` and `packages/ui/src/utils/__test__/screenShell.spec.ts` assert against, so the two duplicated `screen-shell` implementations drifting apart fails a test.

## Test plan
- [x] `pnpm run -r test` — 429 API + 97 UI tests passing
- [x] `pnpm run -r type-check` and `pnpm run -r lint` clean
- [x] Live-checked `/htmlPreview` in a headless browser against the Vite dev server (API calls stubbed): sandboxed iframe, correct `min(90vw, model.width)` sizing that still clamps to a narrower grid column, and the 300ms debounce (no re-render immediately after typing, re-renders ~500ms later)

https://claude.ai/code/session_01EJi8JqVCUMrVyQdGdibAwy