### PR TITLE
fix(ui): keep battery voltage and RSSI legible on Overview at narrow widths

### DIFF
--- a/packages/ui/src/views/OverviewView.vue
+++ b/packages/ui/src/views/OverviewView.vue
@@ -117,20 +117,26 @@ async function update() {
                 :key="device.id"
                 :to="{ name: 'device', params: { id: device.id } }"
                 link
+                lines="two"
                 class="mb-2"
               >
                 <VListItemTitle>
                   <span class="font-weight-bold">{{ device.name }}</span>
                   <span class="text-medium-emphasis ms-2">({{ device.mac }})</span>
                 </VListItemTitle>
-                <VListItemSubtitle>
+                <VListItemSubtitle style="display: flex; flex-direction: column;">
                   <span><b>Battery Voltage:</b> {{ device.batteryVoltage || 'N/A' }}</span>
-                  <span class="ms-4"><b>RSSI:</b> {{ device.rssi || 'N/A' }}</span>
+                  <span><b>RSSI:</b> {{ device.rssi || 'N/A' }}</span>
                 </VListItemSubtitle>
                 <template #append>
-                  <VBtn color="error" variant="tonal" :prepend-icon="mdiDelete" :loading="loadingDelete.find(currentId => currentId === device.id)" @click.prevent="deleteDevice(device.id)">
-                    Delete
-                  </VBtn>
+                  <VBtn
+                    color="error"
+                    variant="tonal"
+                    :icon="mdiDelete"
+                    aria-label="Delete device"
+                    :loading="loadingDelete.find(currentId => currentId === device.id)"
+                    @click.prevent="deleteDevice(device.id)"
+                  />
                 </template>
               </VListItem>
             </VList>

--- a/packages/ui/src/views/__test__/OverviewView.spec.ts
+++ b/packages/ui/src/views/__test__/OverviewView.spec.ts
@@ -1,10 +1,14 @@
 import { flushPromises, mount } from '@vue/test-utils'
 import { createPinia } from 'pinia'
+import rop from 'resize-observer-polyfill'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import vuetify from '../../plugins/vuetify'
 import OverviewView from '../OverviewView.vue'
 
+globalThis.ResizeObserver = rop
+
 // Mock the device store
+const { deleteDeviceMock } = vi.hoisted(() => ({ deleteDeviceMock: vi.fn() }))
 vi.mock('../../stores/device', () => {
   const devices = [
     { id: '1', friendlyId: 'Test Device', mac: 'AA:BB:CC:DD:EE:FF', apikey: 'key', mirrorEnabled: false, mirrorMac: '', mirrorApikey: '', specialFunction: '', batteryVoltage: '3.7', rssi: '-70' },
@@ -15,7 +19,7 @@ vi.mock('../../stores/device', () => {
       devices,
       fetchDevices: vi.fn(),
       addDevice: vi.fn(),
-      deleteDevice: vi.fn(),
+      deleteDevice: deleteDeviceMock,
       getById: vi.fn(),
       updateDevice: vi.fn(),
     }),
@@ -25,6 +29,7 @@ vi.mock('../../stores/device', () => {
 describe('overviewView', () => {
   let wrapper: ReturnType<typeof mount>
   beforeEach(() => {
+    deleteDeviceMock.mockClear()
     wrapper = mount(OverviewView, {
       global: {
         plugins: [createPinia(), vuetify],
@@ -47,6 +52,13 @@ describe('overviewView', () => {
     const deleteBtns = wrapper.findAll('button')
     const found = deleteBtns.some(btn => btn.attributes('aria-label')?.toLowerCase() === 'delete device')
     expect(found).toBe(true)
+  })
+
+  it('calls deleteDevice with the device id when the delete button is clicked', async () => {
+    const deleteBtn = wrapper.findAll('button').find(btn => btn.attributes('aria-label')?.toLowerCase() === 'delete device')
+    expect(deleteBtn).toBeDefined()
+    await deleteBtn?.trigger('click')
+    expect(deleteDeviceMock).toHaveBeenCalledWith('1')
   })
 
   it('keeps battery voltage and rssi on their own lines so both stay legible on narrow screens', () => {

--- a/packages/ui/src/views/__test__/OverviewView.spec.ts
+++ b/packages/ui/src/views/__test__/OverviewView.spec.ts
@@ -44,10 +44,18 @@ describe('overviewView', () => {
   })
 
   it('shows device details and delete button', () => {
-    // Find a button with text 'Delete'
     const deleteBtns = wrapper.findAll('button')
-    const found = deleteBtns.some(btn => btn.text().toLowerCase().includes('delete'))
+    const found = deleteBtns.some(btn => btn.attributes('aria-label')?.toLowerCase() === 'delete device')
     expect(found).toBe(true)
+  })
+
+  it('keeps battery voltage and rssi on their own lines so both stay legible on narrow screens', () => {
+    const subtitle = wrapper.find('.v-list-item-subtitle')
+    expect(subtitle.exists()).toBe(true)
+    const lines = subtitle.findAll('span')
+    expect(lines).toHaveLength(2)
+    expect(lines[0]?.text()).toContain('Battery Voltage:')
+    expect(lines[1]?.text()).toContain('RSSI:')
   })
 
   it('renders the add device form', () => {


### PR DESCRIPTION
## Summary
- The Overview device list's `VListItemSubtitle` clamped to a single line while the "Delete" button ate most of the row's width, so at 375px both battery voltage and RSSI were invisible behind an ellipsis (`Battery Voltage:…`).
- Stacks battery voltage and RSSI onto their own lines: `lines="two"` on `VListItem` plus an explicit `style="display: flex; flex-direction: column;"` on the subtitle (a `d-flex`/`flex-column` utility class would sit at equal CSS specificity against Vuetify's own `.v-list-item-subtitle { display: -webkit-box }` rule, making the winner load-order dependent — an inline style always wins the cascade).
- Shrinks the Delete button to icon-only (`aria-label="Delete device"`) to free up row width, matching the per-row delete pattern already used in `ScreenListCard.vue`.

## Test plan
- [x] `pnpm run lint` on changed files
- [x] `pnpm run type-check` (vue-tsc)
- [x] `pnpm run test` — full UI suite (98/98 passing), including a new spec asserting battery voltage and RSSI render as two separate lines
- [x] Reviewed via `/code-review` (Standards + Spec sub-agents) — no hard violations; addressed the CSS-specificity risk the Spec review flagged

Closes #737

https://claude.ai/code/session_01EJi8JqVCUMrVyQdGdibAwy