### PR TITLE
fix(device-models): render fallback screens natively per model instead of upscaling PNGs

### DIFF
--- a/packages/api/src/device-models/__test__/fallback-screens.service.spec.ts
+++ b/packages/api/src/device-models/__test__/fallback-screens.service.spec.ts
@@ -1,18 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { FALLBACK_SCREEN_TEMPLATE_VERSION } from '../fallback-screen-templates'
 import { FallbackScreensService } from '../fallback-screens.service'
 import { GRAY_16, V2 } from './mockDeviceModelsService'
 
-const { statMock, mkdirMock, convertToPng } = vi.hoisted(() => ({
+const { statMock, renderHtmlToPng } = vi.hoisted(() => ({
   statMock: vi.fn(),
-  mkdirMock: vi.fn(),
-  convertToPng: vi.fn(),
+  renderHtmlToPng: vi.fn(),
 }))
 
 vi.mock('node:fs', () => ({
-  promises: { stat: statMock, mkdir: mkdirMock },
+  promises: { stat: statMock },
 }))
 
-vi.mock('../../utils/imageUtils', () => ({ convertToPng }))
+vi.mock('../render-html-to-png', () => ({ renderHtmlToPng }))
 
 vi.mock('../../utils/pathHelper', () => ({
   resolveAppPath: (...segments: string[]) => `/app/${segments.join('/')}`,
@@ -21,6 +21,7 @@ vi.mock('../../utils/pathHelper', () => ({
 describe('fallbackScreensService', () => {
   let service: FallbackScreensService
   const target = { model: V2, palette: GRAY_16 }
+  const cacheDir = `/app/public/screens/fallback/v${FALLBACK_SCREEN_TEMPLATE_VERSION}/v2-gray-16`
 
   beforeEach(() => {
     vi.resetAllMocks()
@@ -29,36 +30,26 @@ describe('fallbackScreensService', () => {
 
   it('generates the placeholder for the target when it does not exist yet', async () => {
     statMock.mockRejectedValue(new Error('ENOENT'))
-    convertToPng.mockResolvedValue(undefined)
+    renderHtmlToPng.mockResolvedValue(undefined)
 
     const url = await service.urlFor('noScreen', target)
 
-    expect(mkdirMock).toHaveBeenCalledWith('/app/public/screens/fallback/v2-gray-16', { recursive: true })
-    expect(convertToPng).toHaveBeenCalledWith('/app/public/screens/noScreen.png', '/app/public/screens/fallback/v2-gray-16/noScreen.png', target, expect.any(Object))
-    expect(url).toBe('http://api/screens/fallback/v2-gray-16/noScreen.png')
+    expect(renderHtmlToPng).toHaveBeenCalledWith(expect.any(String), target, `${cacheDir}/noScreen.png`, expect.any(Object))
+    expect(url).toBe(`http://api/screens/fallback/v${FALLBACK_SCREEN_TEMPLATE_VERSION}/v2-gray-16/noScreen.png`)
   })
 
-  it('reuses an existing placeholder that is newer than the source image', async () => {
-    statMock.mockImplementation(async (p: string) => ({ mtimeMs: p.endsWith('/error.png') && !p.includes('fallback') ? 100 : 200 }))
+  it('reuses an existing cached placeholder', async () => {
+    statMock.mockResolvedValue({})
 
     const url = await service.urlFor('error', target)
 
-    expect(convertToPng).not.toHaveBeenCalled()
-    expect(url).toBe('http://api/screens/fallback/v2-gray-16/error.png')
+    expect(renderHtmlToPng).not.toHaveBeenCalled()
+    expect(url).toBe(`http://api/screens/fallback/v${FALLBACK_SCREEN_TEMPLATE_VERSION}/v2-gray-16/error.png`)
   })
 
-  it('regenerates when the source image is newer than the cached placeholder', async () => {
-    statMock.mockImplementation(async (p: string) => ({ mtimeMs: p.includes('fallback') ? 100 : 200 }))
-    convertToPng.mockResolvedValue(undefined)
-
-    await service.urlFor('welcome', target)
-
-    expect(convertToPng).toHaveBeenCalled()
-  })
-
-  it('falls back to the static image when conversion fails', async () => {
+  it('falls back to the static image when rendering fails', async () => {
     statMock.mockRejectedValue(new Error('ENOENT'))
-    convertToPng.mockRejectedValue(new Error('magick exploded'))
+    renderHtmlToPng.mockRejectedValue(new Error('puppeteer exploded'))
 
     await expect(service.urlFor('error', target)).resolves.toBe('http://api/screens/error.png')
   })

--- a/packages/api/src/device-models/fallback-screen-templates.ts
+++ b/packages/api/src/device-models/fallback-screen-templates.ts
@@ -1,0 +1,72 @@
+import type { FallbackScreenKind } from './fallback-screens.service'
+
+/**
+ * Bump whenever the markup below changes so cached renders regenerate. Baked
+ * into the cache path in fallback-screens.service.ts rather than compared via
+ * mtime, since the template lives in compiled JS with no source file to stat.
+ */
+export const FALLBACK_SCREEN_TEMPLATE_VERSION = 1
+
+const CAPTIONS: Record<FallbackScreenKind, string> = {
+  noScreen: 'Empty screen',
+  error: 'Error',
+  welcome: 'Setup in progress',
+}
+
+// Traced from the legacy public/screens/*.png artwork with potrace so the
+// mark stays crisp at any model size instead of being raster-upscaled.
+const ICON_SVG = `<svg viewBox="0 0 303.012687 238.034166" xmlns="http://www.w3.org/2000/svg">
+<g transform="translate(-2.490556,239.968341) scale(0.100000,-0.100000)" fill="#000000" stroke="none">
+<path d="M192 2381 c-31 -11 -70 -35 -94 -57 -79 -77 -73 10 -73 -1105 l0
+-995 24 -48 c45 -86 98 -125 199 -145 84 -17 2518 -14 2598 3 73 15 126 46
+157 89 55 76 52 11 52 1092 l0 1001 -25 49 c-30 59 -97 110 -163 125 -32 7
+-478 10 -1335 10 -1223 -1 -1290 -2 -1340 -19z m2605 -89 c82 -9 118 -29 145
+-83 16 -31 17 -110 18 -990 0 -1031 2 -997 -52 -1045 -12 -12 -33 -27 -45 -33
+-16 -8 -379 -11 -1326 -11 l-1304 0 -34 23 c-19 12 -43 40 -54 62 -20 39 -20
+60 -20 1000 0 901 1 962 18 995 26 52 61 73 136 80 90 10 2428 11 2518 2z"/>
+<path d="M350 2140 c-19 -5 -45 -20 -57 -35 l-23 -26 0 -864 0 -865 29 -32 29
+-33 606 -3 606 -3 0 936 0 935 -577 -1 c-318 -1 -594 -5 -613 -9z m930 -680
+l0 -220 -155 0 -155 0 0 -35 0 -35 175 0 175 0 0 -50 0 -50 -175 0 -175 0 0
+-25 0 -25 200 0 200 0 0 -50 0 -50 -466 0 -465 0 3 48 3 47 198 3 197 2 0 25
+0 25 -175 0 -175 0 0 50 0 50 173 2 172 3 3 27 3 27 -163 3 -163 3 -3 203 c-1
+128 1 210 8 222 10 19 23 20 385 20 l375 0 0 -220z m-36 -584 c14 -19 32 -40
+39 -48 7 -7 22 -27 34 -44 20 -28 21 -33 7 -52 -17 -24 -74 -58 -74 -44 0 5
+-27 44 -61 86 -34 42 -59 82 -56 89 4 12 62 46 78 47 4 0 18 -15 33 -34z
+m-609 2 c19 -13 35 -25 35 -29 0 -3 -22 -32 -49 -66 -27 -33 -54 -70 -60 -82
+l-12 -21 -39 26 c-21 14 -41 32 -44 40 -8 21 97 154 121 154 7 0 29 -10 48
+-22z m422 -53 c31 -99 30 -113 -11 -120 -61 -12 -77 -4 -92 45 -8 25 -19 59
+-24 76 -15 45 -13 54 13 54 12 0 29 5 37 10 35 23 54 7 77 -65z m-209 -37 l3
+-88 -61 0 -60 0 0 90 0 91 58 -3 57 -3 3 -87z"/>
+<path d="M640 1550 l0 -41 98 3 97 3 0 35 0 35 -97 3 -98 3 0 -41z"/>
+<path d="M967 1584 c-4 -4 -7 -22 -7 -41 l0 -33 101 0 100 0 -3 38 -3 37 -90
+3 c-50 1 -94 0 -98 -4z"/>
+<path d="M640 1370 l0 -41 98 3 97 3 0 35 0 35 -97 3 -98 3 0 -41z"/>
+<path d="M964 1395 c-3 -8 -3 -26 0 -40 6 -24 8 -25 102 -25 l95 0 -3 38 -3
+37 -93 3 c-76 2 -93 0 -98 -13z"/>
+<path d="M2133 1738 c-4 -7 -21 -40 -38 -73 -35 -71 -39 -72 -197 -74 l-108
+-1 0 -445 0 -445 55 0 c50 0 55 2 61 25 l6 25 294 0 294 0 0 -25 c0 -24 3 -25
+60 -25 l60 0 2 420 c1 231 2 428 2 437 1 9 -13 25 -30 35 -25 15 -37 16 -58 8
+-37 -14 -326 -13 -326 0 0 6 9 28 20 50 30 58 27 67 -32 85 -62 18 -55 18 -65
+3z m355 -280 c8 -8 12 -48 12 -115 l0 -103 -295 0 -295 0 0 108 c0 60 3 112 7
+115 3 4 131 7 283 7 201 0 279 -3 288 -12z m12 -463 l0 -115 -285 0 c-157 0
+-288 0 -292 0 -5 0 -9 52 -11 115 l-3 115 296 0 295 0 0 -115z"/>
+</g>
+</svg>`
+
+/**
+ * Body markup for a fallback screen: the kuroshiro mark plus a caption,
+ * sized relative to the `.screen`/`.view--full` box (percentages, not
+ * vw/vh) since plugins.css lays that box out in design pixels and scales it
+ * with a CSS transform rather than the physical viewport.
+ */
+export function fallbackScreenBody(kind: FallbackScreenKind): string {
+  return `<style>
+  .fallback-screen { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 4%; width: 100%; height: 100%; background: #fff; box-sizing: border-box; }
+  .fallback-screen svg { width: 40%; height: auto; }
+  .fallback-screen span { font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace; font-weight: 700; font-size: calc(var(--screen-w, 100%) / 13); letter-spacing: 0.02em; color: #000; }
+  </style>
+  <div class="fallback-screen">
+    ${ICON_SVG}
+    <span>${CAPTIONS[kind]}</span>
+  </div>`
+}

--- a/packages/api/src/device-models/fallback-screens.service.ts
+++ b/packages/api/src/device-models/fallback-screens.service.ts
@@ -1,17 +1,19 @@
 import type { DeviceRenderTarget } from './device-models.service'
 import * as fs from 'node:fs'
-import * as path from 'node:path'
 import { Injectable, Logger } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
-import { convertToPng } from '../utils/imageUtils'
 import { resolveAppPath } from '../utils/pathHelper'
+import { FALLBACK_SCREEN_TEMPLATE_VERSION, fallbackScreenBody } from './fallback-screen-templates'
+import { renderHtmlToPng } from './render-html-to-png'
+import { viewFull, wrapInScreenShell } from './screen-shell'
 
 export type FallbackScreenKind = 'noScreen' | 'error' | 'welcome'
 
 /**
- * Serves the built-in placeholder screens (no screen, error, welcome) converted
- * for a render target, generated on first use and cached under
- * `public/screens/fallback/<model>-<palette>/`.
+ * Serves the built-in placeholder screens (no screen, error, welcome), rendered
+ * natively at a render target's model size through the same puppeteer shell
+ * regular screens use, generated on first use and cached under
+ * `public/screens/fallback/v<template version>/<model>-<palette>/`.
  */
 @Injectable()
 export class FallbackScreensService {
@@ -20,13 +22,12 @@ export class FallbackScreensService {
   constructor(private readonly configService: ConfigService) {}
 
   async urlFor(kind: FallbackScreenKind, target: DeviceRenderTarget): Promise<string> {
-    const relativePath = ['screens', 'fallback', `${target.model.name}-${target.palette.id}`, `${kind}.png`]
-    const sourcePath = resolveAppPath('public', 'screens', `${kind}.png`)
+    const relativePath = ['screens', 'fallback', `v${FALLBACK_SCREEN_TEMPLATE_VERSION}`, `${target.model.name}-${target.palette.id}`, `${kind}.png`]
     const outputPath = resolveAppPath('public', ...relativePath)
     try {
-      if (await this.isStale(sourcePath, outputPath)) {
-        await fs.promises.mkdir(path.dirname(outputPath), { recursive: true })
-        await convertToPng(sourcePath, outputPath, target, this.logger)
+      if (await this.isStale(outputPath)) {
+        const html = wrapInScreenShell(target, viewFull(fallbackScreenBody(kind)))
+        await renderHtmlToPng(html, target, outputPath, this.logger)
       }
       return `${this.apiUrl()}/${relativePath.join('/')}`
     }
@@ -36,10 +37,10 @@ export class FallbackScreensService {
     }
   }
 
-  private async isStale(sourcePath: string, outputPath: string): Promise<boolean> {
+  private async isStale(outputPath: string): Promise<boolean> {
     try {
-      const [source, output] = await Promise.all([fs.promises.stat(sourcePath), fs.promises.stat(outputPath)])
-      return source.mtimeMs > output.mtimeMs
+      await fs.promises.stat(outputPath)
+      return false
     }
     catch {
       return true

--- a/packages/api/src/device-models/render-html-to-png.ts
+++ b/packages/api/src/device-models/render-html-to-png.ts
@@ -1,0 +1,35 @@
+import type { Logger } from '@nestjs/common'
+import type { DeviceRenderTarget } from './device-models.service'
+import buffer from 'node:buffer'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import puppeteer from 'puppeteer'
+import { convertToPng } from '../utils/imageUtils'
+
+/**
+ * Screenshots an already-shelled HTML document at the render target's native
+ * pixel size and converts the screenshot to the target's PNG at `outputPath`.
+ */
+export async function renderHtmlToPng(html: string, target: DeviceRenderTarget, outputPath: string, logger: Logger): Promise<void> {
+  const browser = await puppeteer.launch({ args: ['--no-sandbox', '--disable-web-security'] })
+  const tmpPath = `${outputPath}.tmp-source`
+  try {
+    const page = await browser.newPage()
+    await page.setViewport({ width: target.model.width, height: target.model.height })
+    await page.setContent(html, { waitUntil: 'load' })
+    const image: Uint8Array = await page.screenshot()
+
+    await fs.promises.mkdir(path.dirname(outputPath), { recursive: true })
+    await fs.promises.writeFile(tmpPath, buffer.Buffer.from(image))
+    await convertToPng(tmpPath, outputPath, target, logger)
+  }
+  finally {
+    await browser.close()
+    try {
+      await fs.promises.unlink(tmpPath)
+    }
+    catch {
+      // best-effort cleanup
+    }
+  }
+}

--- a/packages/api/src/devices/display.service.ts
+++ b/packages/api/src/devices/display.service.ts
@@ -1,16 +1,15 @@
 import type { MashupRendererService } from '../mashup/services/mashup-renderer.service'
 import type { Plugin } from '../plugins/entities/plugin.entity'
 import type { DisplayRequestHeadersDto } from './dto/display-request-headers.dto'
-import buffer from 'node:buffer'
 import * as fs from 'node:fs'
 import * as path from 'node:path'
 import { Injectable, Logger, NotFoundException, UnauthorizedException } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import { InjectRepository } from '@nestjs/typeorm'
-import puppeteer from 'puppeteer'
 import { Repository } from 'typeorm'
 import { DeviceModelsService } from '../device-models/device-models.service'
 import { FallbackScreensService } from '../device-models/fallback-screens.service'
+import { renderHtmlToPng } from '../device-models/render-html-to-png'
 import { viewFull, wrapInScreenShell } from '../device-models/screen-shell'
 import { PluginDataFetcherService } from '../plugins/services/plugin-data-fetcher.service'
 import { PluginRendererService } from '../plugins/services/plugin-renderer.service'
@@ -431,29 +430,8 @@ export class DeviceDisplayService {
    */
   private async renderBodyToScreenPng(bodyHtml: string, screen: Screen, device: Device): Promise<string> {
     const target = await this.deviceModels.renderTargetFor(device)
-    const browser = await puppeteer.launch({ args: ['--no-sandbox', '--disable-web-security'] })
-    const destDir = resolveAppPath('public', 'screens', 'devices', device.id)
-    const inputPath = path.join(destDir, 'tmp-source')
-    try {
-      const page = await browser.newPage()
-      await page.setViewport({ width: target.model.width, height: target.model.height })
-      await page.setContent(wrapInScreenShell(target, bodyHtml), { waitUntil: 'load' })
-      const image: Uint8Array = await page.screenshot()
-
-      await fs.promises.mkdir(destDir, { recursive: true })
-      await fs.promises.writeFile(inputPath, buffer.Buffer.from(image))
-      await convertToPng(inputPath, this.screenImagePath(device, screen), target, this.logger)
-      return this.screenImageUrl(device, screen)
-    }
-    finally {
-      await browser.close()
-      try {
-        await fs.promises.unlink(inputPath)
-      }
-      catch {
-        // best-effort cleanup
-      }
-    }
+    await renderHtmlToPng(wrapInScreenShell(target, bodyHtml), target, this.screenImagePath(device, screen), this.logger)
+    return this.screenImageUrl(device, screen)
   }
 
   private async cachePluginOutput(screen: Screen, renderedHtml: string): Promise<void> {


### PR DESCRIPTION
## Summary
- `FallbackScreensService` now renders `noScreen`/`error`/`welcome` through the same puppeteer + `wrapInScreenShell` pipeline regular screens use, screenshotting at the render target's native `model.width x model.height` instead of ImageMagick-upscaling the static 800x480 PNGs (blurry ~2.3x on a TRMNL X).
- The kuroshiro mark is vector-traced (potrace) from the original PNG artwork and embedded as inline SVG so it stays crisp at any model size; caption text is sized off the injected `--screen-w` CSS variable rather than `vw`/`vh`, since `plugins.css` lays the `.screen` box out in design pixels and scales it up with a CSS transform (confirmed against `screen-shell.ts` / the mock device fixtures — `vw`/`vh` would resolve against the physical viewport and overflow ~1.8x on `v2`).
- Extracted the puppeteer-screenshot → `convertToPng` steps shared with `DeviceDisplayService` into `renderHtmlToPng`.
- The static PNGs remain the last-resort fallback when rendering fails (unchanged `catch` branch); UI references to `/screens/noScreen.png` etc. are untouched.
- Cache path now carries a template version (`fallback/v1/<model>-<palette>/<kind>.png`) instead of comparing mtimes, since the template lives in compiled JS with no source file to stat.

Closes #755

## Test plan
- [x] `pnpm --filter ./packages/api exec vitest run` — 462 passed, 5 skipped
- [x] `pnpm --filter ./packages/api exec eslint` on changed files — clean
- [x] `pnpm --filter ./packages/api run build` — succeeds
- [x] Manually rendered `noScreen`/`error`/`welcome` through the real puppeteer+ImageMagick pipeline at both `og_plus` (800x480) and `v2` (1872x1404) sizes and visually confirmed crisp, non-upscaled output

https://claude.ai/code/session_01EJi8JqVCUMrVyQdGdibAwy