### PR TITLE
docs: record multi-data-source Plugin decisions from grilling #776

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -55,3 +55,7 @@ _Avoid_: stream_limit (bare, in prose — reserve backticks for the field name)
 **Webhook Payload**:
 The single JSON blob a Webhook-kind Plugin persists across POSTs, mutated according to its Merge Strategy and rendered against on every arrival. Readable as-is via `GET` on the Plugin's Webhook URL.
 _Avoid_: merge_variables (TRMNL's term), webhook data, raw payload
+
+**Data Source**:
+One independently-configured HTTP fetch (method, URL, headers, body, optional per-source JS transform), identified by a required, unique-per-Plugin `name`. Belongs to a `Poll`-kind Plugin, which holds an ordered list of zero or more Data Sources, each fetched in parallel on the Plugin's shared `refreshInterval` and exposed to its templates as its own top-level Liquid variable keyed by that `name`. If a Data Source's fetch fails, its variable is still present but carries an error marker instead of real data — the rest of the render proceeds with whatever succeeded. Distinct from a Mashup, which combines multiple Plugins' rendered outputs into layout slots on one Screen — a Data Source combines multiple fetches within a single Plugin.
+_Avoid_: Extension, Exchange (Terminus's terms — not adopted here)

--- a/docs/adr/0004-multi-source-migration-breaks-templates.md
+++ b/docs/adr/0004-multi-source-migration-breaks-templates.md
@@ -1,0 +1,13 @@
+# Multi-Data-Source migration breaks existing templates; no compatibility shim
+
+`PluginRendererService.render()` passes the fetched JSON straight through as the Liquid root scope — a single-Data-Source Plugin whose API returns `{"temp": 72}` writes `{{ temp }}` directly in its template, flat, no wrapper. Issue #776 gives `Poll`-kind Plugins multiple named Data Sources instead of exactly one, each exposed to the template as its own top-level variable keyed by its name (`{{ weather.temp }}`). That necessarily nests what used to be flat, even for a Plugin migrated from having exactly one Data Source.
+
+We considered two compatibility options and rejected both. Auto-flattening only when a Plugin has exactly one Data Source is worse than it looks: a Plugin working fine at one source would silently break the day someone adds a second, with no change to the template itself — a much nastier failure mode than a known break at migration time. Dual-exposing both the flat root fields and the namespaced object simultaneously is permanent hidden-context magic every future reader has to know about to debug a name collision.
+
+We chose to accept the breaking change outright. The migration backfills a `name` for each pre-existing single-Data-Source row (kept at `order: 0`) so it satisfies the new required/unique `name` constraint, but does not attempt to rewrite the Plugin's Liquid template — authors update their own template once, after migration, to prefix their field references with the source's name. This is viable because Kuroshiro is self-hosted and owner-operated: there's no unknown fleet of third-party templates to break silently across a fleet of installs.
+
+## Consequences
+
+- Every existing single-Data-Source Plugin's template needs a one-time manual edit after this migration ships (flat `{{ field }}` → namespaced `{{ source_name.field }}`).
+- Plugin export/import format changes in lockstep (`dataSource` → `dataSources` array) with no legacy-key acceptance, for the same reason.
+- No dual-context resolution logic needs to be built or maintained in `PluginRendererService`.

--- a/docs/adr/0005-data-sources-shared-interval-parallel-fetch.md
+++ b/docs/adr/0005-data-sources-shared-interval-parallel-fetch.md
@@ -1,0 +1,13 @@
+# Data Sources fetch in parallel on one shared Plugin interval, with per-source error markers
+
+Issue #776 gives `Poll`-kind Plugins multiple Data Sources instead of one. `PluginSchedulerService` today runs exactly one `node-cron` job per Plugin, keyed by `plugin.id`, on `plugin.refreshInterval`. Terminus's own multi-source model (Extension Exchanges) polls and error-surfaces each exchange independently, which raised the question of whether Kuroshiro should do the same.
+
+We chose to keep one cron job per Plugin. On each tick, all of that Plugin's Data Sources are fetched in parallel — not sequentially, not gated on each other — still on the Plugin's single existing `refreshInterval`; there is no per-source interval column. If an individual source's fetch or transform fails, that source's key in the render context becomes an error marker instead of aborting the whole render, while sources that succeeded still render normally in the same pass.
+
+We rejected per-source `refreshInterval`s. That would mean one cron job per Data Source instead of per Plugin — N jobs per Plugin, each independently tracking its own last-fetched/next-fetch state — a materially larger scheduler rewrite for a need the issue's own motivating cases (weather + air quality, a paginated endpoint) don't establish. Nothing in those scenarios needs sources on different cadences; the value we did want from Terminus's model — one source's flakiness not blanking the others — is captured by the per-source error marker, not by independent scheduling.
+
+## Consequences
+
+- Adding a Data Source to a Plugin has no cost to the scheduler's job count — it's still one job per Plugin.
+- All Data Sources on a Plugin share one blast radius for scheduling changes (e.g. changing `refreshInterval` affects every source at once).
+- A future need for independent per-source cadences would require revisiting this decision and the scheduler's job-keying scheme.

--- a/docs/adr/0006-data-sources-independent-variables-no-merge.md
+++ b/docs/adr/0006-data-sources-independent-variables-no-merge.md
@@ -1,0 +1,12 @@
+# Data Sources expose independent named variables; no cross-source merge step
+
+Issue #776's motivating cases — weather + air quality, a paginated endpoint split across two requests — are fully satisfied by giving each Data Source its own top-level Liquid variable, keyed by its name: `{{ weather.temp }}` and `{{ air_quality.aqi }}` in the same template. `transformJs` already exists as a column on `PluginDataSource`, applied per-source before its result is placed under its name in the render context.
+
+We considered also offering a plugin-level "combine" transform that would receive all sources' results and return one merged context, matching the general shape of "combining multiple APIs into one screen" the issue describes. We rejected it: the stated use case is already solved by referencing two independent variables in the same template — Liquid itself can read across both. A server-side JS step that runs after every source's own fetch/transform, with its own error-handling semantics layered on top of the already-decided per-source error-marker behavior (ADR-0005), is speculative complexity the issue doesn't ask for.
+
+So independent named top-level variables are the only exposure mode. There is no plugin-level combinator.
+
+## Consequences
+
+- Liquid templates do all the "combining" — computing a value from two sources' fields happens in Liquid/its filters, not in a server-side JS step.
+- If a real need for cross-source computation emerges later, it reopens this decision — the per-source `transformJs` column is not the place to add it, since it only ever sees its own source's raw response.


### PR DESCRIPTION
## Summary
- Adds the **Data Source** glossary entry to `CONTEXT.md` — a Plugin's Data Sources are now a named, ordered collection rather than a single row.
- Adds three ADRs from the `/grilling` session on #776:
  - `0004` — the multi-source migration deliberately breaks existing single-source templates, no compatibility shim
  - `0005` — Data Sources fetch in parallel on one shared Plugin interval, with per-source error markers instead of whole-render failure
  - `0006` — Data Sources expose independent named Liquid variables only, no cross-source merge step

Docs only — the spec for the actual implementation is posted as a comment on #776 (labeled `ready-for-agent`).

## Test plan
- [x] N/A — documentation only, no code changes