### PR TITLE
fix(ui): let card title action buttons wrap instead of overflowing on mobile

### DIFF
--- a/packages/ui/src/components/DeviceInformationCard.vue
+++ b/packages/ui/src/components/DeviceInformationCard.vue
@@ -289,7 +289,7 @@ const nameEditing = ref(false)
 <template>
   <template v-if="device">
     <VCard class="mb-6" elevation="1">
-      <VCardTitle class="d-flex align-center justify-space-between">
+      <VCardTitle class="d-flex align-center justify-space-between flex-wrap ga-2">
         <div v-if="!nameEditing">
           <span data-test-id="device-name">{{ device.name }}</span>
           <v-icon-btn :icon="mdiPencil" size="x-small" class="ml-2" aria-label="Edit device name" variant="text" @click="nameEditing = true" />

--- a/packages/ui/src/components/DeviceLogsCard.vue
+++ b/packages/ui/src/components/DeviceLogsCard.vue
@@ -71,7 +71,7 @@ function getSeverityIcon(severity: string) {
 <template>
   <template v-if="device">
     <VCard elevation="1">
-      <VCardTitle class="d-flex align-center">
+      <VCardTitle class="d-flex align-center flex-wrap ga-2">
         Logs
         <VSpacer />
         <VBtn

--- a/packages/ui/src/components/PluginCard.vue
+++ b/packages/ui/src/components/PluginCard.vue
@@ -85,7 +85,7 @@ function onAssigned() {
     <VSnackbar v-model="showExportSnackbar" :timeout="3000" color="success">
       Downloading plugin export...
     </VSnackbar>
-    <VCardTitle class="d-flex align-center justify-space-between">
+    <VCardTitle class="d-flex align-center justify-space-between flex-wrap ga-2">
       <span>{{ plugin.name }}</span>
       <div class="d-flex ga-2">
         <VChip

--- a/packages/ui/src/views/MaintenanceView.vue
+++ b/packages/ui/src/views/MaintenanceView.vue
@@ -182,7 +182,7 @@ async function executeCleanup() {
     <VRow justify="center">
       <VCol cols="12">
         <VCard elevation="1" class="mb-4">
-          <VCardTitle class="d-flex align-center justify-space-between">
+          <VCardTitle class="d-flex align-center justify-space-between flex-wrap ga-2">
             Maintenance Dashboard
             <VBtn
               :prepend-icon="mdiRefresh"
@@ -203,7 +203,7 @@ async function executeCleanup() {
         </VCard>
 
         <VCard elevation="1" class="mb-4" data-test-id="device-models-card">
-          <VCardTitle class="d-flex align-center justify-space-between">
+          <VCardTitle class="d-flex align-center justify-space-between flex-wrap ga-2">
             Device Models
             <VBtn
               :prepend-icon="mdiCloudSync"
@@ -352,7 +352,7 @@ async function executeCleanup() {
           </VCard>
 
           <VCard v-if="maintenanceStore.issues.orphanedScreenFiles.length > 0" elevation="1" class="mb-4">
-            <VCardTitle class="d-flex align-center justify-space-between">
+            <VCardTitle class="d-flex align-center justify-space-between flex-wrap ga-2">
               Orphaned Screen Files
               <VBtn
                 size="small"
@@ -388,7 +388,7 @@ async function executeCleanup() {
           </VCard>
 
           <VCard v-if="maintenanceStore.issues.orphanedDeviceDirs.length > 0" elevation="1" class="mb-4">
-            <VCardTitle class="d-flex align-center justify-space-between">
+            <VCardTitle class="d-flex align-center justify-space-between flex-wrap ga-2">
               Orphaned Device Directories
               <VBtn
                 size="small"
@@ -424,7 +424,7 @@ async function executeCleanup() {
           </VCard>
 
           <VCard v-if="maintenanceStore.issues.brokenScreens.length > 0" elevation="1" class="mb-4">
-            <VCardTitle class="d-flex align-center justify-space-between">
+            <VCardTitle class="d-flex align-center justify-space-between flex-wrap ga-2">
               Broken Screens (Missing Files)
               <VBtn
                 size="small"
@@ -462,7 +462,7 @@ async function executeCleanup() {
           </VCard>
 
           <VCard v-if="maintenanceStore.issues.tempFiles.length > 0" elevation="1" class="mb-4">
-            <VCardTitle class="d-flex align-center justify-space-between">
+            <VCardTitle class="d-flex align-center justify-space-between flex-wrap ga-2">
               Temporary Files
               <VBtn
                 size="small"
@@ -500,7 +500,7 @@ async function executeCleanup() {
           </VCard>
 
           <VCard v-if="maintenanceStore.issues.oldUploads.length > 0" elevation="1" class="mb-4">
-            <VCardTitle class="d-flex align-center justify-space-between">
+            <VCardTitle class="d-flex align-center justify-space-between flex-wrap ga-2">
               Old Upload Files
               <VBtn
                 size="small"

--- a/packages/ui/src/views/OverviewView.vue
+++ b/packages/ui/src/views/OverviewView.vue
@@ -71,7 +71,7 @@ async function update() {
     <VRow justify="center">
       <VCol cols="12" sm="12">
         <VCard class="mb-6" elevation="1">
-          <VCardTitle class="d-flex align-center justify-space-between">
+          <VCardTitle class="d-flex align-center justify-space-between flex-wrap ga-2">
             Add Device
             <VIconBtn :icon="mdiSync" variant="tonal" color="secondary" aria-label="Refresh device list" :disabled="loadingUpdate" @click="update()" />
           </VCardTitle>

--- a/packages/ui/src/views/PluginsOverviewView.vue
+++ b/packages/ui/src/views/PluginsOverviewView.vue
@@ -48,7 +48,7 @@ function onPluginImported() {
     <VRow justify="center">
       <VCol cols="12">
         <VCard elevation="1">
-          <VCardTitle class="d-flex align-center justify-space-between">
+          <VCardTitle class="d-flex align-center justify-space-between flex-wrap ga-2">
             <span>All Plugins</span>
             <div class="d-flex ga-2">
               <VIconBtn

--- a/packages/ui/src/views/PluginsView.vue
+++ b/packages/ui/src/views/PluginsView.vue
@@ -41,7 +41,7 @@ function createPlugin() {
     <VRow justify="center">
       <VCol cols="12">
         <VCard elevation="1">
-          <VCardTitle class="d-flex align-center justify-space-between">
+          <VCardTitle class="d-flex align-center justify-space-between flex-wrap ga-2">
             <div>
               <span>Plugins for </span>
               <span class="font-weight-bold">{{ device?.name }}</span>


### PR DESCRIPTION
## Summary
Closes #733 — several `VCardTitle` rows used `d-flex align-center justify-space-between` (or `d-flex align-center` + `VSpacer`) with a button group and no `flex-wrap`. On narrow viewports the title text kept its intrinsic width and pushed the action buttons past the card's right edge, where they were clipped and untappable — breaking adding a plugin, creating a plugin, deleting a device, and clearing logs on mobile.

- Added `flex-wrap ga-2` to every `VCardTitle` in `packages/ui/src` using this row pattern, so overflowing buttons drop to a second line instead of clipping. Covers all 4 locations named in the issue (`PluginsView.vue`, `PluginsOverviewView.vue`, `DeviceInformationCard.vue`, `MaintenanceView.vue` — 6 title rows there) plus the explicitly-noted "Clear Logs" card (`DeviceLogsCard.vue`), and two more sites with the identical unwrapped pattern (`OverviewView.vue`, `PluginCard.vue`) to close out the systemic bug rather than leave the same defect at other call sites.
- `flex-wrap`/`ga-2` are existing Vuetify utility classes already used elsewhere in this codebase (e.g. `PluginCard.vue`'s `VCardActions`), so this follows established convention rather than introducing a new one.

## Test plan
- [x] `vue-tsc --noEmit` (via `pnpm run -r type-check`, ran automatically on commit)
- [x] `vitest run` — full `packages/ui` suite (97 tests) passes
- [ ] Manual verification in a real browser at narrow viewports — no browser/Playwright tooling available in this environment, so this is unverified beyond code/CSS inspection; recommend a quick check at 375px before merge

Note: a very long title string can still clip on its own wrapped line (Vuetify's `.v-card-title` keeps `white-space: nowrap`/`overflow: hidden`), but that's the pre-existing title-truncation issue tracked separately in #737, not the button-unreachability bug this closes.

https://claude.ai/code/session_01EJi8JqVCUMrVyQdGdibAwy