### PR TITLE
feat(plugins): Webhook Plugin Kind with persisted payload store and fixed Merge Strategy

### DIFF
--- a/packages/api/src/migrations/1787100000000-AddWebhookPlugins.ts
+++ b/packages/api/src/migrations/1787100000000-AddWebhookPlugins.ts
@@ -1,0 +1,42 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddWebhookPlugins1787100000000 implements MigrationInterface {
+  name = 'AddWebhookPlugins1787100000000'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "plugin"
+        ADD "webhookToken" text,
+        ADD "mergeStrategy" text,
+        ADD "streamLimit" integer,
+        ADD "webhookPayload" jsonb
+    `)
+
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX "UQ_plugin_webhookToken" ON "plugin" ("webhookToken")
+    `)
+
+    // "kind" was an unconstrained text column nothing branched on, so a client
+    // could have written any value into it before the check constraint lands.
+    await queryRunner.query(`
+      UPDATE "plugin" SET "kind" = 'Poll' WHERE "kind" NOT IN ('Poll', 'Webhook')
+    `)
+
+    await queryRunner.query(`
+      ALTER TABLE "plugin"
+        ADD CONSTRAINT "CHK_plugin_kind" CHECK ("kind" IN ('Poll', 'Webhook'))
+    `)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "plugin" DROP CONSTRAINT "CHK_plugin_kind"`)
+    await queryRunner.query(`DROP INDEX "UQ_plugin_webhookToken"`)
+    await queryRunner.query(`
+      ALTER TABLE "plugin"
+        DROP COLUMN "webhookPayload",
+        DROP COLUMN "streamLimit",
+        DROP COLUMN "mergeStrategy",
+        DROP COLUMN "webhookToken"
+    `)
+  }
+}

--- a/packages/api/src/migrations/1787100000000-AddWebhookPlugins.ts
+++ b/packages/api/src/migrations/1787100000000-AddWebhookPlugins.ts
@@ -16,8 +16,7 @@ export class AddWebhookPlugins1787100000000 implements MigrationInterface {
       CREATE UNIQUE INDEX "UQ_plugin_webhookToken" ON "plugin" ("webhookToken")
     `)
 
-    // "kind" was an unconstrained text column nothing branched on, so a client
-    // could have written any value into it before the check constraint lands.
+    // Normalises any value the check constraint below would reject.
     await queryRunner.query(`
       UPDATE "plugin" SET "kind" = 'Poll' WHERE "kind" NOT IN ('Poll', 'Webhook')
     `)

--- a/packages/api/src/plugins/__test__/plugin-render-cache.service.spec.ts
+++ b/packages/api/src/plugins/__test__/plugin-render-cache.service.spec.ts
@@ -1,0 +1,80 @@
+import type { Plugin } from '../entities/plugin.entity'
+import type { PluginRendererService } from '../services/plugin-renderer.service'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { PluginRenderCacheService } from '../services/plugin-render-cache.service'
+
+describe('pluginRenderCacheService', () => {
+  let service: PluginRenderCacheService
+  let mockRenderer: PluginRendererService
+  let mockScreenRepo: any
+  let mockMashupSlotRepo: any
+
+  const plugin = {
+    id: 'plugin-1',
+    templates: [{ layout: 'full', liquidMarkup: '{{ data }}' }],
+  } as unknown as Plugin
+
+  beforeEach(() => {
+    mockRenderer = {
+      render: vi.fn().mockResolvedValue('<div>rendered</div>'),
+    } as any
+
+    mockMashupSlotRepo = {
+      find: vi.fn().mockResolvedValue([]),
+    }
+
+    mockScreenRepo = {
+      update: vi.fn(),
+      manager: { getRepository: vi.fn(() => mockMashupSlotRepo) },
+    }
+
+    service = new PluginRenderCacheService(mockRenderer, mockScreenRepo)
+  })
+
+  it('renders the primary template and caches it to every screen of the plugin', async () => {
+    await service.renderAndCache(plugin, { data: 'hello' })
+
+    expect(mockRenderer.render).toHaveBeenCalledWith('{{ data }}', { data: 'hello' })
+    expect(mockScreenRepo.update).toHaveBeenCalledWith(
+      { plugin: { id: 'plugin-1' } },
+      expect.objectContaining({ cachedPluginOutput: '<div>rendered</div>' }),
+    )
+  })
+
+  it('does nothing when the plugin has no template', async () => {
+    await service.renderAndCache({ ...plugin, templates: [] } as unknown as Plugin, {})
+
+    expect(mockRenderer.render).not.toHaveBeenCalled()
+    expect(mockScreenRepo.update).not.toHaveBeenCalled()
+  })
+
+  it('invalidates mashup caches when plugin updates', async () => {
+    mockMashupSlotRepo.find = vi.fn().mockResolvedValue([
+      { id: 'slot-1', mashupConfiguration: { screen: { id: 'screen-1' } } },
+      { id: 'slot-2', mashupConfiguration: { screen: { id: 'screen-2' } } },
+    ])
+    service.mashupSlotRepository = mockMashupSlotRepo
+
+    await service.invalidateMashupCaches('plugin-1')
+
+    expect(mockMashupSlotRepo.find).toHaveBeenCalledWith({
+      where: { plugin: { id: 'plugin-1' } },
+      relations: { mashupConfiguration: { screen: true } },
+    })
+    expect(mockScreenRepo.update).toHaveBeenCalledWith(
+      { id: 'screen-1' },
+      { cachedPluginOutput: null },
+    )
+    expect(mockScreenRepo.update).toHaveBeenCalledWith(
+      { id: 'screen-2' },
+      { cachedPluginOutput: null },
+    )
+  })
+
+  it('does not fail if mashupSlotRepository not available', async () => {
+    service.mashupSlotRepository = null
+
+    await expect(service.invalidateMashupCaches('plugin-1')).resolves.toBeUndefined()
+    expect(mockScreenRepo.update).not.toHaveBeenCalled()
+  })
+})

--- a/packages/api/src/plugins/__test__/plugin-scheduler.service.spec.ts
+++ b/packages/api/src/plugins/__test__/plugin-scheduler.service.spec.ts
@@ -1,6 +1,6 @@
 import type { Plugin } from '../entities/plugin.entity'
 import type { PluginDataFetcherService } from '../services/plugin-data-fetcher.service'
-import type { PluginRendererService } from '../services/plugin-renderer.service'
+import type { PluginRenderCacheService } from '../services/plugin-render-cache.service'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { PluginSchedulerService } from '../services/plugin-scheduler.service'
 
@@ -16,24 +16,18 @@ vi.mock('node-cron', () => ({
 describe('pluginSchedulerService', () => {
   let service: PluginSchedulerService
   let mockDataFetcher: PluginDataFetcherService
-  let mockRenderer: PluginRendererService
-  let mockScreenRepo: any
+  let mockRenderCache: PluginRenderCacheService
 
   beforeEach(() => {
     mockDataFetcher = {
       fetchData: vi.fn(),
     } as any
 
-    mockRenderer = {
-      render: vi.fn(),
+    mockRenderCache = {
+      renderAndCache: vi.fn(),
     } as any
 
-    mockScreenRepo = {
-      update: vi.fn(),
-      find: vi.fn(),
-    }
-
-    service = new PluginSchedulerService(mockDataFetcher, mockRenderer, mockScreenRepo)
+    service = new PluginSchedulerService(mockDataFetcher, mockRenderCache)
   })
 
   it('schedules a plugin with refresh interval', () => {
@@ -154,46 +148,16 @@ describe('pluginSchedulerService', () => {
     expect(service.hasScheduledJob('plugin-1')).toBe(false)
   })
 
-  it('invalidates mashup caches when plugin updates', async () => {
-    const mockMashupSlotRepo = {
-      find: vi.fn().mockResolvedValue([
-        {
-          id: 'slot-1',
-          mashupConfiguration: {
-            screen: { id: 'screen-1' },
-          },
-        },
-        {
-          id: 'slot-2',
-          mashupConfiguration: {
-            screen: { id: 'screen-2' },
-          },
-        },
-      ]),
-    }
+  it('does not schedule Webhook-kind plugins', () => {
+    const plugin = {
+      id: 'plugin-1',
+      kind: 'Webhook',
+      refreshInterval: 15,
+      templates: [{ layout: 'full', liquidMarkup: 'Test' }],
+    } as unknown as Plugin
 
-    service.mashupSlotRepository = mockMashupSlotRepo
+    service.schedulePlugin(plugin)
 
-    await service.invalidateMashupCaches('plugin-1')
-
-    expect(mockMashupSlotRepo.find).toHaveBeenCalledWith({
-      where: { plugin: { id: 'plugin-1' } },
-      relations: { mashupConfiguration: { screen: true } },
-    })
-    expect(mockScreenRepo.update).toHaveBeenCalledWith(
-      { id: 'screen-1' },
-      { cachedPluginOutput: null },
-    )
-    expect(mockScreenRepo.update).toHaveBeenCalledWith(
-      { id: 'screen-2' },
-      { cachedPluginOutput: null },
-    )
-  })
-
-  it('does not fail if mashupSlotRepository not available', async () => {
-    service.mashupSlotRepository = null
-
-    await expect(service.invalidateMashupCaches('plugin-1')).resolves.toBeUndefined()
-    expect(mockScreenRepo.update).not.toHaveBeenCalled()
+    expect(service.hasScheduledJob('plugin-1')).toBe(false)
   })
 })

--- a/packages/api/src/plugins/__test__/plugins.service.spec.ts
+++ b/packages/api/src/plugins/__test__/plugins.service.spec.ts
@@ -607,6 +607,22 @@ describe('pluginsService', () => {
       )
     })
 
+    it('update rejects a nulled kind', async () => {
+      pluginRepo.findOne.mockResolvedValue({ ...webhookPlugin })
+
+      await expect(service.update('1', { kind: null } as any)).rejects.toThrow(
+        'A Plugin\'s Kind is fixed at creation and cannot be changed',
+      )
+    })
+
+    it('update rejects an explicit stream limit alongside a non-stream merge strategy', async () => {
+      pluginRepo.findOne.mockResolvedValue({ ...webhookPlugin })
+
+      await expect(service.update('1', { mergeStrategy: 'deep_merge', streamLimit: 20 } as any)).rejects.toThrow(
+        'A Stream Limit is only valid for the stream Merge Strategy',
+      )
+    })
+
     it('update accepts an unchanged kind', async () => {
       const stored = { ...webhookPlugin }
       pluginRepo.findOne.mockResolvedValue(stored)

--- a/packages/api/src/plugins/__test__/plugins.service.spec.ts
+++ b/packages/api/src/plugins/__test__/plugins.service.spec.ts
@@ -15,6 +15,7 @@ interface MockRepository {
   create: ReturnType<typeof vi.fn>
   save: ReturnType<typeof vi.fn>
   remove: ReturnType<typeof vi.fn>
+  update: ReturnType<typeof vi.fn>
   maximum?: ReturnType<typeof vi.fn>
 }
 
@@ -26,6 +27,7 @@ function createMockRepository(): MockRepository {
     create: vi.fn(),
     save: vi.fn(),
     remove: vi.fn(),
+    update: vi.fn(),
     maximum: vi.fn(),
   }
 }
@@ -561,5 +563,98 @@ describe('pluginsService', () => {
       {},
       expect.objectContaining({ api_key: 'secret-123' }),
     )
+  })
+
+  describe('webhook-kind plugins', () => {
+    const webhookPlugin = {
+      id: '1',
+      name: 'Sensor Feed',
+      kind: 'Webhook',
+      refreshInterval: 15,
+      webhookToken: 'token-abc',
+      mergeStrategy: 'stream',
+      streamLimit: 20,
+    } as unknown as Plugin
+
+    it('create issues a webhook token and never schedules the plugin', async () => {
+      pluginRepo.save.mockImplementation(async (plugin: any) => ({ ...plugin, id: '1' }))
+      pluginRepo.findOne.mockResolvedValue(webhookPlugin)
+
+      await service.create({ name: 'Sensor Feed', kind: 'Webhook', mergeStrategy: 'standard' } as any)
+
+      expect(pluginRepo.save).toHaveBeenCalledWith(expect.objectContaining({
+        kind: 'Webhook',
+        mergeStrategy: 'standard',
+        webhookToken: expect.any(String),
+      }))
+      expect(mockScheduler.schedulePlugin).not.toHaveBeenCalled()
+    })
+
+    it('create rejects a data source on a webhook-kind plugin', async () => {
+      await expect(service.create({
+        name: 'Sensor Feed',
+        kind: 'Webhook',
+        mergeStrategy: 'standard',
+        dataSource: { url: 'https://api.example.com' },
+      } as any)).rejects.toThrow('A Webhook-kind Plugin cannot have a Data Source')
+    })
+
+    it('update rejects a change of kind', async () => {
+      pluginRepo.findOne.mockResolvedValue({ ...webhookPlugin })
+
+      await expect(service.update('1', { kind: 'Poll' } as any)).rejects.toThrow(
+        'A Plugin\'s Kind is fixed at creation and cannot be changed',
+      )
+    })
+
+    it('update accepts an unchanged kind', async () => {
+      const stored = { ...webhookPlugin }
+      pluginRepo.findOne.mockResolvedValue(stored)
+      pluginRepo.save.mockImplementation(async (plugin: any) => plugin)
+
+      await expect(service.update('1', { kind: 'Webhook', name: 'Renamed' } as any)).resolves.toMatchObject({ name: 'Renamed' })
+    })
+
+    it('update rejects a merge strategy on a poll-kind plugin', async () => {
+      pluginRepo.findOne.mockResolvedValue({ ...basePlugin })
+
+      await expect(service.update('1', { mergeStrategy: 'stream' } as any)).rejects.toThrow(
+        'A Poll-kind Plugin cannot have a Merge Strategy',
+      )
+    })
+
+    it('update drops the stream limit when the merge strategy moves off stream', async () => {
+      const stored = { ...webhookPlugin }
+      pluginRepo.findOne.mockResolvedValue(stored)
+      pluginRepo.save.mockImplementation(async (plugin: any) => plugin)
+
+      const updated = await service.update('1', { mergeStrategy: 'deep_merge' } as any)
+
+      expect(updated).toMatchObject({ mergeStrategy: 'deep_merge', streamLimit: null })
+    })
+
+    it('update rejects a directly supplied webhook token', async () => {
+      pluginRepo.findOne.mockResolvedValue({ ...webhookPlugin })
+
+      await expect(service.update('1', { webhookToken: 'stolen' } as any)).rejects.toThrow(
+        'The Webhook Token is issued by Kuroshiro and cannot be set directly',
+      )
+    })
+
+    it('regenerateWebhookToken issues a new token', async () => {
+      pluginRepo.findOneBy.mockResolvedValue({ ...webhookPlugin })
+
+      const result = await service.regenerateWebhookToken('1')
+
+      expect(result.webhookToken).not.toBe('token-abc')
+      expect(pluginRepo.update).toHaveBeenCalledWith('1', { webhookToken: result.webhookToken })
+    })
+
+    it('clearWebhookPayload rejects a poll-kind plugin', async () => {
+      pluginRepo.findOneBy.mockResolvedValue({ ...basePlugin })
+
+      await expect(service.clearWebhookPayload('1')).rejects.toThrow('is not a Webhook-kind Plugin')
+      expect(pluginRepo.update).not.toHaveBeenCalled()
+    })
   })
 })

--- a/packages/api/src/plugins/__test__/webhook-ingest.integration.spec.ts
+++ b/packages/api/src/plugins/__test__/webhook-ingest.integration.spec.ts
@@ -179,6 +179,14 @@ describe('webhook ingest integration', () => {
       expect(screens[1].cachedPluginOutput).toBeNull()
     })
 
+    it('rejects with 422 rather than accumulating unbounded when a stream Plugin has no Stream Limit', async () => {
+      plugin.mergeStrategy = 'stream'
+      plugin.streamLimit = null
+
+      await expect(ingest.ingest(plugin, { readings: [1] })).rejects.toThrow(UnprocessableEntityException)
+      expect(plugin.webhookPayload).toBeNull()
+    })
+
     it('rejects with 422 and stores nothing when the Plugin has no template', async () => {
       plugin.templates = []
 

--- a/packages/api/src/plugins/__test__/webhook-ingest.integration.spec.ts
+++ b/packages/api/src/plugins/__test__/webhook-ingest.integration.spec.ts
@@ -1,0 +1,216 @@
+import type { TestingModule } from '@nestjs/testing'
+import type { Plugin } from '../entities/plugin.entity'
+import { UnprocessableEntityException } from '@nestjs/common'
+import { Test } from '@nestjs/testing'
+import { getRepositoryToken } from '@nestjs/typeorm'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { MashupSlot } from '../../mashup/entities/mashup-slot.entity'
+import { Screen } from '../../screens/screens.entity'
+import { DevicePlugin } from '../entities/device-plugin.entity'
+import { PluginDataSource } from '../entities/plugin-data-source.entity'
+import { PluginField } from '../entities/plugin-field.entity'
+import { PluginTemplate } from '../entities/plugin-template.entity'
+import { Plugin as PluginEntity } from '../entities/plugin.entity'
+import { PluginsService } from '../plugins.service'
+import { PluginDataFetcherService } from '../services/plugin-data-fetcher.service'
+import { PluginRenderCacheService } from '../services/plugin-render-cache.service'
+import { PluginRendererService } from '../services/plugin-renderer.service'
+import { PluginSchedulerService } from '../services/plugin-scheduler.service'
+import { PluginTransformService } from '../services/plugin-transform.service'
+import { WebhookIngestService } from '../services/webhook-ingest.service'
+
+function matches(entity: any, where: Record<string, any>): boolean {
+  return Object.entries(where).every(([key, value]) => {
+    if (value && typeof value === 'object' && 'id' in value)
+      return entity[key]?.id === value.id
+    return entity[key] === value
+  })
+}
+
+describe('webhook ingest integration', () => {
+  let ingest: WebhookIngestService
+  let pluginsService: PluginsService
+  let plugin: Plugin
+  let screens: any[]
+  let mashupSlots: any[]
+
+  const template = { layout: 'full', liquidMarkup: 'readings: {{ readings.size }} status: {{ status }}' }
+
+  beforeEach(async () => {
+    plugin = {
+      id: 'plugin-1',
+      name: 'Sensor Feed',
+      kind: 'Webhook',
+      refreshInterval: 15,
+      webhookToken: 'token-abc',
+      mergeStrategy: 'standard',
+      streamLimit: null,
+      webhookPayload: null,
+      templates: [template],
+    } as unknown as Plugin
+
+    screens = [
+      { id: 'screen-1', plugin: { id: 'plugin-1' }, cachedPluginOutput: 'stale' },
+      { id: 'mashup-screen-1', plugin: null, cachedPluginOutput: 'stale mashup' },
+    ]
+
+    mashupSlots = [
+      { id: 'slot-1', plugin: { id: 'plugin-1' }, mashupConfiguration: { screen: { id: 'mashup-screen-1' } } },
+    ]
+
+    const mashupSlotRepo = {
+      find: vi.fn(async ({ where }: any) => mashupSlots.filter(slot => matches(slot, where))),
+    }
+
+    const screenRepo = {
+      update: vi.fn(async (where: any, partial: any) => {
+        screens.filter(screen => matches(screen, where)).forEach(screen => Object.assign(screen, partial))
+      }),
+      manager: { getRepository: (name: string) => (name === 'MashupSlot' ? mashupSlotRepo : null) },
+    }
+
+    const pluginRepo = {
+      findOne: vi.fn(async ({ where }: any) => (matches(plugin, where) ? plugin : null)),
+      findOneBy: vi.fn(async (where: any) => (matches(plugin, where) ? plugin : null)),
+      save: vi.fn(async (entity: any) => entity),
+      update: vi.fn(async (id: string, partial: any) => {
+        if (id === plugin.id)
+          Object.assign(plugin, partial)
+      }),
+      manager: { getRepository: (name: string) => (name === 'MashupSlot' ? mashupSlotRepo : null) },
+    }
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WebhookIngestService,
+        PluginRenderCacheService,
+        PluginRendererService,
+        PluginsService,
+        { provide: getRepositoryToken(PluginEntity), useValue: pluginRepo },
+        { provide: getRepositoryToken(DevicePlugin), useValue: {} },
+        { provide: getRepositoryToken(Screen), useValue: screenRepo },
+        { provide: getRepositoryToken(PluginDataSource), useValue: {} },
+        { provide: getRepositoryToken(PluginTemplate), useValue: {} },
+        { provide: getRepositoryToken(PluginField), useValue: {} },
+        { provide: getRepositoryToken(MashupSlot), useValue: mashupSlotRepo },
+        { provide: PluginDataFetcherService, useValue: {} },
+        { provide: PluginTransformService, useValue: {} },
+        { provide: PluginSchedulerService, useValue: { schedulePlugin: vi.fn(), removeScheduledJob: vi.fn() } },
+      ],
+    }).compile()
+
+    ingest = module.get(WebhookIngestService)
+    pluginsService = module.get(PluginsService)
+
+    // Wait for lazy injection of mashupSlotRepository
+    await new Promise(resolve => setTimeout(resolve, 10))
+  })
+
+  describe('standard merge strategy', () => {
+    it('replaces the stored Webhook Payload outright', async () => {
+      await ingest.ingest(plugin, { status: 'ok', readings: [1, 2] })
+      await ingest.ingest(plugin, { status: 'degraded' })
+
+      expect(plugin.webhookPayload).toEqual({ status: 'degraded' })
+    })
+  })
+
+  describe('deep_merge merge strategy', () => {
+    beforeEach(() => {
+      plugin.mergeStrategy = 'deep_merge'
+    })
+
+    it('recursively merges nested objects', async () => {
+      await ingest.ingest(plugin, { sensor: { name: 'attic', temp: 21 }, status: 'ok' })
+      await ingest.ingest(plugin, { sensor: { temp: 23 } })
+
+      expect(plugin.webhookPayload).toEqual({ sensor: { name: 'attic', temp: 23 }, status: 'ok' })
+    })
+
+    it('replaces a colliding array wholesale instead of concatenating', async () => {
+      await ingest.ingest(plugin, { readings: [1, 2, 3] })
+      await ingest.ingest(plugin, { readings: [9] })
+
+      expect(plugin.webhookPayload).toEqual({ readings: [9] })
+    })
+  })
+
+  describe('stream merge strategy', () => {
+    beforeEach(() => {
+      plugin.mergeStrategy = 'stream'
+      plugin.streamLimit = 3
+    })
+
+    it('appends top-level arrays and replaces other keys normally', async () => {
+      await ingest.ingest(plugin, { readings: [1], status: 'ok' })
+      await ingest.ingest(plugin, { readings: [2], status: 'degraded' })
+
+      expect(plugin.webhookPayload).toEqual({ readings: [1, 2], status: 'degraded' })
+    })
+
+    it('evicts the oldest entries once the Stream Limit is exceeded', async () => {
+      await ingest.ingest(plugin, { readings: [1, 2] })
+      await ingest.ingest(plugin, { readings: [3, 4] })
+
+      expect(plugin.webhookPayload).toEqual({ readings: [2, 3, 4] })
+    })
+
+    it('evicts within a single oversized POST', async () => {
+      await ingest.ingest(plugin, { readings: [1, 2, 3, 4, 5] })
+
+      expect(plugin.webhookPayload).toEqual({ readings: [3, 4, 5] })
+    })
+  })
+
+  describe('rendering', () => {
+    it('renders the template against the full merged payload and caches it to every Screen', async () => {
+      plugin.mergeStrategy = 'stream'
+      plugin.streamLimit = 10
+
+      await ingest.ingest(plugin, { readings: [1, 2], status: 'ok' })
+      await ingest.ingest(plugin, { readings: [3] })
+
+      expect(screens[0].cachedPluginOutput).toBe('readings: 3 status: ok')
+    })
+
+    it('invalidates Mashup caches that include the Plugin', async () => {
+      await ingest.ingest(plugin, { status: 'ok' })
+
+      expect(screens[1].cachedPluginOutput).toBeNull()
+    })
+
+    it('rejects with 422 and stores nothing when the Plugin has no template', async () => {
+      plugin.templates = []
+
+      await expect(ingest.ingest(plugin, { status: 'ok' })).rejects.toThrow(UnprocessableEntityException)
+      expect(plugin.webhookPayload).toBeNull()
+    })
+  })
+
+  describe('reading the stored payload', () => {
+    it('returns the Webhook Payload as-is', async () => {
+      await ingest.ingest(plugin, { status: 'ok', readings: [1, 2] })
+
+      expect(ingest.readPayload(plugin)).toEqual({ status: 'ok', readings: [1, 2] })
+    })
+
+    it('returns null before the first POST', () => {
+      expect(ingest.readPayload(plugin)).toBeNull()
+    })
+  })
+
+  describe('clearing the stored payload', () => {
+    it('empties the Webhook Payload without touching the webhook configuration', async () => {
+      plugin.mergeStrategy = 'stream'
+      plugin.streamLimit = 3
+      await ingest.ingest(plugin, { readings: [1] })
+
+      await pluginsService.clearWebhookPayload('plugin-1')
+
+      expect(plugin.webhookPayload).toBeNull()
+      expect(plugin.webhookToken).toBe('token-abc')
+      expect(plugin.mergeStrategy).toBe('stream')
+      expect(plugin.streamLimit).toBe(3)
+    })
+  })
+})

--- a/packages/api/src/plugins/__test__/webhook-plugin.guard.spec.ts
+++ b/packages/api/src/plugins/__test__/webhook-plugin.guard.spec.ts
@@ -1,0 +1,52 @@
+import type { ExecutionContext } from '@nestjs/common'
+import { UnauthorizedException } from '@nestjs/common'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { WebhookPluginGuard } from '../guards/webhook-plugin.guard'
+
+describe('webhookPluginGuard', () => {
+  let guard: WebhookPluginGuard
+  let pluginRepo: any
+  let request: any
+
+  const plugin = { id: 'plugin-1', kind: 'Webhook', webhookToken: 'token-abc' }
+
+  function contextFor(token?: string): ExecutionContext {
+    request = { params: token === undefined ? {} : { token } }
+    return {
+      switchToHttp: () => ({ getRequest: () => request }),
+    } as unknown as ExecutionContext
+  }
+
+  beforeEach(() => {
+    pluginRepo = {
+      findOne: vi.fn(async ({ where }: any) => (where.webhookToken === plugin.webhookToken ? plugin : null)),
+    }
+    guard = new WebhookPluginGuard(pluginRepo)
+  })
+
+  it('resolves the Plugin from its Webhook Token and attaches it to the request', async () => {
+    await expect(guard.canActivate(contextFor('token-abc'))).resolves.toBe(true)
+
+    expect(request.plugin).toBe(plugin)
+  })
+
+  it('only resolves Webhook-kind Plugins', async () => {
+    await guard.canActivate(contextFor('token-abc'))
+
+    expect(pluginRepo.findOne).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { webhookToken: 'token-abc', kind: 'Webhook' } }),
+    )
+  })
+
+  it('rejects an unknown Webhook Token', async () => {
+    await expect(guard.canActivate(contextFor('nope'))).rejects.toThrow(UnauthorizedException)
+
+    expect(request.plugin).toBeUndefined()
+  })
+
+  it('rejects a missing Webhook Token without touching Plugin data', async () => {
+    await expect(guard.canActivate(contextFor())).rejects.toThrow(UnauthorizedException)
+
+    expect(pluginRepo.findOne).not.toHaveBeenCalled()
+  })
+})

--- a/packages/api/src/plugins/dto/__test__/create-plugin.dto.spec.ts
+++ b/packages/api/src/plugins/dto/__test__/create-plugin.dto.spec.ts
@@ -1,5 +1,12 @@
+import { plainToInstance } from 'class-transformer'
+import { validate } from 'class-validator'
 import { describe, expect, it } from 'vitest'
 import { CreatePluginDto } from '../create-plugin.dto'
+
+async function violations(payload: Record<string, any>): Promise<string[]> {
+  const errors = await validate(plainToInstance(CreatePluginDto, payload))
+  return errors.flatMap(error => Object.values(error.constraints ?? {}))
+}
 
 describe('create-plugin dto', () => {
   it('creates dto with basic fields', () => {
@@ -44,5 +51,78 @@ describe('create-plugin dto', () => {
 
     expect(dto.fields).toHaveLength(1)
     expect(dto.fields?.[0].keyname).toBe('api_key')
+  })
+
+  describe('plugin kind', () => {
+    it('defaults to Poll', () => {
+      expect(plainToInstance(CreatePluginDto, { name: 'Weather Plugin' }).kind).toBe('Poll')
+    })
+
+    it('accepts Poll and Webhook', async () => {
+      await expect(violations({ name: 'Poll Plugin', kind: 'Poll' })).resolves.toEqual([])
+      await expect(violations({ name: 'Webhook Plugin', kind: 'Webhook', mergeStrategy: 'standard' })).resolves.toEqual([])
+    })
+
+    it('rejects any other kind', async () => {
+      await expect(violations({ name: 'Weird Plugin', kind: 'Push' })).resolves.toContain(
+        'kind must be one of the following values: Poll, Webhook',
+      )
+    })
+  })
+
+  describe('poll-kind field restrictions', () => {
+    it('rejects a Merge Strategy', async () => {
+      await expect(violations({ name: 'Poll Plugin', mergeStrategy: 'standard' })).resolves.toContain(
+        'A Poll-kind Plugin cannot have a Merge Strategy',
+      )
+    })
+
+    it('rejects a Stream Limit', async () => {
+      await expect(violations({ name: 'Poll Plugin', streamLimit: 10 })).resolves.toContain(
+        'A Poll-kind Plugin cannot have a Stream Limit',
+      )
+    })
+
+    it('rejects a Webhook Token', async () => {
+      await expect(violations({ name: 'Poll Plugin', webhookToken: 'token-abc' })).resolves.toContain(
+        'The Webhook Token is issued by Kuroshiro and cannot be set directly',
+      )
+    })
+  })
+
+  describe('webhook-kind field restrictions', () => {
+    it('rejects a Data Source', async () => {
+      const payload = { name: 'Webhook Plugin', kind: 'Webhook', mergeStrategy: 'standard', dataSource: { url: 'https://api.example.com' } }
+
+      await expect(violations(payload)).resolves.toContain('A Webhook-kind Plugin cannot have a Data Source')
+    })
+
+    it('requires a Merge Strategy', async () => {
+      await expect(violations({ name: 'Webhook Plugin', kind: 'Webhook' })).resolves.toContain(
+        'A Webhook-kind Plugin requires a Merge Strategy',
+      )
+    })
+
+    it('rejects an unknown Merge Strategy', async () => {
+      await expect(violations({ name: 'Webhook Plugin', kind: 'Webhook', mergeStrategy: 'append' })).resolves.toContain(
+        'mergeStrategy must be one of the following values: standard, deep_merge, stream',
+      )
+    })
+
+    it('requires a Stream Limit for the stream Merge Strategy', async () => {
+      await expect(violations({ name: 'Webhook Plugin', kind: 'Webhook', mergeStrategy: 'stream' })).resolves.toContain(
+        'A stream Merge Strategy requires a Stream Limit',
+      )
+    })
+
+    it('accepts a Stream Limit alongside the stream Merge Strategy', async () => {
+      await expect(violations({ name: 'Webhook Plugin', kind: 'Webhook', mergeStrategy: 'stream', streamLimit: 50 })).resolves.toEqual([])
+    })
+
+    it('rejects a Stream Limit for any other Merge Strategy', async () => {
+      await expect(violations({ name: 'Webhook Plugin', kind: 'Webhook', mergeStrategy: 'deep_merge', streamLimit: 50 })).resolves.toContain(
+        'A Stream Limit is only valid for the stream Merge Strategy',
+      )
+    })
   })
 })

--- a/packages/api/src/plugins/dto/__test__/update-plugin.dto.spec.ts
+++ b/packages/api/src/plugins/dto/__test__/update-plugin.dto.spec.ts
@@ -66,8 +66,6 @@ describe('update-plugin dto', () => {
       await expect(violations({ streamLimit: 0 })).resolves.toContain('streamLimit must not be less than 1')
     })
 
-    // Kind immutability and the Poll/Webhook field restrictions need the stored
-    // Plugin to compare against, so PluginsService.update enforces them.
     it('rejects a kind outside Poll and Webhook', async () => {
       await expect(violations({ kind: 'Push' })).resolves.toContain(
         'kind must be one of the following values: Poll, Webhook',

--- a/packages/api/src/plugins/dto/__test__/update-plugin.dto.spec.ts
+++ b/packages/api/src/plugins/dto/__test__/update-plugin.dto.spec.ts
@@ -1,5 +1,12 @@
+import { plainToInstance } from 'class-transformer'
+import { validate } from 'class-validator'
 import { describe, expect, it } from 'vitest'
 import { UpdatePluginDto } from '../update-plugin.dto'
+
+async function violations(payload: Record<string, any>): Promise<string[]> {
+  const errors = await validate(plainToInstance(UpdatePluginDto, payload))
+  return errors.flatMap(error => Object.values(error.constraints ?? {}))
+}
 
 describe('update-plugin dto', () => {
   it('creates dto with partial fields', () => {
@@ -42,5 +49,29 @@ describe('update-plugin dto', () => {
 
     expect(dto.fields).toHaveLength(1)
     expect(dto.fields?.[0].keyname).toBe('new_field')
+  })
+
+  describe('webhook fields', () => {
+    it('accepts a new Merge Strategy and Stream Limit', async () => {
+      await expect(violations({ mergeStrategy: 'stream', streamLimit: 20 })).resolves.toEqual([])
+    })
+
+    it('rejects an unknown Merge Strategy', async () => {
+      await expect(violations({ mergeStrategy: 'append' })).resolves.toContain(
+        'mergeStrategy must be one of the following values: standard, deep_merge, stream',
+      )
+    })
+
+    it('rejects a Stream Limit below 1', async () => {
+      await expect(violations({ streamLimit: 0 })).resolves.toContain('streamLimit must not be less than 1')
+    })
+
+    // Kind immutability and the Poll/Webhook field restrictions need the stored
+    // Plugin to compare against, so PluginsService.update enforces them.
+    it('rejects a kind outside Poll and Webhook', async () => {
+      await expect(violations({ kind: 'Push' })).resolves.toContain(
+        'kind must be one of the following values: Poll, Webhook',
+      )
+    })
   })
 })

--- a/packages/api/src/plugins/dto/create-plugin.dto.ts
+++ b/packages/api/src/plugins/dto/create-plugin.dto.ts
@@ -1,4 +1,41 @@
-import { IsBoolean, IsInt, IsOptional, IsString } from 'class-validator'
+import type { ValidationArguments, ValidationOptions, ValidatorConstraintInterface } from 'class-validator'
+import type { MergeStrategy, PluginKind } from '../entities/plugin.entity'
+import { IsBoolean, IsIn, IsInt, IsOptional, IsString, Min, registerDecorator, ValidatorConstraint } from 'class-validator'
+import { MERGE_STRATEGIES, PLUGIN_KINDS } from '../entities/plugin.entity'
+import { pluginKindFieldViolation } from '../plugin-kind-fields'
+
+@ValidatorConstraint({ name: 'pluginKindFields' })
+class PluginKindFieldsConstraint implements ValidatorConstraintInterface {
+  validate(_value: unknown, args: ValidationArguments): boolean {
+    return pluginKindFieldViolation(this.fieldsOf(args)) === null
+  }
+
+  defaultMessage(args: ValidationArguments): string {
+    return pluginKindFieldViolation(this.fieldsOf(args)) ?? ''
+  }
+
+  private fieldsOf(args: ValidationArguments) {
+    const dto = args.object as CreatePluginDto
+    return {
+      kind: dto.kind,
+      dataSource: dto.dataSource,
+      webhookToken: dto.webhookToken,
+      mergeStrategy: dto.mergeStrategy,
+      streamLimit: dto.streamLimit,
+    }
+  }
+}
+
+function MatchesPluginKind(validationOptions?: ValidationOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      validator: PluginKindFieldsConstraint,
+    })
+  }
+}
 
 export class CreatePluginDto {
   @IsString()
@@ -8,9 +45,9 @@ export class CreatePluginDto {
   @IsString()
   description?: string
 
-  @IsOptional()
-  @IsString()
-  kind?: string
+  @IsIn(PLUGIN_KINDS)
+  @MatchesPluginKind()
+  kind: PluginKind = 'Poll'
 
   @IsOptional()
   @IsInt()
@@ -23,6 +60,19 @@ export class CreatePluginDto {
   @IsOptional()
   @IsInt()
   order?: number
+
+  @IsOptional()
+  @IsString()
+  webhookToken?: string
+
+  @IsOptional()
+  @IsIn(MERGE_STRATEGIES)
+  mergeStrategy?: MergeStrategy
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  streamLimit?: number
 
   @IsOptional()
   dataSource?: any

--- a/packages/api/src/plugins/dto/update-plugin.dto.ts
+++ b/packages/api/src/plugins/dto/update-plugin.dto.ts
@@ -1,4 +1,6 @@
-import { IsBoolean, IsInt, IsOptional, IsString } from 'class-validator'
+import type { MergeStrategy, PluginKind } from '../entities/plugin.entity'
+import { IsBoolean, IsIn, IsInt, IsOptional, IsString, Min } from 'class-validator'
+import { MERGE_STRATEGIES, PLUGIN_KINDS } from '../entities/plugin.entity'
 
 export class UpdatePluginDto {
   @IsOptional()
@@ -10,8 +12,8 @@ export class UpdatePluginDto {
   description?: string
 
   @IsOptional()
-  @IsString()
-  kind?: string
+  @IsIn(PLUGIN_KINDS)
+  kind?: PluginKind
 
   @IsOptional()
   @IsInt()
@@ -24,6 +26,19 @@ export class UpdatePluginDto {
   @IsOptional()
   @IsInt()
   order?: number
+
+  @IsOptional()
+  @IsString()
+  webhookToken?: string
+
+  @IsOptional()
+  @IsIn(MERGE_STRATEGIES)
+  mergeStrategy?: MergeStrategy
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  streamLimit?: number
 
   @IsOptional()
   dataSource?: any

--- a/packages/api/src/plugins/entities/plugin.entity.ts
+++ b/packages/api/src/plugins/entities/plugin.entity.ts
@@ -3,7 +3,15 @@ import type { PluginDataSource } from './plugin-data-source.entity'
 import type { PluginField } from './plugin-field.entity'
 import type { PluginTemplate } from './plugin-template.entity'
 import type { PluginVariable } from './plugin-variable.entity'
-import { Column, CreateDateColumn, Entity, OneToMany, OneToOne, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm'
+import { Column, CreateDateColumn, Entity, Index, OneToMany, OneToOne, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm'
+
+export const PLUGIN_KINDS = ['Poll', 'Webhook'] as const
+export type PluginKind = typeof PLUGIN_KINDS[number]
+
+export const MERGE_STRATEGIES = ['standard', 'deep_merge', 'stream'] as const
+export type MergeStrategy = typeof MERGE_STRATEGIES[number]
+
+export type WebhookPayload = Record<string, any> | any[] | null
 
 @Entity()
 export class Plugin {
@@ -17,10 +25,23 @@ export class Plugin {
   description?: string
 
   @Column('text', { default: 'Poll' })
-  kind: string = 'Poll'
+  kind: PluginKind = 'Poll'
 
   @Column('int', { default: 15 })
   refreshInterval: number = 15
+
+  @Index({ unique: true })
+  @Column('text', { nullable: true })
+  webhookToken?: string | null
+
+  @Column('text', { nullable: true })
+  mergeStrategy?: MergeStrategy | null
+
+  @Column('int', { nullable: true })
+  streamLimit?: number | null
+
+  @Column('jsonb', { nullable: true })
+  webhookPayload?: WebhookPayload
 
   @CreateDateColumn()
   createdAt: Date

--- a/packages/api/src/plugins/guards/webhook-plugin.guard.ts
+++ b/packages/api/src/plugins/guards/webhook-plugin.guard.ts
@@ -19,7 +19,7 @@ export class WebhookPluginGuard implements CanActivate {
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest<WebhookRequest>()
-    const token = request.params?.token
+    const token = request.params?.token as string | undefined
 
     if (!token) {
       throw new UnauthorizedException('Invalid webhook token')

--- a/packages/api/src/plugins/guards/webhook-plugin.guard.ts
+++ b/packages/api/src/plugins/guards/webhook-plugin.guard.ts
@@ -1,0 +1,40 @@
+import type { CanActivate, ExecutionContext } from '@nestjs/common'
+import type { Request } from 'express'
+import type { Repository } from 'typeorm'
+import type { Plugin } from '../entities/plugin.entity'
+import { Injectable, UnauthorizedException } from '@nestjs/common'
+import { InjectRepository } from '@nestjs/typeorm'
+import { Plugin as PluginEntity } from '../entities/plugin.entity'
+
+export interface WebhookRequest extends Request {
+  plugin: Plugin
+}
+
+@Injectable()
+export class WebhookPluginGuard implements CanActivate {
+  constructor(
+    @InjectRepository(PluginEntity)
+    private readonly pluginRepository: Repository<PluginEntity>,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest<WebhookRequest>()
+    const token = request.params?.token
+
+    if (!token) {
+      throw new UnauthorizedException('Invalid webhook token')
+    }
+
+    const plugin = await this.pluginRepository.findOne({
+      where: { webhookToken: token, kind: 'Webhook' },
+      relations: { templates: true },
+    })
+
+    if (!plugin) {
+      throw new UnauthorizedException('Invalid webhook token')
+    }
+
+    request.plugin = plugin
+    return true
+  }
+}

--- a/packages/api/src/plugins/plugin-kind-fields.ts
+++ b/packages/api/src/plugins/plugin-kind-fields.ts
@@ -1,0 +1,50 @@
+import type { MergeStrategy, PluginKind } from './entities/plugin.entity'
+
+export interface PluginKindFields {
+  kind: PluginKind
+  dataSource?: unknown
+  webhookToken?: unknown
+  mergeStrategy?: MergeStrategy | null
+  streamLimit?: number | null
+}
+
+function isPresent(value: unknown): boolean {
+  return value !== undefined && value !== null
+}
+
+/**
+ * Poll and Webhook Plugins have disjoint required fields; a Plugin carrying a
+ * field from the Kind it isn't is rejected rather than silently ignored.
+ */
+export function pluginKindFieldViolation(fields: PluginKindFields): string | null {
+  const { kind, dataSource, webhookToken, mergeStrategy, streamLimit } = fields
+
+  if (isPresent(webhookToken)) {
+    return 'The Webhook Token is issued by Kuroshiro and cannot be set directly'
+  }
+
+  if (kind === 'Poll') {
+    if (isPresent(mergeStrategy)) {
+      return 'A Poll-kind Plugin cannot have a Merge Strategy'
+    }
+    if (isPresent(streamLimit)) {
+      return 'A Poll-kind Plugin cannot have a Stream Limit'
+    }
+    return null
+  }
+
+  if (isPresent(dataSource)) {
+    return 'A Webhook-kind Plugin cannot have a Data Source'
+  }
+  if (!isPresent(mergeStrategy)) {
+    return 'A Webhook-kind Plugin requires a Merge Strategy'
+  }
+  if (mergeStrategy === 'stream' && !isPresent(streamLimit)) {
+    return 'A stream Merge Strategy requires a Stream Limit'
+  }
+  if (mergeStrategy !== 'stream' && isPresent(streamLimit)) {
+    return 'A Stream Limit is only valid for the stream Merge Strategy'
+  }
+
+  return null
+}

--- a/packages/api/src/plugins/plugins.controller.ts
+++ b/packages/api/src/plugins/plugins.controller.ts
@@ -1,5 +1,5 @@
 import type { Response } from 'express'
-import { Body, Controller, Delete, Get, Param, Patch, Post, Res, UploadedFile, UseInterceptors } from '@nestjs/common'
+import { Body, Controller, Delete, Get, Param, Patch, Post, Res, UploadedFile, UseInterceptors, UsePipes, ValidationPipe } from '@nestjs/common'
 import { FileInterceptor } from '@nestjs/platform-express'
 import { diskStorage } from 'multer'
 import { AssignPluginToDeviceDto } from './dto/assign-plugin-to-device.dto'
@@ -38,13 +38,25 @@ export class PluginsController {
   }
 
   @Post()
+  @UsePipes(new ValidationPipe({ transform: true }))
   async create(@Body() createPluginDto: CreatePluginDto) {
     return this.pluginsService.create(createPluginDto)
   }
 
   @Patch(':id')
+  @UsePipes(new ValidationPipe({ transform: true }))
   async update(@Param('id') id: string, @Body() updatePluginDto: UpdatePluginDto) {
     return this.pluginsService.update(id, updatePluginDto)
+  }
+
+  @Delete(':id/webhook-payload')
+  async clearWebhookPayload(@Param('id') id: string) {
+    return this.pluginsService.clearWebhookPayload(id)
+  }
+
+  @Post(':id/webhook-token')
+  async regenerateWebhookToken(@Param('id') id: string) {
+    return this.pluginsService.regenerateWebhookToken(id)
   }
 
   @Delete(':id')

--- a/packages/api/src/plugins/plugins.module.ts
+++ b/packages/api/src/plugins/plugins.module.ts
@@ -8,14 +8,18 @@ import { PluginFieldValue } from './entities/plugin-field-value.entity'
 import { PluginField } from './entities/plugin-field.entity'
 import { PluginTemplate } from './entities/plugin-template.entity'
 import { Plugin } from './entities/plugin.entity'
+import { WebhookPluginGuard } from './guards/webhook-plugin.guard'
 import { PluginsController } from './plugins.controller'
 import { PluginsService } from './plugins.service'
 import { PluginDataFetcherService } from './services/plugin-data-fetcher.service'
 import { PluginExporterService } from './services/plugin-exporter.service'
 import { PluginImporterService } from './services/plugin-importer.service'
+import { PluginRenderCacheService } from './services/plugin-render-cache.service'
 import { PluginRendererService } from './services/plugin-renderer.service'
 import { PluginSchedulerService } from './services/plugin-scheduler.service'
 import { PluginTransformService } from './services/plugin-transform.service'
+import { WebhookIngestService } from './services/webhook-ingest.service'
+import { WebhookIngestController } from './webhook-ingest.controller'
 
 @Module({
   imports: [
@@ -30,7 +34,7 @@ import { PluginTransformService } from './services/plugin-transform.service'
       Screen,
     ]),
   ],
-  controllers: [PluginsController],
+  controllers: [PluginsController, WebhookIngestController],
   providers: [
     PluginsService,
     PluginDataFetcherService,
@@ -39,7 +43,10 @@ import { PluginTransformService } from './services/plugin-transform.service'
     PluginImporterService,
     PluginExporterService,
     PluginTransformService,
+    PluginRenderCacheService,
+    WebhookIngestService,
+    WebhookPluginGuard,
   ],
-  exports: [PluginsService, PluginSchedulerService, PluginDataFetcherService, PluginRendererService, PluginTransformService],
+  exports: [PluginsService, PluginSchedulerService, PluginDataFetcherService, PluginRendererService, PluginTransformService, PluginRenderCacheService],
 })
 export class PluginsModule {}

--- a/packages/api/src/plugins/plugins.service.ts
+++ b/packages/api/src/plugins/plugins.service.ts
@@ -258,28 +258,24 @@ export class PluginsService implements OnModuleInit {
 
     const { dataSource, templates, fields, webhookToken, webhookPayload, ...basicFields } = pluginData as any
 
-    if (basicFields.kind != null && basicFields.kind !== plugin.kind) {
+    if ('kind' in basicFields && basicFields.kind !== plugin.kind) {
       throw new BadRequestException(`A Plugin's Kind is fixed at creation and cannot be changed`)
     }
 
-    if (webhookToken != null && webhookToken !== plugin.webhookToken) {
-      throw new BadRequestException('The Webhook Token is issued by Kuroshiro and cannot be set directly')
-    }
-
     const mergeStrategy = 'mergeStrategy' in basicFields ? basicFields.mergeStrategy : plugin.mergeStrategy
-    const streamLimit = 'streamLimit' in basicFields ? basicFields.streamLimit : plugin.streamLimit
-    const effectiveStreamLimit = plugin.kind === 'Webhook' && mergeStrategy !== 'stream' ? null : streamLimit
+    const streamLimit = mergeStrategy === 'stream' ? basicFields.streamLimit ?? plugin.streamLimit : basicFields.streamLimit
 
     this.assertKindFields({
       kind: plugin.kind,
       dataSource: dataSource ?? plugin.dataSource,
+      webhookToken: webhookToken === plugin.webhookToken ? undefined : webhookToken,
       mergeStrategy,
-      streamLimit: effectiveStreamLimit,
+      streamLimit,
     })
 
     if (plugin.kind === 'Webhook') {
       basicFields.mergeStrategy = mergeStrategy
-      basicFields.streamLimit = effectiveStreamLimit
+      basicFields.streamLimit = streamLimit ?? null
     }
 
     Object.assign(plugin, basicFields)

--- a/packages/api/src/plugins/plugins.service.ts
+++ b/packages/api/src/plugins/plugins.service.ts
@@ -1,14 +1,17 @@
 import type { MashupSlot } from '../mashup/entities/mashup-slot.entity'
 import type { AssignPluginToDeviceDto } from './dto/assign-plugin-to-device.dto'
-import { BadRequestException, Injectable, Logger, OnModuleInit } from '@nestjs/common'
+import type { PluginKindFields } from './plugin-kind-fields'
+import { BadRequestException, Injectable, Logger, NotFoundException, OnModuleInit } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
 import { Repository } from 'typeorm'
 import { Screen } from '../screens/screens.entity'
+import generateApikey from '../utils/generateApikey'
 import { DevicePlugin } from './entities/device-plugin.entity'
 import { PluginDataSource } from './entities/plugin-data-source.entity'
 import { PluginField } from './entities/plugin-field.entity'
 import { PluginTemplate } from './entities/plugin-template.entity'
 import { Plugin } from './entities/plugin.entity'
+import { pluginKindFieldViolation } from './plugin-kind-fields'
 import { PluginDataFetcherService } from './services/plugin-data-fetcher.service'
 import { PluginRendererService } from './services/plugin-renderer.service'
 import { PluginSchedulerService } from './services/plugin-scheduler.service'
@@ -57,6 +60,9 @@ export class PluginsService implements OnModuleInit {
     })
 
     for (const plugin of plugins) {
+      if (plugin.kind === 'Webhook') {
+        continue
+      }
       if (plugin.dataSource && plugin.templates && plugin.templates.length > 0) {
         this.scheduler.schedulePlugin(plugin)
         this.logger.log(`Scheduled plugin: ${plugin.name}`)
@@ -156,11 +162,28 @@ export class PluginsService implements OnModuleInit {
 
     this.logger.debug(`Creating plugin with data: ${JSON.stringify({ dataSource, templates, fields, basicFields })}`)
 
+    const kind = basicFields.kind || 'Poll'
+
+    this.assertKindFields({
+      kind,
+      dataSource,
+      webhookToken: basicFields.webhookToken,
+      mergeStrategy: basicFields.mergeStrategy,
+      streamLimit: basicFields.streamLimit,
+    })
+
     const pluginToSave = {
       name: basicFields.name,
       description: basicFields.description,
-      kind: basicFields.kind || 'Poll',
+      kind,
       refreshInterval: basicFields.refreshInterval || 15,
+      ...(kind === 'Webhook'
+        ? {
+            webhookToken: generateApikey(),
+            mergeStrategy: basicFields.mergeStrategy,
+            streamLimit: basicFields.streamLimit ?? null,
+          }
+        : {}),
     }
 
     const savedPlugin = await this.pluginRepository.save(pluginToSave)
@@ -233,7 +256,31 @@ export class PluginsService implements OnModuleInit {
     if (!plugin)
       return null
 
-    const { dataSource, templates, fields, ...basicFields } = pluginData as any
+    const { dataSource, templates, fields, webhookToken, webhookPayload, ...basicFields } = pluginData as any
+
+    if (basicFields.kind != null && basicFields.kind !== plugin.kind) {
+      throw new BadRequestException(`A Plugin's Kind is fixed at creation and cannot be changed`)
+    }
+
+    if (webhookToken != null && webhookToken !== plugin.webhookToken) {
+      throw new BadRequestException('The Webhook Token is issued by Kuroshiro and cannot be set directly')
+    }
+
+    const mergeStrategy = 'mergeStrategy' in basicFields ? basicFields.mergeStrategy : plugin.mergeStrategy
+    const streamLimit = 'streamLimit' in basicFields ? basicFields.streamLimit : plugin.streamLimit
+    const effectiveStreamLimit = plugin.kind === 'Webhook' && mergeStrategy !== 'stream' ? null : streamLimit
+
+    this.assertKindFields({
+      kind: plugin.kind,
+      dataSource: dataSource ?? plugin.dataSource,
+      mergeStrategy,
+      streamLimit: effectiveStreamLimit,
+    })
+
+    if (plugin.kind === 'Webhook') {
+      basicFields.mergeStrategy = mergeStrategy
+      basicFields.streamLimit = effectiveStreamLimit
+    }
 
     Object.assign(plugin, basicFields)
 
@@ -305,6 +352,43 @@ export class PluginsService implements OnModuleInit {
     }
 
     return updated
+  }
+
+  async clearWebhookPayload(id: string): Promise<Plugin> {
+    const plugin = await this.requireWebhookPlugin(id)
+
+    await this.pluginRepository.update(id, { webhookPayload: null })
+    this.logger.log(`Cleared webhook payload for plugin: ${plugin.name}`)
+
+    return { ...plugin, webhookPayload: null }
+  }
+
+  async regenerateWebhookToken(id: string): Promise<Plugin> {
+    const plugin = await this.requireWebhookPlugin(id)
+    const webhookToken = generateApikey()
+
+    await this.pluginRepository.update(id, { webhookToken })
+    this.logger.log(`Regenerated webhook token for plugin: ${plugin.name}`)
+
+    return { ...plugin, webhookToken }
+  }
+
+  private async requireWebhookPlugin(id: string): Promise<Plugin> {
+    const plugin = await this.pluginRepository.findOneBy({ id })
+    if (!plugin) {
+      throw new NotFoundException(`Plugin ${id} not found`)
+    }
+    if (plugin.kind !== 'Webhook') {
+      throw new BadRequestException(`Plugin "${plugin.name}" is not a Webhook-kind Plugin`)
+    }
+    return plugin
+  }
+
+  private assertKindFields(fields: PluginKindFields): void {
+    const violation = pluginKindFieldViolation(fields)
+    if (violation) {
+      throw new BadRequestException(violation)
+    }
   }
 
   async checkPluginUsage(id: string): Promise<{ inMashups: Array<{ screenId: string, screenName: string }> }> {

--- a/packages/api/src/plugins/services/plugin-importer.service.ts
+++ b/packages/api/src/plugins/services/plugin-importer.service.ts
@@ -1,3 +1,4 @@
+import type { PluginKind } from '../entities/plugin.entity'
 import { Buffer } from 'node:buffer'
 import * as fs from 'node:fs'
 import * as path from 'node:path'
@@ -44,7 +45,7 @@ interface TerminusSettings {
 interface ParsedPlugin {
   name: string
   description?: string
-  kind: string
+  kind: PluginKind
   refreshInterval: number
   dataSource: {
     method: string

--- a/packages/api/src/plugins/services/plugin-render-cache.service.ts
+++ b/packages/api/src/plugins/services/plugin-render-cache.service.ts
@@ -1,0 +1,74 @@
+import type { MashupSlot } from '../../mashup/entities/mashup-slot.entity'
+import type { Plugin } from '../entities/plugin.entity'
+import { Injectable, Logger } from '@nestjs/common'
+import { InjectRepository } from '@nestjs/typeorm'
+import { Repository } from 'typeorm'
+import { Screen } from '../../screens/screens.entity'
+import { PluginRendererService } from './plugin-renderer.service'
+
+@Injectable()
+export class PluginRenderCacheService {
+  private mashupSlotRepository: Repository<MashupSlot>
+  private readonly logger = new Logger(PluginRenderCacheService.name)
+
+  constructor(
+    private readonly renderer: PluginRendererService,
+    @InjectRepository(Screen)
+    private readonly screenRepository: Repository<Screen>,
+  ) {
+    // Lazy injection to avoid circular dependency
+    setTimeout(() => {
+      try {
+        this.mashupSlotRepository = this.screenRepository.manager.getRepository('MashupSlot')
+      }
+      catch {
+        this.logger.debug('MashupSlot repository not available')
+      }
+    }, 0)
+  }
+
+  async renderAndCache(plugin: Plugin, data: any): Promise<void> {
+    if (!plugin.templates || plugin.templates.length === 0) {
+      return
+    }
+
+    const rendered = await this.renderer.render(plugin.templates[0].liquidMarkup, data)
+
+    await this.screenRepository.update(
+      { plugin: { id: plugin.id } },
+      {
+        cachedPluginOutput: rendered,
+        generatedAt: new Date(),
+      },
+    )
+
+    await this.invalidateMashupCaches(plugin.id)
+  }
+
+  async invalidateMashupCaches(pluginId: string): Promise<void> {
+    if (!this.mashupSlotRepository) {
+      return
+    }
+
+    try {
+      const mashupsWithPlugin = await this.mashupSlotRepository.find({
+        where: { plugin: { id: pluginId } },
+        relations: { mashupConfiguration: { screen: true } },
+      })
+
+      for (const slot of mashupsWithPlugin) {
+        await this.screenRepository.update(
+          { id: slot.mashupConfiguration.screen.id },
+          { cachedPluginOutput: null },
+        )
+      }
+
+      if (mashupsWithPlugin.length > 0) {
+        this.logger.log(`Invalidated ${mashupsWithPlugin.length} mashup cache(s) for plugin ${pluginId}`)
+      }
+    }
+    catch (error) {
+      this.logger.error(`Failed to invalidate mashup caches for plugin ${pluginId}: ${error.message}`)
+    }
+  }
+}

--- a/packages/api/src/plugins/services/plugin-scheduler.service.ts
+++ b/packages/api/src/plugins/services/plugin-scheduler.service.ts
@@ -60,7 +60,7 @@ export class PluginSchedulerService {
         await this.renderCache.renderAndCache(plugin, data)
       }
       catch (error) {
-        this.logger.error(`Error executing plugin ${plugin.id}: ${error.message}`)
+        this.logger.error(`Error executing plugin ${plugin.id}`, error)
       }
     })
 

--- a/packages/api/src/plugins/services/plugin-scheduler.service.ts
+++ b/packages/api/src/plugins/services/plugin-scheduler.service.ts
@@ -1,38 +1,25 @@
 import type { ScheduledTask } from 'node-cron'
-import type { MashupSlot } from '../../mashup/entities/mashup-slot.entity'
 import type { Plugin } from '../entities/plugin.entity'
 import { Injectable, Logger } from '@nestjs/common'
-import { InjectRepository } from '@nestjs/typeorm'
 import cron from 'node-cron'
-import { Repository } from 'typeorm'
-import { Screen } from '../../screens/screens.entity'
 import { PluginDataFetcherService } from './plugin-data-fetcher.service'
-import { PluginRendererService } from './plugin-renderer.service'
+import { PluginRenderCacheService } from './plugin-render-cache.service'
 
 @Injectable()
 export class PluginSchedulerService {
   private scheduledJobs: Map<string, ScheduledTask> = new Map()
-  private mashupSlotRepository: Repository<MashupSlot>
   private readonly logger = new Logger(PluginSchedulerService.name)
 
   constructor(
     private readonly dataFetcher: PluginDataFetcherService,
-    private readonly renderer: PluginRendererService,
-    @InjectRepository(Screen)
-    private readonly screenRepository: Repository<Screen>,
-  ) {
-    // Lazy injection to avoid circular dependency
-    setTimeout(() => {
-      try {
-        this.mashupSlotRepository = this.screenRepository.manager.getRepository('MashupSlot')
-      }
-      catch {
-        this.logger.debug('MashupSlot repository not available')
-      }
-    }, 0)
-  }
+    private readonly renderCache: PluginRenderCacheService,
+  ) {}
 
   schedulePlugin(plugin: Plugin): void {
+    if (plugin.kind === 'Webhook') {
+      return
+    }
+
     if (!plugin.dataSource || !plugin.templates || plugin.templates.length === 0) {
       return
     }
@@ -70,56 +57,14 @@ export class PluginSchedulerService {
           templateContext,
         )
 
-        // Render primary template and cache to all associated screens
-        if (plugin.templates.length > 0) {
-          const rendered = await this.renderer.render(plugin.templates[0].liquidMarkup, data)
-
-          // Update all screens for this plugin
-          await this.screenRepository.update(
-            { plugin: { id: plugin.id } },
-            {
-              cachedPluginOutput: rendered,
-              generatedAt: new Date(),
-            },
-          )
-
-          // Invalidate mashup caches that use this plugin
-          await this.invalidateMashupCaches(plugin.id)
-        }
+        await this.renderCache.renderAndCache(plugin, data)
       }
       catch (error) {
-        console.error(`Error executing plugin ${plugin.id}:`, error)
+        this.logger.error(`Error executing plugin ${plugin.id}: ${error.message}`)
       }
     })
 
     this.scheduledJobs.set(plugin.id, task)
-  }
-
-  async invalidateMashupCaches(pluginId: string): Promise<void> {
-    if (!this.mashupSlotRepository) {
-      return
-    }
-
-    try {
-      const mashupsWithPlugin = await this.mashupSlotRepository.find({
-        where: { plugin: { id: pluginId } },
-        relations: { mashupConfiguration: { screen: true } },
-      })
-
-      for (const slot of mashupsWithPlugin) {
-        await this.screenRepository.update(
-          { id: slot.mashupConfiguration.screen.id },
-          { cachedPluginOutput: null },
-        )
-      }
-
-      if (mashupsWithPlugin.length > 0) {
-        this.logger.log(`Invalidated ${mashupsWithPlugin.length} mashup cache(s) for plugin ${pluginId}`)
-      }
-    }
-    catch (error) {
-      this.logger.error(`Failed to invalidate mashup caches for plugin ${pluginId}: ${error.message}`)
-    }
   }
 
   removeScheduledJob(pluginId: string): void {

--- a/packages/api/src/plugins/services/webhook-ingest.service.ts
+++ b/packages/api/src/plugins/services/webhook-ingest.service.ts
@@ -1,0 +1,86 @@
+import type { MergeStrategy, WebhookPayload } from '../entities/plugin.entity'
+import { Injectable, Logger, UnprocessableEntityException } from '@nestjs/common'
+import { InjectRepository } from '@nestjs/typeorm'
+import { Repository } from 'typeorm'
+import { Plugin } from '../entities/plugin.entity'
+import { PluginRenderCacheService } from './plugin-render-cache.service'
+
+type JsonObject = Record<string, any>
+
+function isPlainObject(value: unknown): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function deepMerge(stored: unknown, incoming: unknown): unknown {
+  if (!isPlainObject(stored) || !isPlainObject(incoming)) {
+    return incoming
+  }
+
+  return Object.entries(incoming).reduce<JsonObject>(
+    (merged, [key, value]) => ({
+      ...merged,
+      [key]: isPlainObject(value) && isPlainObject(stored[key]) ? deepMerge(stored[key], value) : value,
+    }),
+    { ...stored },
+  )
+}
+
+function appendStream(stored: unknown, incoming: unknown, streamLimit?: number | null): unknown {
+  if (!isPlainObject(incoming)) {
+    return incoming
+  }
+
+  const base: JsonObject = isPlainObject(stored) ? { ...stored } : {}
+
+  return Object.entries(incoming).reduce<JsonObject>((merged, [key, value]) => {
+    if (!Array.isArray(value)) {
+      return { ...merged, [key]: value }
+    }
+
+    const existing = Array.isArray(merged[key]) ? merged[key] : []
+    const appended = [...existing, ...value]
+
+    return { ...merged, [key]: streamLimit && streamLimit > 0 ? appended.slice(-streamLimit) : appended }
+  }, base)
+}
+
+function merge(strategy: MergeStrategy | null | undefined, stored: unknown, incoming: unknown, streamLimit?: number | null): unknown {
+  switch (strategy) {
+    case 'deep_merge':
+      return deepMerge(stored, incoming)
+    case 'stream':
+      return appendStream(stored, incoming, streamLimit)
+    default:
+      return incoming
+  }
+}
+
+@Injectable()
+export class WebhookIngestService {
+  private readonly logger = new Logger(WebhookIngestService.name)
+
+  constructor(
+    @InjectRepository(Plugin)
+    private readonly pluginRepository: Repository<Plugin>,
+    private readonly renderCache: PluginRenderCacheService,
+  ) {}
+
+  async ingest(plugin: Plugin, body: unknown): Promise<{ success: boolean }> {
+    if (!plugin.templates || plugin.templates.length === 0) {
+      throw new UnprocessableEntityException(`Plugin "${plugin.name}" has no template configured`)
+    }
+
+    const merged = merge(plugin.mergeStrategy, plugin.webhookPayload, body, plugin.streamLimit) as WebhookPayload
+
+    await this.pluginRepository.update(plugin.id, { webhookPayload: merged })
+    await this.renderCache.renderAndCache(plugin, merged)
+
+    this.logger.debug(`Ingested webhook payload for plugin ${plugin.id} using ${plugin.mergeStrategy} merge strategy`)
+
+    return { success: true }
+  }
+
+  readPayload(plugin: Plugin): WebhookPayload {
+    return plugin.webhookPayload ?? null
+  }
+}

--- a/packages/api/src/plugins/services/webhook-ingest.service.ts
+++ b/packages/api/src/plugins/services/webhook-ingest.service.ts
@@ -1,4 +1,4 @@
-import type { MergeStrategy, WebhookPayload } from '../entities/plugin.entity'
+import type { WebhookPayload } from '../entities/plugin.entity'
 import { Injectable, Logger, UnprocessableEntityException } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
 import { Repository } from 'typeorm'
@@ -25,7 +25,7 @@ function deepMerge(stored: unknown, incoming: unknown): unknown {
   )
 }
 
-function appendStream(stored: unknown, incoming: unknown, streamLimit?: number | null): unknown {
+function appendStream(stored: unknown, incoming: unknown, streamLimit: number): unknown {
   if (!isPlainObject(incoming)) {
     return incoming
   }
@@ -40,19 +40,8 @@ function appendStream(stored: unknown, incoming: unknown, streamLimit?: number |
     const existing = Array.isArray(merged[key]) ? merged[key] : []
     const appended = [...existing, ...value]
 
-    return { ...merged, [key]: streamLimit && streamLimit > 0 ? appended.slice(-streamLimit) : appended }
+    return { ...merged, [key]: appended.slice(-streamLimit) }
   }, base)
-}
-
-function merge(strategy: MergeStrategy | null | undefined, stored: unknown, incoming: unknown, streamLimit?: number | null): unknown {
-  switch (strategy) {
-    case 'deep_merge':
-      return deepMerge(stored, incoming)
-    case 'stream':
-      return appendStream(stored, incoming, streamLimit)
-    default:
-      return incoming
-  }
 }
 
 @Injectable()
@@ -70,7 +59,7 @@ export class WebhookIngestService {
       throw new UnprocessableEntityException(`Plugin "${plugin.name}" has no template configured`)
     }
 
-    const merged = merge(plugin.mergeStrategy, plugin.webhookPayload, body, plugin.streamLimit) as WebhookPayload
+    const merged = this.merge(plugin, body)
 
     await this.pluginRepository.update(plugin.id, { webhookPayload: merged })
     await this.renderCache.renderAndCache(plugin, merged)
@@ -82,5 +71,19 @@ export class WebhookIngestService {
 
   readPayload(plugin: Plugin): WebhookPayload {
     return plugin.webhookPayload ?? null
+  }
+
+  private merge(plugin: Plugin, body: unknown): WebhookPayload {
+    switch (plugin.mergeStrategy) {
+      case 'deep_merge':
+        return deepMerge(plugin.webhookPayload, body) as WebhookPayload
+      case 'stream':
+        if (!plugin.streamLimit || plugin.streamLimit < 1) {
+          throw new UnprocessableEntityException(`Plugin "${plugin.name}" has a stream Merge Strategy without a Stream Limit`)
+        }
+        return appendStream(plugin.webhookPayload, body, plugin.streamLimit) as WebhookPayload
+      default:
+        return body as WebhookPayload
+    }
   }
 }

--- a/packages/api/src/plugins/webhook-ingest.controller.ts
+++ b/packages/api/src/plugins/webhook-ingest.controller.ts
@@ -1,0 +1,28 @@
+import type { WebhookRequest } from './guards/webhook-plugin.guard'
+import { Body, Controller, Get, Header, Post, Req, UseGuards } from '@nestjs/common'
+import { WebhookPluginGuard } from './guards/webhook-plugin.guard'
+import { WebhookIngestService } from './services/webhook-ingest.service'
+
+@Controller('webhook')
+@UseGuards(WebhookPluginGuard)
+export class WebhookIngestController {
+  constructor(
+    private readonly ingestService: WebhookIngestService,
+  ) {}
+
+  /**
+   * Serialized here rather than returned as an object because Nest answers a
+   * null return with an empty body, and a Plugin with nothing stored yet should
+   * still answer with JSON.
+   */
+  @Get(':token')
+  @Header('Content-Type', 'application/json')
+  readPayload(@Req() request: WebhookRequest): string {
+    return JSON.stringify(this.ingestService.readPayload(request.plugin))
+  }
+
+  @Post(':token')
+  async ingest(@Req() request: WebhookRequest, @Body() body: unknown) {
+    return this.ingestService.ingest(request.plugin, body)
+  }
+}


### PR DESCRIPTION
## What

Implements the `Webhook` Plugin Kind end to end (API only): an ingest route, a persisted Webhook Payload, and a fixed per-Plugin Merge Strategy.

Closes #789.

## How it works

**Ingest route** — `GET`/`POST` on `/api/webhook/:token`, in its own controller (`webhook-ingest.controller.ts`), parallel to how the device-display controller sits apart from the device admin controller. The Plugin's `id` never appears in the route.

**`WebhookPluginGuard`** — the codebase's first Nest Guard. Resolves the Plugin from `:token` (Webhook-kind only), attaches it to the request, and rejects with `401` before any payload is read or written. Justified over the inline token comparisons used elsewhere because `GET` and `POST` share identical auth logic.

**`WebhookIngestService`** — merges the POST body into the stored Webhook Payload per the Plugin's Merge Strategy:

| Strategy | Behaviour |
| --- | --- |
| `standard` | replaces the stored payload outright |
| `deep_merge` | recursively merges plain objects; a colliding array is replaced wholesale, never concatenated |
| `stream` | appends top-level array values to the stored arrays, truncating oldest-first to the Stream Limit; other top-level keys are replaced normally |

Then persists it and renders the template against the **full merged payload** synchronously. A Plugin with no template configured gets `422` and nothing is stored. `GET` returns the stored payload as-is — no wrapper, no metadata.

**`PluginRenderCacheService`** — the render-and-cache logic (render primary template → write `Screen.cachedPluginOutput` → invalidate dependent Mashup caches) is lifted out of the Poll scheduler's cron callback into its own service, so both Kinds share one pipeline and only the trigger differs. Mashup cache invalidation therefore fires on webhook-triggered renders too.

**`Plugin.kind`** is now a real `'Poll' | 'Webhook'` type: validated at the DTO layer, enforced by a DB check constraint, and immutable after creation. Poll and Webhook fields are rejected at the Kind they don't belong to (`dataSource` on Webhook; `mergeStrategy`/`streamLimit`/`webhookToken` on Poll), with `streamLimit` required for `stream`. Webhook-kind Plugins are skipped by the scheduler's registration pass outright rather than by the incidental "has a Data Source" check.

**Admin actions** on the existing Plugin API surface:
- `DELETE /api/plugins/:id/webhook-payload` — clears the stored payload, leaving Webhook Token, Merge Strategy and Stream Limit untouched.
- `POST /api/plugins/:id/webhook-token` — regenerates the Webhook Token.

**Migration** `1787100000000-AddWebhookPlugins` adds the four columns, the unique `webhookToken` index, and the `kind` check constraint. No backfill needed — no Plugin has ever been `Webhook` in practice — though any stray `kind` value is normalised to `Poll` first, since the column was unconstrained text until now.

## Judgement calls worth flagging

- **Kind immutability and the update-path field rules are enforced in `PluginsService.update`, not in `UpdatePluginDto`.** The DTO can't see the stored Plugin, so it can't tell an attempted Kind *change* from the UI echoing the Kind back unchanged (`PluginEditView` PATCHes the whole fetched Plugin object). Same reasoning for the Webhook Token: supplying a *different* token is rejected, echoing the current one is not. `CreatePluginDto` does carry the full cross-field rules, since `kind` is always present there. The rule itself lives once, in `pluginKindFieldViolation()`, and both paths call it.
- **`ValidationPipe` is now applied to `POST /plugins` and `PATCH /plugins/:id`.** The DTO decorators on this controller were never enforced before, so none of the new validation would have run. Configured as `{ transform: true }` only — no `whitelist`/`forbidNonWhitelisted`, which would reject the extra properties the UI already sends.
- **Changing Merge Strategy away from `stream` nulls the Stream Limit** rather than making the caller clear it by hand ("required when `stream`, disallowed/ignored otherwise").
- **`GET` serializes the payload explicitly** so a Plugin with nothing stored yet answers `null` instead of Nest's empty body.
- **The migration normalises stray `kind` values to `'Poll'` before adding the check constraint.** The spec says no backfill is needed, and in practice none is — but `kind` was unconstrained text with no validation in front of it, and a single unexpected value would fail the migration and stop the container from booting. Nothing has ever branched on the column, so `'Poll'` is what any other value already behaved as.
- **A `stream` Plugin missing its Stream Limit answers `422`** rather than merging unbounded. Validation makes it unreachable, but the invariant fails loudly instead of silently growing the payload.

## Known gap

**Story 23 — "no payload size limit enforced" — is only partly delivered.** Nothing in this PR adds a limit, but Nest's default `express.json` 100 KB body cap still applies, so a POST above that gets a `413`. Lifting it for this route needs either `express` added as a direct dependency of `packages/api` (it isn't one today — only `@types/express` is, so `import { json } from 'express'` doesn't resolve under pnpm) or a global `main.ts` body-parser change affecting every endpoint. Both are wider than this spec, and "payload size limits" is listed under its Out of Scope, so I left it — worth its own issue if a real integration hits the cap.

## Out of scope (per the spec)

No admin UI (Kind selector, token display/regeneration, Merge Strategy editing, clear button) — that needs its own spec now that this API exists. No payload size or rate limits, no `GET` response metadata, no per-request `merge_strategy`.

## Tests

- `webhook-ingest.integration.spec.ts` — the primary seam: real services through Nest's testing module with in-memory fake repositories, covering all three strategies (including the array-replace and FIFO-eviction rules), the `422` case, `GET`, the clear action, and Mashup cache invalidation on a webhook-triggered render.
- `webhook-plugin.guard.spec.ts` — narrow unit spec for the Guard alone.
- Extended `create-plugin.dto.spec.ts` / `update-plugin.dto.spec.ts` with real `class-validator` runs for the Kind and field-exclusivity rules.
- Kind immutability, token regeneration and the clear action's Poll-kind rejection are covered in `plugins.service.spec.ts` rather than in the update DTO spec the testing decisions named — the DTO can't see the stored Plugin, so that's where the rule actually lives.
- `plugin-render-cache.service.spec.ts` takes over the Mashup-invalidation tests from the scheduler spec.

Full API suite: 520 passed, 5 skipped. Reviewed on both the Standards and Spec axes before opening; the findings worth acting on are folded into the second commit.

---
https://claude.ai/code/session_01X2RKQepMLodbBgKoNorCeW
