### PR TITLE
docs: record Sleep Mode and Firmware management decisions from grilling #779, #781

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -71,3 +71,11 @@ _Avoid_: Extension, Exchange (Terminus's terms), Plugin (the imported result —
 **Sleep Mode**:
 A per-Device night window (`sleepStartTime`–`sleepEndTime`, time-of-day, may cross midnight, evaluated in the server's timezone) gated by an independent `sleepModeEnabled` toggle, mirroring Schedule's enabled/window split. While active, the Device's Active Screen stops advancing, and `/display` returns a `refresh_rate` computed as seconds-until-`sleepEndTime` so the Device wakes exactly when the window ends rather than on its usual cadence. A second toggle, `sleepScreenEnabled`, chooses between showing a dedicated `sleep` fallback screen (a new kind on the same mechanism as `noScreen`/`error`/`welcome`) or freezing whatever content was already showing. Applies only to non-mirrored Devices, and is entirely independent of the `sleep` specialFunction value — a separate, persisted manual override sent verbatim in every `/display` response, sharing nothing but a name.
 _Avoid_: Sleep (bare, in prose — ambiguous with the specialFunction value of the same name), Night Mode, Do Not Disturb
+
+**Firmware**:
+A versioned OTA binary a Device can be pushed to — either `official-synced` (mirrored automatically from `usetrmnl.com/api/firmware/latest`) or `custom` (uploaded directly by an admin). Carries a SHA-256 checksum, verified again at serve-time, and an optional set of compatible Device Models (empty means universal) enforced whenever a Firmware is assigned to a Device. A Device references at most one Firmware as its target for the next push, cleared once served — the same explicit, admin-driven assignment Device Model already uses, never inferred by comparing version numbers. Applies only to non-mirrored Devices.
+_Avoid_: Update, OTA package, release, firmware version (bare — reserve for the `version` field)
+
+**Firmware Kind**:
+Where a Firmware came from — `official-synced` (Kuroshiro's daily sync job) or `custom` (an admin's direct upload).
+_Avoid_: Firmware type, firmware source

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -67,3 +67,7 @@ _Avoid_: Extension, Exchange (Terminus's terms — not adopted here)
 **Recipe**:
 A pre-built, TRMNL-vetted Plugin template published at trmnl.com/recipes, importable into Kuroshiro by pasting its id or page URL. A Recipe exists only as an import source — the result of importing one is a normal Poll-kind Plugin, indistinguishable from a hand-built one, carrying only its source Recipe's id as inert metadata (no ongoing link, no auto-updates).
 _Avoid_: Extension, Exchange (Terminus's terms), Plugin (the imported result — see above)
+
+**Sleep Mode**:
+A per-Device night window (`sleepStartTime`–`sleepEndTime`, time-of-day, may cross midnight, evaluated in the server's timezone) gated by an independent `sleepModeEnabled` toggle, mirroring Schedule's enabled/window split. While active, the Device's Active Screen stops advancing, and `/display` returns a `refresh_rate` computed as seconds-until-`sleepEndTime` so the Device wakes exactly when the window ends rather than on its usual cadence. A second toggle, `sleepScreenEnabled`, chooses between showing a dedicated `sleep` fallback screen (a new kind on the same mechanism as `noScreen`/`error`/`welcome`) or freezing whatever content was already showing. Applies only to non-mirrored Devices, and is entirely independent of the `sleep` specialFunction value — a separate, persisted manual override sent verbatim in every `/display` response, sharing nothing but a name.
+_Avoid_: Sleep (bare, in prose — ambiguous with the specialFunction value of the same name), Night Mode, Do Not Disturb

--- a/docs/adr/0012-sleep-mode-wakes-via-dynamic-refresh-rate-independent-of-special-function.md
+++ b/docs/adr/0012-sleep-mode-wakes-via-dynamic-refresh-rate-independent-of-special-function.md
@@ -1,0 +1,15 @@
+# Sleep Mode wakes a Device via a dynamic refresh_rate, not the specialFunction toggle
+
+The TRMNL protocol gives Kuroshiro exactly one lever over when a Device next polls: the `refresh_rate` int on every `/display` response — the Device always decides its next poll from the last value it received, and there is no "stop polling" primitive. So while a Device is inside its Sleep Mode window, `/display` returns `refresh_rate` computed as seconds-until-`sleepEndTime` (clamped to a minimum), rather than a long fixed value re-checked on the next poll. This wakes the Device exactly when the window ends instead of oversleeping by up to a full sleep-rate interval. The Active Screen also stops advancing for the duration — "last content" means the Device keeps showing the same image it already had, not a rotation that silently moved on in the background.
+
+Sleep Mode is deliberately independent of the existing `sleep` `specialFunction` value (`Device.specialFunction`, sent verbatim in every `/display` response). That field turned out, on inspection, to be a sticky manual override — nothing in the codebase resets it after use — not the one-shot trigger the firmware evidence suggested. Coupling Sleep Mode to it would mean setting `specialFunction: 'sleep'` on window entry and un-setting it on exit, which both adds a state machine and risks stomping a user's own manual selection. The two features share a name and nothing else.
+
+Two related priority rules fall out of the same window logic: the new `sleep` fallback-screen kind (added to `FallbackScreensService` alongside `noScreen`/`error`/`welcome`) only ever appears when `sleepScreenEnabled` is true — with it false, a zero-Screen Device still falls through to plain `noScreen`, since "last content" has nothing to preserve on a Device that never had a Screen. And `/current_screen`, the non-advancing admin preview, reflects sleep state too, since it exists specifically to show "what a Device shows right now."
+
+Sleep Mode is skipped entirely for mirrored Devices (`mirrorEnabled: true`) — in that mode `refresh_rate` and `specialFunction` already come from the real TRMNL account's own `/display` response, which Kuroshiro just relays. Layering a local sleep window on top would fight values Kuroshiro doesn't actually control.
+
+## Consequences
+
+- No new field or process tracks whether a Device is "currently asleep" — it's a pure function of `sleepStartTime`/`sleepEndTime`/`sleepModeEnabled` against server time, recomputed on every `/display` call, same pattern as Schedule eligibility.
+- A future change that wants Sleep Mode to trigger real firmware deep-sleep (via `specialFunction`) is additive but non-trivial — it would need to introduce the coupling and state-restoration logic explicitly rejected here.
+- Mirrored Devices cannot use Kuroshiro's Sleep Mode at all; if that's needed later, TRMNL's own account-level Sleep Mode is the workaround in the meantime.

--- a/docs/adr/0013-sleep-mode-v1-scope-cuts.md
+++ b/docs/adr/0013-sleep-mode-v1-scope-cuts.md
@@ -1,0 +1,13 @@
+# Sleep Mode v1 has no per-Device timezone and no custom-uploadable sleep screen
+
+Issue #779's evidence section raises two follow-on questions beyond the core window/refresh-rate mechanics (ADR-0012). Grilling this issue deliberately cut the following from v1:
+
+- **No per-Device timezone.** Sleep Mode's `sleepStartTime`/`sleepEndTime` are evaluated in the server's local timezone, reusing the decision already made for Schedule's day-parting in ADR-0009 rather than reopening it. Same accepted limitation applies: a Device not co-located with the server (in timezone terms) sees its sleep window fire at the wrong local wall-clock time.
+- **No custom-uploadable sleep screen.** TRMNL's own product lets a user upload a bespoke image to show while asleep. v1 instead adds `sleep` as a fourth kind to the existing `FallbackScreensService` mechanism (alongside `noScreen`/`error`/`welcome`) — rendered and cached per Device Model/Palette like the others, with no per-Device upload path. A real upload feature needs its own storage, upload UI, and validation, which is materially bigger than this issue's scope.
+
+Unlike the Recipe Import and Schedule features this repo has grilled before, Sleep Mode ships as a single full-stack pass — entity fields, `/display` logic, the `sleep` fallback kind, and the Device-settings UI all in one issue — rather than staged across multiple PRs. The whole feature is a handful of fields, one new fallback-screen kind, and one settings card; it doesn't have the surface area (multi-source fetching, mashup rendering, day-parting eligibility) that justified staging those larger features.
+
+## Consequences
+
+- A future per-Device timezone field is additive to both Schedule and Sleep Mode — neither one's shape changes, only what timezone their windows are evaluated against.
+- A future custom-sleep-screen upload feature slots in as an alternative to the `sleep` fallback kind (e.g. a per-Device override checked before falling back to the shared rendered image) without touching the window/refresh-rate mechanics in ADR-0012.

--- a/docs/adr/0014-firmware-push-is-manual-and-admin-assigned.md
+++ b/docs/adr/0014-firmware-push-is-manual-and-admin-assigned.md
@@ -1,0 +1,13 @@
+# Firmware push is manual and admin-assigned, not automatic version comparison
+
+Issue #781 asks whether firmware updates should be pushed automatically — Kuroshiro already captures a Device's exact reported firmware version (`fw-version` header → `device.fwVersion`), so comparing it against the latest synced Firmware and auto-flipping `update_firmware` was a real option. We rejected it for v1: a Device only receives a push when an admin explicitly assigns a Firmware as its `targetFirmware` and sets `updateFirmware` (an entity column that already existed but was dead code — `display.service.ts` hardcoded it to `false`). On the Device's next poll, `/display` serves that Firmware's binary URL once and clears the flag — the same explicit, one-shot pattern `resetDevice` already uses, and the same "admin assigns, never inferred" shape as `device.deviceModel`. This applies only to non-mirrored Devices; a mirrored Device already gets `firmware_url` via TRMNL's own pass-through, and letting Kuroshiro's own targeting logic apply there too would create two competing authorities for the same field.
+
+## Considered options
+
+- **Automatic version-diffing** (compare `fwVersion` against the latest synced Firmware, auto-push when behind). Rejected: flashing the wrong or incompatible binary can brick a physical device, and per-Device explicit action is a much smaller blast radius than a background job deciding on its own — version-ordering semantics (semver vs. build number vs. string compare) aren't settled either.
+- **Global auto-update toggle** applying to every Device. Deferred: no global settings module exists in Kuroshiro yet; building one just for this would be new architecture, not a firmware decision.
+
+## Consequences
+
+- `device.updateFirmware` and `device.targetFirmware` are the entire push mechanism — nothing decides on its own that a Device is "due" for an update.
+- A future automatic policy is additive: it would set the same two fields Kuroshiro already reads on every poll, not change how `/display` serves them.

--- a/docs/adr/0015-firmware-compatibility-enforced-og-only-sync.md
+++ b/docs/adr/0015-firmware-compatibility-enforced-og-only-sync.md
@@ -1,0 +1,13 @@
+# Firmware compatibility is enforced against Device Model; official sync only ever produces an OG binary
+
+While grilling issue #781, we probed `usetrmnl.com/api/firmware/latest` directly — the same public, unauthenticated endpoint Terminus's own sync job hits. It always returns the OG binary (`trmnl_og/FW*.bin`) regardless of query params or headers; there is no public way to fetch the V2/BWRY variants through it. Of the roughly 50 Device Models TRMNL's `/api/models` lists, only four are actual OTA-capable first-party hardware (`v2`, `og_png`, `og_plus`, `og_bwry`, all `kind: "trmnl"`) — everything else (BYOD/Kindle/Tidbyt) never receives a firmware push at all. Because the sync source can't disambiguate hardware variants, and because flashing the wrong variant's binary can brick a Device, every Firmware carries an optional `compatibleModels` set (empty means universal) that's enforced as a hard block — not a warning — whenever a Firmware is assigned to a Device. The daily-synced row defaults its `compatibleModels` to the three OG variants, since the URL path (`trmnl_og/`) is the only concrete evidence of what it actually is. This deliberately improves on Terminus's own `Firmware` model, which carries no link to its `model` table at all — it treats firmware as a single flat, undifferentiated resource.
+
+## Considered options
+
+- **Match Terminus: no compatibility link.** Rejected: Kuroshiro already has the Device Model concept Terminus's schema lacks; not using it here to prevent an obviously-wrong flash would be leaving a real guardrail on the table.
+- **Try to reverse-engineer per-model official binaries** (e.g. guessing S3 paths for other variants). Rejected: no public, documented way to do this; the differentiation logic clearly lives in TRMNL's closed-source Core, reached only through the authenticated, per-account `/api/display` flow.
+
+## Consequences
+
+- V2/BWRY official firmware is unreachable via the sync job. Getting it into Kuroshiro requires an admin sourcing the binary themselves (e.g. building from `usetrmnl/firmware`) and uploading it as `custom`, tagged with the correct compatible models.
+- If TRMNL ever exposes per-model official binaries publicly, the sync job only needs to populate `compatibleModels` correctly per row — the assignment-time enforcement itself doesn't change.

--- a/docs/adr/0016-firmware-management-v1-scope-cuts.md
+++ b/docs/adr/0016-firmware-management-v1-scope-cuts.md
@@ -1,0 +1,15 @@
+# Firmware management v1 scope cuts
+
+Grilling issue #781 deliberately cut the following from v1:
+
+- **No global auto-update toggle** — per-Device only (see ADR-0014). No global settings module exists in Kuroshiro today.
+- **No binary/magic-byte validation on custom uploads** — only file size and extension/mimetype are checked, the same trust level Screens already gives uploaded images. Verifying a `.bin` actually looks like a legitimate ESP32 firmware image is real effort for a self-hosted, admin-only upload path; the admin is responsible for uploading a binary that matches their own hardware.
+- **Dedicated storage, not reused Screens storage** — binaries live under `public/firmware/{firmwareId}.bin`, not `public/screens/devices/{deviceId}/`, since a Firmware is a resource shared across many Devices, not generated per-Device.
+- **Sync cadence matches Device Model sync** (daily-at-4am + on boot), not Terminus's 6-hourly job — official firmware doesn't change often enough to justify a second cadence convention alongside the one sync job Kuroshiro already has.
+- **Full history retained, nothing silently overwritten** — official-synced rows are deprecated, never deleted, matching Device Model's own deprecate-on-disappear behaviour; custom uploads support explicit delete, mirroring Terminus's bulk delete.
+- **SHA-256 checksum, computed at upload/sync and re-verified at serve-time** — the wire protocol's `firmware_url` carries no checksum of its own, so this is the only integrity check available.
+
+## Consequences
+
+- Rolling a Device back to an older version is possible (nothing is deleted out from under a `targetFirmware` reference) without any extra "rollback" feature — it's just assigning an older row.
+- A future global auto-update toggle or deeper upload validation are both additive; neither requires reshaping the `Firmware` entity or the `/display` push mechanism from ADR-0014.


### PR DESCRIPTION
## Summary
- Sleep Mode (#779): dynamic-refresh-rate wake mechanic + v1 scope cuts (no per-Device timezone, no custom-uploadable sleep screen).
- Firmware management (#781): manual admin-assigned firmware push (no auto version-diffing), Device Model compatibility enforcement (official sync only ever produces an OG binary, confirmed against usetrmnl.com's public API), and v1 scope cuts.

## Test plan
- [x] Docs-only change, no code touched — nothing to test.

https://claude.ai/code/session_01FjPrcZND1RwsLYunhktwGw