### PR TITLE
fix(ui): hide the tab strip on mobile and add Plugins to the nav drawer

### DIFF
--- a/packages/ui/src/App.vue
+++ b/packages/ui/src/App.vue
@@ -4,7 +4,7 @@ import { mdiThemeLightDark } from '@mdi/js'
 import { usePreferredDark } from '@vueuse/core'
 import { onMounted, ref, toRaw, watch } from 'vue'
 import { RouterView, useRoute } from 'vue-router'
-import { useTheme } from 'vuetify'
+import { useDisplay, useTheme } from 'vuetify'
 
 import NavigationDrawer from '@/components/NavigationDrawer.vue'
 import { useDemoInfo } from '@/composeables/useDemoInfo.ts'
@@ -13,6 +13,7 @@ import packageJson from '../../../package.json'
 const isDark = usePreferredDark()
 
 const theme = useTheme()
+const { mobile } = useDisplay()
 
 onMounted(() => {
   theme.global.name.value = isDark.value ? 'dark' : 'light'
@@ -68,6 +69,7 @@ const { isDemo } = useDemoInfo()
         </v-btn>
       </v-app-bar-title>
       <v-tabs
+        v-if="!mobile"
         v-model="currentRoute"
         align-tabs="center"
         class="ml-4"

--- a/packages/ui/src/__test__/App.spec.ts
+++ b/packages/ui/src/__test__/App.spec.ts
@@ -1,20 +1,52 @@
 import { mount } from '@vue/test-utils'
 import { createPinia } from 'pinia'
 import rop from 'resize-observer-polyfill'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
+import { nextTick } from 'vue'
 import App from '../App.vue'
 import vuetify from '../plugins/vuetify'
 import router from '../router'
 
 globalThis.ResizeObserver = rop
 
+const MOBILE_WIDTH = 375
+const DESKTOP_WIDTH = 1280
+const DEFAULT_TEST_WIDTH = 1024
+
+async function setWindowWidth(width: number) {
+  Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: width })
+  window.dispatchEvent(new Event('resize'))
+  await nextTick()
+}
+
+function mountApp() {
+  return mount(App, {
+    global: {
+      plugins: [createPinia(), router, vuetify],
+    },
+  })
+}
+
 describe('app', () => {
+  afterEach(async () => {
+    await setWindowWidth(DEFAULT_TEST_WIDTH)
+  })
+
   it('mounts without error', () => {
-    const wrapper = mount(App, {
-      global: {
-        plugins: [createPinia(), router, vuetify],
-      },
-    })
+    const wrapper = mountApp()
     expect(wrapper.exists()).toBe(true)
+  })
+
+  it('hides the tab strip and keeps the title visible on narrow viewports', async () => {
+    await setWindowWidth(MOBILE_WIDTH)
+    const wrapper = mountApp()
+    expect(wrapper.findComponent({ name: 'VTabs' }).exists()).toBe(false)
+    expect(wrapper.find('.v-app-bar-title').text()).toContain('Kuroshiro')
+  })
+
+  it('shows the tab strip on wide viewports', async () => {
+    await setWindowWidth(DESKTOP_WIDTH)
+    const wrapper = mountApp()
+    expect(wrapper.findComponent({ name: 'VTabs' }).exists()).toBe(true)
   })
 })

--- a/packages/ui/src/components/NavigationDrawer.vue
+++ b/packages/ui/src/components/NavigationDrawer.vue
@@ -4,6 +4,7 @@ import {
   mdiCodeBlockTags,
   mdiCog,
   mdiMonitor,
+  mdiPuzzle,
   mdiRobot,
   mdiViewDashboard,
 } from '@mdi/js'
@@ -21,6 +22,7 @@ const devices = computed(() => deviceStore.devices)
   <VList>
     <VList density="compact" nav>
       <VListItem :prepend-icon="mdiViewDashboard" title="Overview" :to="{ name: 'overview' }" data-test-id="nav-overview" />
+      <VListItem :prepend-icon="mdiPuzzle" title="Plugins" :to="{ name: 'pluginsOverview' }" data-test-id="nav-plugins" />
       <VDivider />
       <VListGroup data-test-id="nav-devices-group">
         <template #activator="{ props }">

--- a/packages/ui/src/components/__test__/NavigationDrawer.spec.ts
+++ b/packages/ui/src/components/__test__/NavigationDrawer.spec.ts
@@ -19,7 +19,7 @@ vi.mock('@/utils/isDeviceOnline', () => ({
 }))
 
 describe('navigationDrawer', () => {
-  it('renders without error and shows Overview and Devices', () => {
+  it('renders without error and shows Overview, Plugins and Devices', () => {
     const wrapper = mount(NavigationDrawer, {
       global: {
         plugins: [createPinia(), vuetify],
@@ -27,6 +27,7 @@ describe('navigationDrawer', () => {
     })
     expect(wrapper.exists()).toBe(true)
     expect(wrapper.find('[data-test-id="nav-overview"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test-id="nav-plugins"]').exists()).toBe(true)
     expect(wrapper.find('[data-test-id="nav-devices-group"]').exists()).toBe(true)
     expect(wrapper.find('[data-test-id="nav-device-device1"]').exists()).toBe(true)
     expect(wrapper.find('[data-test-id="nav-device-device2"]').exists()).toBe(true)


### PR DESCRIPTION
## Summary
- `App.vue` hides the app-bar tab strip below Vuetify's `mobile` breakpoint (`useDisplay()`, same threshold `v-navigation-drawer` already uses to go temporary) so the "Kuroshiro" title and TRMNL link are no longer squeezed out on narrow viewports.
- `NavigationDrawer.vue` gains a "Plugins" entry (matching the existing item pattern) so the drawer is a complete fallback for every route once the tabs are hidden.

Closes #736

## Test plan
- [x] `vitest run` — full UI suite passes (101 tests)
- [x] `vue-tsc --build` — typecheck passes
- [x] `eslint` — clean
- [x] Verified visually with Puppeteer screenshots at 375px, 768px, and 1280px: title + TRMNL link fully visible and tabs hidden below the breakpoint, tabs still shown on desktop, drawer shows the new Plugins entry

https://claude.ai/code/session_01EJi8JqVCUMrVyQdGdibAwy