### PR TITLE
fix(ui): add real-browser viewport overflow CI check, fix plugin toolbar overflow at 375px

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -25,5 +25,7 @@ jobs:
         run: pnpm run type-check
       - name: Test
         run: pnpm run test
+      - name: Test UI viewport regressions
+        run: pnpm --filter ./packages/ui test:e2e
       - name: Build
         run: pnpm run build

--- a/README.md
+++ b/README.md
@@ -218,6 +218,10 @@ We love contributions! Jump in:
 - Run all tests before submitting a PR
 - **We use [release-please](https://github.com/googleapis/release-please)!** Use [Conventional Commits](https://www.conventionalcommits.org/) for your commit messages to enable automatic versioning and changelogs.
 
+### UI responsive support
+
+The dashboard (`packages/ui`) supports viewports down to **375px** wide. CI drives every route in a real Chromium browser at 375 / 768 / 1280px (`pnpm --filter ./packages/ui test:e2e`) and fails on horizontal overflow, so if you add a toolbar, card header, or dialog, check it at 375px before opening a PR.
+
 ### Contributors
 
 <a href="https://github.com/phyberapex/kuroshiro/graphs/contributors">

--- a/packages/ui/e2e/viewport-overflow.spec.ts
+++ b/packages/ui/e2e/viewport-overflow.spec.ts
@@ -1,0 +1,192 @@
+import type { Browser, HTTPRequest, Page } from 'puppeteer'
+import type { ViteDevServer } from 'vite'
+import { fileURLToPath } from 'node:url'
+import puppeteer from 'puppeteer'
+import { createServer } from 'vite'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+/**
+ * Real-browser regression check for the horizontal-overflow breaks tracked in
+ * kuroshiro#733-#737 (and the umbrella issue kuroshiro#738): jsdom-based unit
+ * tests never lay out CSS, so they can't catch a toolbar or app bar that only
+ * overflows at a narrow viewport. This drives an actual Chromium page instead.
+ */
+
+const WIDTHS = [375, 768, 1280]
+const VIEWPORT_HEIGHT = 900
+const DEVICE_ID = 'e2e-device-1'
+
+const ROUTES: { name: string, path: string }[] = [
+  { name: 'Overview', path: '/' },
+  { name: 'Device Details', path: `/devices/${DEVICE_ID}` },
+  { name: 'Device Plugins', path: `/devices/${DEVICE_ID}/plugins` },
+  { name: 'Plugins Overview', path: '/plugins' },
+  { name: 'Plugin Create', path: '/plugins/create' },
+  { name: 'Maintenance', path: '/maintenance' },
+  { name: 'Virtual Device', path: '/virtualDevice' },
+  { name: 'HTML Preview', path: '/htmlPreview' },
+]
+
+const API_FIXTURES: Record<string, unknown> = {
+  '/api/devices': [{
+    id: DEVICE_ID,
+    name: 'Living Room TRMNL',
+    friendlyId: 'ABCDEF',
+    mac: 'AA:BB:CC:DD:EE:FF',
+    apikey: 'e2e-api-key',
+    batteryVoltage: '4.05',
+    fwVersion: '1.5.2',
+    refreshRate: 900,
+    rssi: '-52',
+    userAgent: 'ESP32',
+    width: 800,
+    height: 480,
+    reportedModel: 'og',
+    deviceModel: null,
+    palette: null,
+    mirrorEnabled: false,
+    mirrorMac: '',
+    mirrorApikey: '',
+    specialFunction: 'none',
+    resetDevice: false,
+    updateFirmware: false,
+    lastSeen: new Date().toISOString(),
+  }],
+  '/api/device-models': [],
+  '/api/device-models/palettes': [],
+  '/api/plugins': [{
+    id: 'e2e-plugin-1',
+    name: 'Weather',
+    description: 'Shows the current forecast',
+    kind: 'Poll',
+    refreshInterval: 900,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  }],
+  [`/api/plugins/device/${DEVICE_ID}`]: [],
+  [`/api/screens/device/${DEVICE_ID}`]: [],
+  '/api/current_screen': {
+    filename: 'placeholder.png',
+    image_url: '/screens/placeholder.png',
+    refresh_rate: 900,
+    rendered_at: new Date().toISOString(),
+  },
+  '/api/maintenance/scan': {
+    orphanedScreenFiles: [],
+    orphanedDeviceDirs: [],
+    brokenScreens: [],
+    tempFiles: [],
+    oldUploads: [],
+    totalSize: 0,
+    scannedAt: new Date().toISOString(),
+  },
+}
+
+async function mockApi(page: Page) {
+  await page.setRequestInterception(true)
+  page.on('request', (request: HTTPRequest) => {
+    const pathname = new URL(request.url()).pathname
+    if (pathname in API_FIXTURES) {
+      request.respond({
+        status: 200,
+        headers: {},
+        contentType: 'application/json',
+        body: JSON.stringify(API_FIXTURES[pathname]),
+      })
+      return
+    }
+    request.continue()
+  })
+}
+
+interface OverflowReport {
+  documentOverflow: number
+  offenders: { selector: string, overflow: number }[]
+}
+
+/**
+ * Vuetify's app bar and nav drawer are `position: fixed`, so an oversized child
+ * never grows `documentElement`'s scrollWidth — it just gets clipped by the
+ * viewport edge and disappears (this is how kuroshiro#733-#737 slipped through
+ * page-level-only checks). These are the non-grid content boundaries #738 calls
+ * out by name (toolbars, card headers, dialog content): checking scrollWidth
+ * against clientWidth on each one catches a child that no longer fits, without
+ * flagging elements that scroll or scale by design — a native input's own text
+ * scroll, or ScreenFrame's `transform: scale()` preview, are never selected here.
+ */
+const OVERFLOW_CANDIDATE_SELECTOR = '.v-toolbar__content, .v-card-title, .v-card-actions, .v-card-text'
+
+async function measureHorizontalOverflow(page: Page): Promise<OverflowReport> {
+  return page.evaluate((selector) => {
+    const root = document.documentElement
+    const offenders: { selector: string, overflow: number }[] = []
+
+    for (const el of document.querySelectorAll<HTMLElement>(selector)) {
+      const overflowX = getComputedStyle(el).overflowX
+      if (overflowX === 'auto' || overflowX === 'scroll')
+        continue
+
+      const overflow = el.scrollWidth - el.clientWidth
+      if (overflow > 1) {
+        const label = el.className ? `${el.tagName.toLowerCase()}.${String(el.className).replace(/\s+/g, '.')}` : el.tagName.toLowerCase()
+        offenders.push({ selector: label, overflow })
+      }
+    }
+
+    return {
+      documentOverflow: root.scrollWidth - root.clientWidth,
+      offenders,
+    }
+  }, OVERFLOW_CANDIDATE_SELECTOR)
+}
+
+describe('viewport overflow regression', () => {
+  let viteServer: ViteDevServer
+  let browser: Browser
+  let baseUrl: string
+
+  beforeAll(async () => {
+    viteServer = await createServer({
+      root: fileURLToPath(new URL('..', import.meta.url)),
+      configFile: fileURLToPath(new URL('../vite.config.ts', import.meta.url)),
+      logLevel: 'silent',
+      server: { port: 0, strictPort: false },
+    })
+    await viteServer.listen()
+    const address = viteServer.httpServer?.address()
+    if (!address || typeof address === 'string')
+      throw new Error('Vite dev server did not bind to a TCP port')
+    baseUrl = `http://localhost:${address.port}`
+
+    browser = await puppeteer.launch({ args: ['--no-sandbox', '--disable-web-security'] })
+  })
+
+  afterAll(async () => {
+    await browser.close()
+    await viteServer.close()
+  })
+
+  for (const route of ROUTES) {
+    describe(route.name, () => {
+      for (const width of WIDTHS) {
+        it(`has no horizontal overflow at ${width}px`, async () => {
+          const page = await browser.newPage()
+          try {
+            await mockApi(page)
+            await page.setViewport({ width, height: VIEWPORT_HEIGHT })
+            await page.goto(`${baseUrl}${route.path}`, { waitUntil: 'networkidle0' })
+            await page.waitForSelector('#app', { timeout: 10_000 })
+
+            const report = await measureHorizontalOverflow(page)
+
+            expect(report.documentOverflow, `page scrolled horizontally by ${report.documentOverflow}px at ${width}px on ${route.path}`).toBeLessThanOrEqual(1)
+            expect(report.offenders, `elements overflowed horizontally at ${width}px on ${route.path}: ${JSON.stringify(report.offenders)}`).toEqual([])
+          }
+          finally {
+            await page.close()
+          }
+        })
+      }
+    })
+  }
+})

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -9,9 +9,11 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "test:e2e": "vitest run --config vitest.e2e.config.ts",
     "type-check": "vue-tsc --build",
     "lint": "eslint",
-    "lint:fix": "eslint --fix"
+    "lint:fix": "eslint --fix",
+    "prepare": "puppeteer browsers install chrome"
   },
   "dependencies": {
     "@mdi/js": "catalog:",
@@ -40,6 +42,7 @@
     "jiti": "catalog:",
     "jsdom": "catalog:",
     "npm-run-all2": "catalog:",
+    "puppeteer": "catalog:",
     "resize-observer-polyfill": "catalog:",
     "start-server-and-test": "catalog:",
     "typescript": "catalog:",

--- a/packages/ui/src/views/PluginsOverviewView.vue
+++ b/packages/ui/src/views/PluginsOverviewView.vue
@@ -50,7 +50,7 @@ function onPluginImported() {
         <VCard elevation="1">
           <VCardTitle class="d-flex align-center justify-space-between flex-wrap ga-2">
             <span>All Plugins</span>
-            <div class="d-flex ga-2">
+            <div class="d-flex flex-wrap ga-2">
               <VIconBtn
                 :icon="mdiSync"
                 variant="tonal"

--- a/packages/ui/src/views/PluginsView.vue
+++ b/packages/ui/src/views/PluginsView.vue
@@ -42,11 +42,11 @@ function createPlugin() {
       <VCol cols="12">
         <VCard elevation="1">
           <VCardTitle class="d-flex align-center justify-space-between flex-wrap ga-2">
-            <div>
+            <div class="text-truncate">
               <span>Plugins for </span>
               <span class="font-weight-bold">{{ device?.name }}</span>
             </div>
-            <div class="d-flex ga-2">
+            <div class="d-flex flex-wrap ga-2">
               <VIconBtn
                 :icon="mdiSync"
                 variant="tonal"

--- a/packages/ui/tsconfig.node.json
+++ b/packages/ui/tsconfig.node.json
@@ -11,9 +11,11 @@
   "include": [
     "vite.config.*",
     "vitest.config.*",
+    "vitest.e2e.config.*",
     "cypress.config.*",
     "nightwatch.conf.*",
     "playwright.config.*",
-    "eslint.config.*"
+    "eslint.config.*",
+    "e2e/**/*"
   ]
 }

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -8,7 +8,7 @@ export default mergeConfig(
     test: {
       globals: true,
       environment: 'jsdom',
-      exclude: [...configDefaults.exclude],
+      exclude: [...configDefaults.exclude, 'e2e/**'],
       root: fileURLToPath(new URL('./', import.meta.url)),
       server: {
         deps: {

--- a/packages/ui/vitest.e2e.config.ts
+++ b/packages/ui/vitest.e2e.config.ts
@@ -1,0 +1,14 @@
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['e2e/**/*.spec.ts'],
+    root: fileURLToPath(new URL('./', import.meta.url)),
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
+    fileParallelism: false,
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -427,6 +427,9 @@ importers:
       npm-run-all2:
         specifier: 'catalog:'
         version: 9.0.3
+      puppeteer:
+        specifier: 'catalog:'
+        version: 25.7.0
       resize-observer-polyfill:
         specifier: 'catalog:'
         version: 1.5.1


### PR DESCRIPTION
## Summary
- Closes #738. Adds a Puppeteer-driven e2e test (`packages/ui/e2e/viewport-overflow.spec.ts`) that drives every route in a real Chromium browser at 375/768/1280px and fails on horizontal overflow — the check the issue asks for, since jsdom-based unit tests never lay out CSS and so couldn't have caught #733-#737.
- While building it, the check found a real, live overflow: the plugin list header's button row (Refresh/Import/Create) doesn't wrap at 375px and silently overflows past the card edge, invisibly clipped by `v-card-title`'s `overflow: hidden` (no page scrollbar, which is why it went unnoticed). Same root cause hit the "Plugins for {device}" title on the Device Plugins route — a flex item without `min-width: 0` ignores its own ellipsis truncation. Both are fixed.
- Wires the check into `checks.yml` as a new CI step, and documents the 375px minimum supported width in the README.

## Why this design
- Reuses the `puppeteer` devDependency/`prepare` pattern already used by `packages/api` instead of adding a second browser-automation framework (e.g. Playwright) — same cached Chromium binary, no extra CI setup.
- The overflow check targets `.v-toolbar__content`, `.v-card-title`, `.v-card-actions`, `.v-card-text` — the exact "non-grid" boundaries the issue calls out (toolbars, card headers, dialog content) — rather than every DOM element, which avoided false positives from native `<input>` text-scroll and `ScreenFrame`'s intentional `transform: scale()` preview while still catching the real bug.
- `documentElement.scrollWidth` alone isn't enough: Vuetify's app bar is `position: fixed`, so an oversized child never grows page scrollWidth — it just gets clipped off-screen. Per-element checks are what actually catch this class of bug.

## Test plan
- [x] `pnpm --filter ./packages/ui lint`
- [x] `pnpm --filter ./packages/ui type-check` (now includes `e2e/**`, verified it catches a deliberately-injected type error)
- [x] `pnpm --filter ./packages/ui test` (101 unit tests)
- [x] `pnpm --filter ./packages/ui test:e2e` (24 new e2e tests, all passing)
- [x] `pnpm run build`
- [x] Verified the fix visually via screenshot at 375px (device name truncates with ellipsis, buttons wrap to their own row, no clipping)
- [x] Verified the check catches real regressions: manually injected an overflow bug into `App.vue`'s title and confirmed the test failed before reverting it

https://claude.ai/code/session_01EJi8JqVCUMrVyQdGdibAwy