### PR TITLE
docs: record screen-playlist scheduling decisions from grilling #777

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -25,7 +25,7 @@ An integer position (1..N, sequential, no gaps) that determines a Screen's place
 _Avoid_: Position, index, sequence number
 
 **Active Screen**:
-The one Screen per Device currently being shown (`isActive: true`). Not a fixed pointer — advances dynamically to the next Screen by `order` each time the Device polls for its display, wrapping back to `order: 1` after the last screen.
+The one Screen per Device currently being shown (`isActive: true`). Not a fixed pointer — advances dynamically to the next eligible Screen by `order` each time the Device polls for its display, wrapping back to `order: 1` after the last screen. If no Screen on the Device is currently eligible (every Screen has a Schedule, and none match), there is no Active Screen — the Device gets the same fallback image as a Device with zero Screens at all.
 _Avoid_: Selected screen
 
 **Current Screen**:
@@ -33,8 +33,12 @@ The specific feature/endpoint (`/current_screen`) that returns the Active Screen
 _Avoid_: Active screen (see above — related but not the same concept)
 
 **Rotation**:
-The cycle through a Device's Screens in `order`, one step per `/display` poll.
-_Avoid_: Cycling, playlist
+The cycle through a Device's Screens in `order`, one step per `/display` poll — skipping any Screen currently ineligible per its Schedule, if it has one.
+_Avoid_: Cycling, playlist (see Schedule below — the concept "playlist" usually points at is Schedule, not Rotation)
+
+**Schedule**:
+A set of day/time constraints (weekday selection, daily time-of-day window — may cross midnight — optional active date range) plus an independent enabled/disabled toggle, attached to at most one per Screen, that gates whether that Screen is eligible to become the Active Screen. A Screen with no Schedule is always eligible; a disabled Schedule makes its Screen ineligible outright regardless of the day/time rules, without discarding them (soft-hide). Time-of-day windows are evaluated in the server's local timezone — Devices have no timezone of their own. Applies uniformly to every Screen type, including Mashup. Distinct from Rotation, which orders currently-eligible Screens — Schedule only narrows eligibility, it never reorders. A Screen needing more than one window (e.g. two separate times of day) needs a second Screen with its own Schedule, not a compound rule on one Schedule.
+_Avoid_: Playlist, playlist item, recurrence rule
 
 **Plugin Kind**:
 Which strategy a Plugin uses to get data into its template — `Poll` (Kuroshiro fetches from a Data Source on a schedule) or `Webhook` (an external system pushes data by POSTing to the Plugin's Webhook URL, rendered synchronously on arrival).

--- a/docs/adr/0007-schedule-gates-rotation-eligibility.md
+++ b/docs/adr/0007-schedule-gates-rotation-eligibility.md
@@ -1,0 +1,15 @@
+# Schedule gates Rotation eligibility; "Playlist" rejected as the concept name
+
+Issue #777 asks for day-parted, recurring screen scheduling — TRMNL's Playlist Scheduler and Terminus's `playlist_item` model (weekday arrays, date windows, `hidden_at`) both name this concept "playlist." Kuroshiro's `CONTEXT.md` already defines **Rotation** as the cycle through a Device's Screens by `order`, and had already flagged "playlist" as a rejected synonym for it. Reusing "playlist" for the new feature would have re-opened that exact conflict.
+
+We introduced **Schedule** instead: a set of day/time constraints (weekday selection, a daily time-of-day window that may cross midnight, an optional active date range) plus an independent enabled/disabled toggle, attached to at most one per Screen. Rotation is unchanged as the ordering mechanism — `order`, `isActive`, the advance-and-wrap logic in `display.service.ts` all stay as they are. Schedule only narrows *eligibility*: the advance step now skips a Screen whose Schedule doesn't currently match, continuing around the ring, instead of picking whatever's next by `order` unconditionally. A Screen with no Schedule is always eligible, so existing Devices with no Schedules configured see no behavior change at all.
+
+We considered replacing the round-robin advance with a rules engine that computes "what should be showing right now" from scratch each poll (closer to option (b) we rejected in grilling). We rejected it: it would touch every Screen regardless of whether it uses scheduling, is a materially bigger change, and Terminus's own advancing logic (`current_item_advancer`, `slide_window`, `screen_optioner`) is itself filter-shaped, not a from-scratch recompute — validating that the filter approach is sufficient.
+
+We also decided a Screen carries at most one Schedule, not a compound "AND" of several (TRMNL's "+And during" templates). A Screen needing two separate windows gets a second Screen with its own Schedule — Rotation already cycles through multiple Screens, so this reuses existing machinery instead of adding compound-rule evaluation.
+
+## Consequences
+
+- Schedule applies uniformly to every Screen `type`, including `mashup` — no special-casing in the eligibility check.
+- When no Screen on a Device is currently eligible, the Device falls back to the same `noScreen.png` path used today when a Device has zero Screens at all (`display.service.ts:100-112`) — no new fallback concept was introduced.
+- A future need for compound per-Screen schedule rules, or a from-scratch rules engine, reopens this decision.

--- a/docs/adr/0008-schedule-v1-scope-cuts.md
+++ b/docs/adr/0008-schedule-v1-scope-cuts.md
@@ -1,0 +1,13 @@
+# Screen Playlists v1 excludes skip logic, per-item overrides, device grouping, and a pause/resume API
+
+Issue #777's evidence section lists a wide TRMNL/Terminus feature set beyond day-parted scheduling: conditional skip logic (`window.TRMNL_SKIP_SCREEN_GENERATION` / `TRMNL_SKIP_DISPLAY`, a "skip if stale" TTL mode), per-item duration and colour-palette overrides, device grouping via a shared playlist (Terminus's `PUT /playlists/:id/mirror`), and a `/api/playlist_items` pause/resume endpoint. Grilling this issue deliberately cut all four from v1, on separate grounds:
+
+- **Conditional skip logic** is a plugin-rendering-contract change — a plugin's own output would need to signal "don't show me right now" — which is an orthogonal mechanism to time-based Schedule eligibility (ADR-0007) and touches the plugin/template pipeline, not the Screen/Schedule relationship.
+- **Per-item overrides** (duration, palette): duration needs a server-side elapsed-time-per-Screen model that doesn't exist today — Devices just poll at their own `refreshRate`, there is no timer — so it's a real new subsystem, not a Schedule field. Palette-per-Screen is a rendering concern, not an eligibility concern; Kuroshiro already has per-Device palette (`devices.entity.ts`), and extending it per-Screen is unrelated to whether that Screen is *currently eligible*.
+- **Device grouping** ("shared schedule/playlist across Devices") is a distinct concern from per-Screen scheduling. It's also a naming trap: `Device` already has `mirrorEnabled`/`mirrorMac`/`mirrorApikey` meaning "this Device mirrors TRMNL cloud's own display" — reusing "mirror" for device-grouping, as Terminus does, would collide with that existing meaning.
+- **Pause/resume API** (`/api/playlist_items`-equivalent) targets multi-tenant SaaS automation — a third party programmatically pausing a customer's item. Kuroshiro is self-hosted/single-tenant; an admin can edit or delete a Schedule through the existing admin surface. The soft-hide need this would otherwise cover is met by Schedule's enabled/disabled toggle (ADR-0007), reachable through normal admin CRUD rather than a dedicated endpoint.
+
+## Consequences
+
+- None of these four are precluded by the Schedule design in ADR-0007 — each can be layered on independently later without revisiting Schedule's shape.
+- Each is expected to be filed as its own follow-up issue rather than folded into #777's implementation.

--- a/docs/adr/0009-schedule-server-timezone.md
+++ b/docs/adr/0009-schedule-server-timezone.md
@@ -1,0 +1,10 @@
+# Schedule's time-of-day window is evaluated in the server's timezone, not per-Device
+
+Day-parting (issue #777) needs a timezone to anchor "7am–9am" against, and `Device` has no timezone field today — nothing on the entity locates a Device geographically or otherwise. Grilling raised adding a per-Device IANA-timezone field, since self-hosted Kuroshiro deployments can have Devices physically distant from the server (e.g. a US-hosted server with a Device in Berlin). That was rejected in favor of evaluating every Schedule's time-of-day window against the server process's own local timezone — no new Device field, no per-Device configuration step.
+
+This is a known, accepted limitation: a Device not co-located (in timezone terms) with the server will see its day-parting fire at the wrong local wall-clock time, offset by the difference between server and Device timezones. We're recording this explicitly so it reads as a deliberate simplicity trade-off for v1, not an oversight — and so a future fix (adding a per-Device timezone field and threading it through Schedule's eligibility check) knows exactly what it's replacing.
+
+## Consequences
+
+- Self-hosted users with geographically distributed Devices need to account for the offset manually when authoring a Schedule (e.g. shift the window by the known difference).
+- Adding per-Device timezone later is additive — it doesn't change Schedule's shape from ADR-0007, only what timezone its window is evaluated against — but does require a migration and a UI field.


### PR DESCRIPTION
## Summary
- Records the shared understanding reached grilling issue #777 (Screen Playlists: scheduled/recurring rotation with day-parting)
- Adds **Schedule** to `CONTEXT.md` as a new concept (day/time eligibility gate on a Screen), keeps **Rotation** as the ordering mechanism, and formally rejects "Playlist" as domain vocabulary — it was already flagged as an avoided synonym for Rotation
- Adds three ADRs:
  - `0007-schedule-gates-rotation-eligibility.md` — Schedule as an eligibility filter over the existing order-based advance, not a replacement engine; one Schedule per Screen, not compound rules
  - `0008-schedule-v1-scope-cuts.md` — conditional skip logic, per-item duration/palette overrides, device grouping, and a pause/resume API are all deliberately out of v1 scope, each to be its own follow-up issue
  - `0009-schedule-server-timezone.md` — Schedule's time-of-day window evaluates in the server's timezone (no per-Device timezone field), recorded as a known limitation

No implementation in this PR — docs only, ahead of building #777.

## Test plan
- [x] `pnpm run -r type-check` passed via pre-commit hook
- N/A — no code changes