### PR TITLE
docs: record custom colour palette decisions from grilling #783

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -13,8 +13,12 @@ The hardware class a Device belongs to — pixel dimensions, colour depth, rotat
 _Avoid_: Model (bare, in prose), panel, profile, display type
 
 **Palette**:
-The set of greys or colours an image is reduced to for a Device — chosen per Device from those its Device Model supports. Determines the image's bit depth.
+The set of greys or colours an image is reduced to for a Device — chosen per Device from those its Device Model supports. Determines the image's bit depth. Either `official` (synced from TRMNL, curated per Device Model via `paletteIds`) or `custom` (admin-created, restricted to a fixed colour family — see Palette Family — with compatibility derived automatically rather than curated per model).
 _Avoid_: Colour mode, bit depth (as a name for the choice), dither mode
+
+**Palette Family**:
+Which of TRMNL's 9 fixed rendering modes a Palette belongs to — 3 grayscale (1/2/4-bit), 5 colour (`3bwr`/`3bwy`/`4bwry`/`6a`/`7a`, each a fixed set of physical ink colours), or full-color. Identified by `frameworkClass`, which also drives the on-device CSS class — not a freely inventable string. Custom Palettes may only be authored in a colour family; a "custom" grayscale or full-color Palette would be indistinguishable from the official one of that family, so isn't offered.
+_Avoid_: Framework class (bare, in prose — reserve for the field name), colour mode, render mode
 
 **Screen**:
 A single unit of content assigned to a Device's rotation — a static image, an externally-fetched image, raw HTML, a plugin's rendered output, or a mashup. Screens belong to exactly one Device.

--- a/docs/adr/0014-custom-palettes-kind-flag-and-family-derived-compatibility.md
+++ b/docs/adr/0014-custom-palettes-kind-flag-and-family-derived-compatibility.md
@@ -1,0 +1,14 @@
+# Custom palettes are `kind`-flagged rows with generated IDs and family-derived compatibility
+
+`Palette` gains a `kind: 'official' | 'custom'` column. The daily sync job (`device-model-sync.service.ts`) only ever upserts or deprecates `kind: 'official'` rows; custom rows are written solely through admin CRUD and are never touched by sync. This is necessary because sync upserts by `id`, and without a discriminator a future upstream ID could collide with — or the deprecate-if-missing pass could wrongly touch — an admin-created row.
+
+Custom palette IDs are opaque and generated (nanoid), not human-chosen slugs like the official palettes' TRMNL-sourced IDs (`bw`, `gray-16`, …). This trades away a readable ID in exchange for making collision with a future upstream ID structurally impossible; `name` remains the human-facing label.
+
+Device-model compatibility for a custom palette is derived automatically from the colour family (see ADR-0015) it belongs to, rather than stored as an explicit per-model list. `DeviceModel.paletteIds` — the mechanism official palettes use — is wholesale overwritten from the upstream payload on every sync (`trmnl-payloads.ts`), so it cannot safely hold a custom palette's ID without a sync-ordering bug wiping it. `applyModelChanges`'s validation branches: membership in `paletteIds` for `kind: 'official'`, family-match against the target Device Model's `frameworkClass` for `kind: 'custom'`.
+
+A custom palette's `colors` array is arbitrary length, pre-filled with its family's official colours as a starting point but freely editable — not locked to the family's canonical count. The firmware classifies each dithered pixel independently by RGB threshold against its fixed physical ink colours (ADR-0002), rather than matching against the PNG palette's length, so there's no structural reason to enforce count parity.
+
+## Consequences
+
+- Deriving compatibility by family instead of reusing TRMNL's curated `paletteIds` bypasses per-model curation — including firmware colour-matching ADR-0002 found still unverified for `color-3bwr` and `color-7a`. An admin can assign a custom palette in either family to any device model in that family without that caveat surfacing.
+- Colours landing outside a family's firmware threshold bands may misclassify on real hardware; this isn't validated server-side, only worth surfacing as a UI hint.

--- a/docs/adr/0015-custom-palettes-v1-scope-cuts.md
+++ b/docs/adr/0015-custom-palettes-v1-scope-cuts.md
@@ -1,0 +1,12 @@
+# Custom palettes v1 scope cuts
+
+Grilling issue #783 deliberately cut the following from v1:
+
+- **No grayscale or full-color custom authoring.** Custom palettes are restricted to the 5 colour families (`color-3bwr`, `color-3bwy`, `color-4bwry`, `color-6a`, `color-7a`). Under this design's constraints (fixed `frameworkClass` families, grayscale locked to its canonical computed levels, full-color having no palette at all — ADR-0014), a "custom" grayscale or full-color entry would be byte-for-byte identical to the existing official palette of that family. Only the colour families have a genuinely free parameter — the `colors` array.
+- **No delete guard.** Deleting a custom palette that's still assigned to a Device relies on the existing `Device.palette` `SET NULL` FK, same as any other FK in the codebase — the Device silently falls back to `defaultPaletteFor(model)`, matching the existing behaviour for a Device with no palette set at all. This is a deliberate asymmetry from official palettes, which are never hard-deleted (sync only flips `deprecated: true`) — custom palettes are admin-owned and admin-deletable by design.
+- **No per-Screen / per-playlist-item palette override.** Reconfirms ADR-0008's existing deferral: palette is a rendering concern attached at the Device level, not a Schedule/eligibility concern. Still blocked on the separate Screen Playlists work landing a concrete Screen-level rendering hook to attach an override to.
+
+## Consequences
+
+- A future "custom grayscale palette" request should be treated as a signal the family-based authoring constraint (ADR-0014) needs revisiting, not as a simple additive feature — there's currently nothing distinct to store.
+- A per-Screen override, when built, is additive on top of this design — it doesn't require reshaping how custom palettes are authored or how compatibility is derived.


### PR DESCRIPTION
## Summary
- Records the design decisions from a `/grilling` session on #783 (user-created custom colour palettes)
- Adds ADR-0014: custom palettes are `kind`-flagged rows with generated IDs and family-derived compatibility
- Adds ADR-0015: v1 scope cuts (no grayscale/full-color custom authoring, no delete guard, per-Screen override still deferred)
- Updates `CONTEXT.md`'s `Palette` entry and adds a new `Palette Family` term

Docs only — no implementation in this PR.

Closes #783

https://claude.ai/code/session_01FjPrcZND1RwsLYunhktwGw