### PR TITLE
docs: record Recipe import decisions from grilling #778

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -63,3 +63,7 @@ _Avoid_: merge_variables (TRMNL's term), webhook data, raw payload
 **Data Source**:
 One independently-configured HTTP fetch (method, URL, headers, body, optional per-source JS transform), identified by a required, unique-per-Plugin `name`. Belongs to a `Poll`-kind Plugin, which holds an ordered list of zero or more Data Sources, each fetched in parallel on the Plugin's shared `refreshInterval` and exposed to its templates as its own top-level Liquid variable keyed by that `name`. If a Data Source's fetch fails, its variable is still present but carries an error marker instead of real data — the rest of the render proceeds with whatever succeeded. Distinct from a Mashup, which combines multiple Plugins' rendered outputs into layout slots on one Screen — a Data Source combines multiple fetches within a single Plugin.
 _Avoid_: Extension, Exchange (Terminus's terms — not adopted here)
+
+**Recipe**:
+A pre-built, TRMNL-vetted Plugin template published at trmnl.com/recipes, importable into Kuroshiro by pasting its id or page URL. A Recipe exists only as an import source — the result of importing one is a normal Poll-kind Plugin, indistinguishable from a hand-built one, carrying only its source Recipe's id as inert metadata (no ongoing link, no auto-updates).
+_Avoid_: Extension, Exchange (Terminus's terms), Plugin (the imported result — see above)

--- a/docs/adr/0010-recipe-import-reshapes-flat-archive-into-existing-importer.md
+++ b/docs/adr/0010-recipe-import-reshapes-flat-archive-into-existing-importer.md
@@ -1,0 +1,17 @@
+# Recipe import reshapes TRMNL's flat archive into the existing GitHub-importer's plugin shape
+
+Issue #778 asks Kuroshiro to import TRMNL Recipes, the same catalog Terminus's Extension Gallery imports from. We downloaded and inspected a real archive (`trmnl.com/api/plugin_settings/:id/archive`) rather than assuming it matched `plugin-importer.service.ts`'s existing GitHub-repo import path. It doesn't: a Recipe archive is flat — `settings.yml` plus `*.liquid` files at the zip root, no `.trmnlp.yml` manifest, no `src/` prefix — whereas `importFromZip` requires both and throws if either is missing. `settings.yml` itself carries both manifest-level fields (`name`, `description`, `custom_fields`) and settings-level polling config (`polling_url`/`polling_verb`/`polling_headers`/`polling_body`, `refresh_interval`) in one file, which `buildParsedPlugin` already knows how to read across its manifest/settings fallback logic.
+
+We add a thin adapter ahead of the existing zip-import path — reshape the flat archive's entries as if they lived under `src/`, synthesize the manifest fields `buildParsedPlugin` expects from `settings.yml` — rather than writing a second, parallel parser. The field-mapping work (Terminus-format fallbacks, `custom_fields` → `PluginField`, `transform.js` extraction) already lives in `buildParsedPlugin`; duplicating it in a Recipe-specific service would mean two places to keep in sync every time that mapping changes.
+
+Two mapping decisions fall out of this:
+
+- **Serverless-transform recipes are supported**, unlike Terminus (which rejects any archive containing a `transform` file — `terminus/app/aspects/extensions/importers/remote/transformer.rb`). Kuroshiro's importer already has first-class `transform.js` handling; excluding it here would be an arbitrary restriction with no implementation cost saved.
+- **The `author_bio` custom field is forced `required: false`** on import. TRMNL ships it without an `optional: true` flag, so the existing `required: !field.optional` mapping would otherwise treat a read-only credit blurb as a field the admin must fill in before saving — this is the field that carries Recipe attribution, and forcing it optional is what makes it usable as informational text rather than a blocking required input.
+
+Import accepts either a bare numeric Recipe id or a full `trmnl.com/recipes/...` URL, parsed down to the id the same way `importFromGithubUrl` already parses a GitHub URL down to a zip download URL.
+
+## Consequences
+
+- If TRMNL changes the archive's flat shape or adds new top-level `settings.yml` fields, only the adapter needs updating — `buildParsedPlugin` and its Terminus-format fallbacks are unaffected.
+- Any future non-Recipe import source that shares this flat shape (e.g. a direct file upload) could reuse the same adapter instead of `importFromZip`'s manifest-required path.

--- a/docs/adr/0011-recipe-import-v1-scope-cuts.md
+++ b/docs/adr/0011-recipe-import-v1-scope-cuts.md
@@ -1,0 +1,13 @@
+# Recipe import v1 is a one-time copy via id/URL paste; no gallery, no OAuth, no static-data recipes
+
+Issue #778's evidence section raises several open questions beyond "can we import a Recipe at all." Grilling this issue deliberately cut the following from v1:
+
+- **No Browse/Gallery UI.** Recipes are imported by pasting an id or URL, mirroring the existing GitHub-import UX. A searchable gallery against `recipes-api`/`categories-api` is a materially bigger surface (search, facets, pagination) that isn't needed to prove the import mechanics work, and can be layered on top of the same import path later without revisiting it.
+- **OAuth-enabled recipes are rejected outright**, with a clear error at import time. Kuroshiro's Data Source model has no OAuth support anywhere today; importing one would silently produce a Data Source that can never authenticate, which is a worse failure mode than refusing up front. Matches Terminus's own behavior (`terminus/app/aspects/extensions/importers/remote/transformers/kind.rb` fails the same way).
+- **`strategy: static` recipes are rejected outright.** We initially assumed "static" was just a UI label for a `Poll`-kind Plugin with zero Data Sources (already valid per the Data Source glossary entry from #776). Inspecting Terminus's importer (`transformers/kind.rb`) showed this is wrong: a static recipe carries a real fixed `static_data` JSON payload, kept as its own `static_body` distinct from `poll_body` — there's nowhere in Kuroshiro's current model (Data Source is explicitly "one independently-configured HTTP fetch") to put that literal data. Building real support for it is a separate feature, tracked at #794, not something to fold into this issue's scope.
+- **Import is a one-time, disconnected copy.** The resulting Plugin stores its source Recipe's id as inert metadata but has no ongoing link back to it — no auto-update, no "check for updates" action. TRMNL auto-propagates Recipe updates to installers; Terminus itself doesn't replicate that (no `external_id`/source column persists past its importer's in-memory transform step). We reject it too: silently overwriting a user's local edits to an imported Plugin (custom field tweaks, template edits) needs its own conflict-handling design, which is out of scope here.
+
+## Consequences
+
+- A future Browse/Gallery UI, OAuth support, static-data Plugins (#794), and Recipe update-sync are all additive — none require reshaping what v1 ships.
+- The stored source Recipe id has no consumer yet beyond being present on the Plugin record; it exists so a future update-sync feature doesn't need a data migration to backfill it.


### PR DESCRIPTION
## Summary
- Adds the **Recipe** glossary entry to `CONTEXT.md`
- **ADR-0010**: Recipe archives are flat (no `.trmnlp.yml` manifest, no `src/` prefix) — a thin adapter reshapes them into the existing GitHub-importer's expected shape rather than a parallel parser; `transform.js` recipes are supported; the `author_bio` custom field is forced non-required on import (it's the attribution field, not something an admin must fill in).
- **ADR-0011**: v1 scope cuts — import by pasting a Recipe id/URL only (no gallery/browse UI), OAuth-enabled recipes rejected outright, `strategy: static` recipes rejected outright (real fixed-data payload with nowhere to live in the current Data Source model — tracked at #794), import is a one-time disconnected copy (source Recipe id stored as inert metadata, no auto-update sync).

Closes the grilling pass on #778. Static/literal-data Plugin support (needed for `strategy: static` recipe parity with Terminus) is tracked separately at #794.

## Test plan
- Docs-only change — no code, no tests to run.