### PR TITLE
feat(device-models): support admin-created custom colour palettes

### DIFF
--- a/packages/api/src/device-models/__test__/custom-palettes.service.spec.ts
+++ b/packages/api/src/device-models/__test__/custom-palettes.service.spec.ts
@@ -1,0 +1,104 @@
+import type { Repository } from 'typeorm'
+import type { Palette } from '../entities/palette.entity'
+import { BadRequestException, NotFoundException } from '@nestjs/common'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { CustomPalettesService } from '../custom-palettes.service'
+import { CUSTOM_PALETTE_FRAMEWORK_CLASSES } from '../entities/palette.entity'
+
+interface MockRepository {
+  create: ReturnType<typeof vi.fn>
+  save: ReturnType<typeof vi.fn>
+  findOneBy: ReturnType<typeof vi.fn>
+  remove: ReturnType<typeof vi.fn>
+}
+
+function createMockRepository(): MockRepository {
+  return {
+    create: vi.fn(entity => entity),
+    save: vi.fn(async entity => entity),
+    findOneBy: vi.fn(),
+    remove: vi.fn(async entity => entity),
+  }
+}
+
+const validDto = { name: 'My Red', frameworkClass: 'screen--color-3bwr', colors: ['#ff0000', '#ffffff', '#000000'] } as const
+
+describe('customPalettesService', () => {
+  let service: CustomPalettesService
+  let repo: MockRepository
+
+  beforeEach(() => {
+    repo = createMockRepository()
+    service = new CustomPalettesService(repo as unknown as Repository<Palette>)
+  })
+
+  describe('create', () => {
+    it.each(CUSTOM_PALETTE_FRAMEWORK_CLASSES)('creates a custom palette for the %s family', async (frameworkClass) => {
+      const result = await service.create({ ...validDto, frameworkClass } as any)
+      expect(result.kind).toBe('custom')
+      expect(result.frameworkClass).toBe(frameworkClass)
+      expect(result.colors).toEqual(validDto.colors)
+      expect(result.name).toBe(validDto.name)
+    })
+
+    it('generates an opaque id, not derived from name', async () => {
+      const result = await service.create({ ...validDto } as any)
+      expect(result.id).not.toContain('My Red')
+      expect(result.id).toMatch(/^[0-9a-f-]{36}$/)
+    })
+
+    it('generates a different id for every call', async () => {
+      const a = await service.create({ ...validDto } as any)
+      const b = await service.create({ ...validDto } as any)
+      expect(a.id).not.toBe(b.id)
+    })
+
+    it('fixes grays at 2 and leaves grayscaleBitDepth unset', async () => {
+      const result = await service.create({ ...validDto } as any)
+      expect(result.grays).toBe(2)
+      expect(result.grayscaleBitDepth).toBeNull()
+    })
+
+    it('rejects a non-colour frameworkClass', async () => {
+      await expect(service.create({ ...validDto, frameworkClass: 'screen--1bit' } as any)).rejects.toThrow(BadRequestException)
+      expect(repo.save).not.toHaveBeenCalled()
+    })
+
+    it('rejects an unrecognised frameworkClass', async () => {
+      await expect(service.create({ ...validDto, frameworkClass: 'not-a-real-family' } as any)).rejects.toThrow(BadRequestException)
+    })
+
+    it('rejects an empty colors array', async () => {
+      await expect(service.create({ ...validDto, colors: [] } as any)).rejects.toThrow(BadRequestException)
+    })
+
+    it('rejects a malformed colour value', async () => {
+      await expect(service.create({ ...validDto, colors: ['not-a-hex-color'] } as any)).rejects.toThrow(BadRequestException)
+    })
+
+    it('rejects a missing name', async () => {
+      await expect(service.create({ ...validDto, name: '' } as any)).rejects.toThrow(BadRequestException)
+    })
+  })
+
+  describe('delete', () => {
+    it('hard-deletes an existing custom palette', async () => {
+      const palette = { id: 'abc', kind: 'custom' } as Palette
+      repo.findOneBy.mockResolvedValue(palette)
+      await service.delete('abc')
+      expect(repo.remove).toHaveBeenCalledWith(palette)
+    })
+
+    it('404s when the palette does not exist', async () => {
+      repo.findOneBy.mockResolvedValue(null)
+      await expect(service.delete('nope')).rejects.toThrow(NotFoundException)
+      expect(repo.remove).not.toHaveBeenCalled()
+    })
+
+    it('rejects deleting an official palette', async () => {
+      repo.findOneBy.mockResolvedValue({ id: 'bw', kind: 'official' } as Palette)
+      await expect(service.delete('bw')).rejects.toThrow(BadRequestException)
+      expect(repo.remove).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/api/src/device-models/__test__/device-model-sync.service.spec.ts
+++ b/packages/api/src/device-models/__test__/device-model-sync.service.spec.ts
@@ -104,6 +104,21 @@ describe('deviceModelSyncService', () => {
       expect(result.syncedAt).toBeInstanceOf(Date)
     })
 
+    it('never upserts or deprecates a kind: custom palette, regardless of what upstream reports', async () => {
+      mockFetch.mockImplementation(async (url: string) =>
+        url.endsWith('/palettes') ? jsonResponse([paletteA]) : jsonResponse([modelA]))
+      paletteRepo.find.mockResolvedValue([{ id: 'bw' }])
+      modelRepo.find.mockResolvedValue([{ name: 'og_plus' }])
+
+      await service.sync()
+
+      expect(paletteRepo.find).toHaveBeenCalledWith({ select: { id: true }, where: { deprecated: false, kind: 'official' } })
+      expect(paletteRepo.upsert).toHaveBeenCalledWith(
+        [expect.objectContaining({ id: 'bw', kind: 'official' })],
+        ['id'],
+      )
+    })
+
     it('does not deprecate anything when the live list matches', async () => {
       mockFetch.mockImplementation(async (url: string) =>
         url.endsWith('/palettes') ? jsonResponse([paletteA]) : jsonResponse([modelA]))

--- a/packages/api/src/device-models/__test__/device-models.controller.spec.ts
+++ b/packages/api/src/device-models/__test__/device-models.controller.spec.ts
@@ -2,17 +2,19 @@ import type { MockDeviceModelsService } from './mockDeviceModelsService'
 import { ServiceUnavailableException } from '@nestjs/common'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { DeviceModelsController } from '../device-models.controller'
-import { BW, createMockDeviceModelsService, OG_PLUS } from './mockDeviceModelsService'
+import { BW, createMockDeviceModelsService, CUSTOM_RED_3BWR, OG_PLUS } from './mockDeviceModelsService'
 
 describe('deviceModelsController', () => {
   let controller: DeviceModelsController
   let deviceModels: MockDeviceModelsService
   let syncService: { sync: ReturnType<typeof vi.fn> }
+  let customPalettesService: { create: ReturnType<typeof vi.fn>, delete: ReturnType<typeof vi.fn> }
 
   beforeEach(() => {
     deviceModels = createMockDeviceModelsService()
     syncService = { sync: vi.fn() }
-    controller = new DeviceModelsController(deviceModels as any, syncService as any)
+    customPalettesService = { create: vi.fn(), delete: vi.fn() }
+    controller = new DeviceModelsController(deviceModels as any, syncService as any, customPalettesService as any)
   })
 
   it('lists device models', async () => {
@@ -34,5 +36,18 @@ describe('deviceModelsController', () => {
   it('maps a failed sync to 503', async () => {
     syncService.sync.mockRejectedValue(new Error('TRMNL models request failed: 502 Bad Gateway'))
     await expect(controller.sync()).rejects.toThrow(ServiceUnavailableException)
+  })
+
+  it('delegates palette creation to CustomPalettesService', async () => {
+    const dto = { name: 'My Red', frameworkClass: 'screen--color-3bwr', colors: ['#ff0000'] } as any
+    customPalettesService.create.mockResolvedValue(CUSTOM_RED_3BWR)
+    await expect(controller.createPalette(dto)).resolves.toBe(CUSTOM_RED_3BWR)
+    expect(customPalettesService.create).toHaveBeenCalledWith(dto)
+  })
+
+  it('delegates palette deletion to CustomPalettesService', async () => {
+    customPalettesService.delete.mockResolvedValue(undefined)
+    await controller.deletePalette(CUSTOM_RED_3BWR.id)
+    expect(customPalettesService.delete).toHaveBeenCalledWith(CUSTOM_RED_3BWR.id)
   })
 })

--- a/packages/api/src/device-models/__test__/device-models.service.spec.ts
+++ b/packages/api/src/device-models/__test__/device-models.service.spec.ts
@@ -89,6 +89,21 @@ describe('deviceModelsService', () => {
     })
   })
 
+  describe('compatibleFamiliesFor', () => {
+    it('returns every colour family represented among the model\'s official palettes', async () => {
+      await expect(service.compatibleFamiliesFor(SEEED_E1002)).resolves.toEqual(new Set(['screen--color-6a']))
+    })
+
+    it('returns an empty set for a model with only grayscale official palettes', async () => {
+      await expect(service.compatibleFamiliesFor(OG_PLUS)).resolves.toEqual(new Set())
+    })
+
+    it('is derived from paletteIds-matched rows, not from colors/bitDepth', async () => {
+      const grayscaleOnlyModel = { ...OG_PLUS, colors: 999, bitDepth: 99, paletteIds: ['bw'] }
+      await expect(service.compatibleFamiliesFor(grayscaleOnlyModel)).resolves.toEqual(new Set())
+    })
+  })
+
   describe('assignResolvedModel', () => {
     it('sets model and default palette on the device', async () => {
       const device = { reportedModel: 'x', width: 1872, height: 1404 } as any

--- a/packages/api/src/device-models/__test__/mockDeviceModelsService.ts
+++ b/packages/api/src/device-models/__test__/mockDeviceModelsService.ts
@@ -38,9 +38,10 @@ export const V2: DeviceModel = {
   cssVariables: { '--screen-w': '1040px', '--screen-h': '780px' },
 }
 
-export const BW: Palette = { id: 'bw', name: 'Black & White (1-bit)', grays: 2, colors: null, frameworkClass: 'screen--1bit', grayscaleBitDepth: null, deprecated: false, syncedAt: null }
-export const GRAY_4: Palette = { id: 'gray-4', name: '4 Grays (2-bit)', grays: 4, colors: null, frameworkClass: 'screen--2bit', grayscaleBitDepth: null, deprecated: false, syncedAt: null }
-export const GRAY_16: Palette = { id: 'gray-16', name: '16 Grays (4-bit)', grays: 16, colors: null, frameworkClass: 'screen--4bit', grayscaleBitDepth: null, deprecated: false, syncedAt: null }
+export const BW: Palette = { id: 'bw', name: 'Black & White (1-bit)', kind: 'official', grays: 2, colors: null, frameworkClass: 'screen--1bit', grayscaleBitDepth: null, deprecated: false, syncedAt: null }
+export const GRAY_4: Palette = { id: 'gray-4', name: '4 Grays (2-bit)', kind: 'official', grays: 4, colors: null, frameworkClass: 'screen--2bit', grayscaleBitDepth: null, deprecated: false, syncedAt: null }
+export const GRAY_16: Palette = { id: 'gray-16', name: '16 Grays (4-bit)', kind: 'official', grays: 16, colors: null, frameworkClass: 'screen--4bit', grayscaleBitDepth: null, deprecated: false, syncedAt: null }
+export const CUSTOM_RED_3BWR: Palette = { id: 'a1b2c3d4-e5f6-4789-a0b1-c2d3e4f5a6b7', name: 'My Red', kind: 'custom', grays: 2, colors: ['#ff0000', '#ffffff', '#000000'], frameworkClass: 'screen--color-3bwr', grayscaleBitDepth: null, deprecated: false, syncedAt: null }
 
 export function createMockDeviceModelsService() {
   return {
@@ -50,6 +51,7 @@ export function createMockDeviceModelsService() {
     findPalette: vi.fn(),
     allowedPalettesFor: vi.fn(),
     defaultPaletteFor: vi.fn(),
+    compatibleFamiliesFor: vi.fn(),
     resolve: vi.fn(),
     assignResolvedModel: vi.fn(),
     renderTargetFor: vi.fn(),

--- a/packages/api/src/device-models/custom-palettes.service.ts
+++ b/packages/api/src/device-models/custom-palettes.service.ts
@@ -1,0 +1,53 @@
+import { randomUUID } from 'node:crypto'
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common'
+import { InjectRepository } from '@nestjs/typeorm'
+import { Repository } from 'typeorm'
+import { CreateCustomPaletteDto } from './dto/create-custom-palette.dto'
+import { CUSTOM_PALETTE_FRAMEWORK_CLASSES, Palette } from './entities/palette.entity'
+import { HEX_COLOR_PATTERN } from './trmnl-payloads'
+
+@Injectable()
+export class CustomPalettesService {
+  constructor(
+    @InjectRepository(Palette)
+    private readonly paletteRepository: Repository<Palette>,
+  ) {}
+
+  /**
+   * IDs are generated (never derived from `name`) so a custom row can never
+   * collide with a future TRMNL-introduced palette id, which sync upserts by.
+   */
+  async create(dto: CreateCustomPaletteDto): Promise<Palette> {
+    this.assertValid(dto)
+    const palette = this.paletteRepository.create({
+      id: randomUUID(),
+      name: dto.name,
+      kind: 'custom',
+      grays: 2,
+      colors: dto.colors,
+      frameworkClass: dto.frameworkClass,
+      grayscaleBitDepth: null,
+      deprecated: false,
+      syncedAt: null,
+    })
+    return this.paletteRepository.save(palette)
+  }
+
+  async delete(id: string): Promise<void> {
+    const palette = await this.paletteRepository.findOneBy({ id })
+    if (!palette)
+      throw new NotFoundException(`Palette ${id} not found`)
+    if (palette.kind !== 'custom')
+      throw new BadRequestException(`Palette ${id} is not a custom palette and cannot be deleted`)
+    await this.paletteRepository.remove(palette)
+  }
+
+  private assertValid(dto: CreateCustomPaletteDto): void {
+    if (!dto.name?.trim())
+      throw new BadRequestException('name is required')
+    if (!CUSTOM_PALETTE_FRAMEWORK_CLASSES.includes(dto.frameworkClass as any))
+      throw new BadRequestException(`frameworkClass must be one of: ${CUSTOM_PALETTE_FRAMEWORK_CLASSES.join(', ')}`)
+    if (!Array.isArray(dto.colors) || dto.colors.length === 0 || dto.colors.some(c => !HEX_COLOR_PATTERN.test(c)))
+      throw new BadRequestException('colors must be a non-empty array of #RRGGBB hex values')
+  }
+}

--- a/packages/api/src/device-models/device-model-sync.service.ts
+++ b/packages/api/src/device-models/device-model-sync.service.ts
@@ -131,8 +131,9 @@ export class DeviceModelSyncService implements OnApplicationBootstrap {
     return missing.length
   }
 
+  /** Scoped to `kind: 'official'` so a sync run never deprecates an admin-created custom palette. */
   private async deprecateMissingPalettes(presentIds: string[]): Promise<number> {
-    const active = await this.paletteRepository.find({ select: { id: true }, where: { deprecated: false } })
+    const active = await this.paletteRepository.find({ select: { id: true }, where: { deprecated: false, kind: 'official' } })
     const missing = active.map(p => p.id).filter(id => !presentIds.includes(id))
     if (missing.length > 0)
       await this.paletteRepository.update({ id: In(missing) }, { deprecated: true })

--- a/packages/api/src/device-models/device-models.controller.ts
+++ b/packages/api/src/device-models/device-models.controller.ts
@@ -1,6 +1,8 @@
-import { Controller, Get, Logger, Post, ServiceUnavailableException } from '@nestjs/common'
+import { Body, Controller, Delete, Get, Logger, Param, Post, ServiceUnavailableException, UsePipes, ValidationPipe } from '@nestjs/common'
+import { CustomPalettesService } from './custom-palettes.service'
 import { DeviceModelSyncResult, DeviceModelSyncService } from './device-model-sync.service'
 import { DeviceModelsService } from './device-models.service'
+import { CreateCustomPaletteDto } from './dto/create-custom-palette.dto'
 import { DeviceModel } from './entities/device-model.entity'
 import { Palette } from './entities/palette.entity'
 
@@ -11,6 +13,7 @@ export class DeviceModelsController {
   constructor(
     private readonly deviceModelsService: DeviceModelsService,
     private readonly syncService: DeviceModelSyncService,
+    private readonly customPalettesService: CustomPalettesService,
   ) {}
 
   @Get()
@@ -21,6 +24,17 @@ export class DeviceModelsController {
   @Get('palettes')
   getPalettes(): Promise<Palette[]> {
     return this.deviceModelsService.findAllPalettes()
+  }
+
+  @Post('palettes')
+  @UsePipes(new ValidationPipe({ transform: true }))
+  createPalette(@Body() dto: CreateCustomPaletteDto): Promise<Palette> {
+    return this.customPalettesService.create(dto)
+  }
+
+  @Delete('palettes/:id')
+  deletePalette(@Param('id') id: string): Promise<void> {
+    return this.customPalettesService.delete(id)
   }
 
   @Post('sync')

--- a/packages/api/src/device-models/device-models.module.ts
+++ b/packages/api/src/device-models/device-models.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common'
 import { ConfigModule } from '@nestjs/config'
 import { TypeOrmModule } from '@nestjs/typeorm'
+import { CustomPalettesService } from './custom-palettes.service'
 import { DeviceModelSyncService } from './device-model-sync.service'
 import { DeviceModelsController } from './device-models.controller'
 import { DeviceModelsService } from './device-models.service'
@@ -11,7 +12,7 @@ import { FallbackScreensService } from './fallback-screens.service'
 @Module({
   imports: [TypeOrmModule.forFeature([DeviceModel, Palette]), ConfigModule],
   controllers: [DeviceModelsController],
-  providers: [DeviceModelsService, DeviceModelSyncService, FallbackScreensService],
+  providers: [DeviceModelsService, DeviceModelSyncService, FallbackScreensService, CustomPalettesService],
   exports: [DeviceModelsService, FallbackScreensService],
 })
 export class DeviceModelsModule {}

--- a/packages/api/src/device-models/device-models.service.ts
+++ b/packages/api/src/device-models/device-models.service.ts
@@ -3,7 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm'
 import { Repository } from 'typeorm'
 import { TRMNL_MODELS_SNAPSHOT, TRMNL_PALETTES_SNAPSHOT } from './data/trmnl-snapshot'
 import { DeviceModel } from './entities/device-model.entity'
-import { Palette } from './entities/palette.entity'
+import { CUSTOM_PALETTE_FRAMEWORK_CLASSES, Palette } from './entities/palette.entity'
 import { FALLBACK_MODEL_NAME, FIRMWARE_MODEL_NAMES } from './firmware-model-names'
 import { toDeviceModelAttributes, toPaletteAttributes, TrmnlModelPayload } from './trmnl-payloads'
 
@@ -77,6 +77,22 @@ export class DeviceModelsService {
 
   async defaultPaletteFor(model: DeviceModel): Promise<Palette | null> {
     return pickRichest(await this.allowedPalettesFor(model))
+  }
+
+  /**
+   * The colour families a custom palette may target on this model: whichever
+   * of the 5 custom-eligible colour families are already represented among
+   * its curated official palettes. Deliberately ignores `DeviceModel.colors`/
+   * `bitDepth` — those reflect native grayscale depth only, not colour-family
+   * support.
+   */
+  async compatibleFamiliesFor(model: DeviceModel): Promise<Set<string>> {
+    const palettes = await this.allowedPalettesFor(model)
+    return new Set(
+      palettes
+        .filter(p => p.kind === 'official' && (CUSTOM_PALETTE_FRAMEWORK_CLASSES as readonly string[]).includes(p.frameworkClass))
+        .map(p => p.frameworkClass),
+    )
   }
 
   /**

--- a/packages/api/src/device-models/dto/__test__/create-custom-palette.dto.spec.ts
+++ b/packages/api/src/device-models/dto/__test__/create-custom-palette.dto.spec.ts
@@ -1,0 +1,40 @@
+import { plainToInstance } from 'class-transformer'
+import { validate } from 'class-validator'
+import { describe, expect, it } from 'vitest'
+import { CreateCustomPaletteDto } from '../create-custom-palette.dto'
+
+async function rejectedFields(dto: object): Promise<string[]> {
+  const errors = await validate(dto)
+  return errors.map(error => error.property)
+}
+
+describe('create-custom-palette dto', () => {
+  it('accepts a well-formed custom palette', async () => {
+    const dto = plainToInstance(CreateCustomPaletteDto, {
+      name: 'My Red',
+      frameworkClass: 'screen--color-3bwr',
+      colors: ['#ff0000', '#ffffff', '#000000'],
+    })
+    await expect(rejectedFields(dto)).resolves.toEqual([])
+  })
+
+  it('rejects a missing name', async () => {
+    const dto = plainToInstance(CreateCustomPaletteDto, { frameworkClass: 'screen--color-3bwr', colors: ['#ff0000'] })
+    await expect(rejectedFields(dto)).resolves.toEqual(['name'])
+  })
+
+  it('rejects a grayscale or full-color frameworkClass', async () => {
+    const dto = plainToInstance(CreateCustomPaletteDto, { name: 'x', frameworkClass: 'screen--1bit', colors: ['#ff0000'] })
+    await expect(rejectedFields(dto)).resolves.toEqual(['frameworkClass'])
+  })
+
+  it('rejects an empty colors array', async () => {
+    const dto = plainToInstance(CreateCustomPaletteDto, { name: 'x', frameworkClass: 'screen--color-3bwr', colors: [] })
+    await expect(rejectedFields(dto)).resolves.toEqual(['colors'])
+  })
+
+  it('rejects a non-hex colour value', async () => {
+    const dto = plainToInstance(CreateCustomPaletteDto, { name: 'x', frameworkClass: 'screen--color-3bwr', colors: ['red'] })
+    await expect(rejectedFields(dto)).resolves.toEqual(['colors'])
+  })
+})

--- a/packages/api/src/device-models/dto/create-custom-palette.dto.ts
+++ b/packages/api/src/device-models/dto/create-custom-palette.dto.ts
@@ -1,0 +1,18 @@
+import type { CustomPaletteFrameworkClass } from '../entities/palette.entity'
+import { ArrayNotEmpty, IsArray, IsIn, IsNotEmpty, IsString, Matches } from 'class-validator'
+import { CUSTOM_PALETTE_FRAMEWORK_CLASSES } from '../entities/palette.entity'
+import { HEX_COLOR_PATTERN } from '../trmnl-payloads'
+
+export class CreateCustomPaletteDto {
+  @IsString()
+  @IsNotEmpty()
+  name: string
+
+  @IsIn(CUSTOM_PALETTE_FRAMEWORK_CLASSES)
+  frameworkClass: CustomPaletteFrameworkClass
+
+  @IsArray()
+  @ArrayNotEmpty()
+  @Matches(HEX_COLOR_PATTERN, { each: true, message: 'colors must each be a #RRGGBB hex value' })
+  colors: string[]
+}

--- a/packages/api/src/device-models/entities/palette.entity.ts
+++ b/packages/api/src/device-models/entities/palette.entity.ts
@@ -1,5 +1,17 @@
 import { Column, Entity, PrimaryColumn } from 'typeorm'
 
+export const PALETTE_KINDS = ['official', 'custom'] as const
+export type PaletteKind = typeof PALETTE_KINDS[number]
+
+export const CUSTOM_PALETTE_FRAMEWORK_CLASSES = [
+  'screen--color-3bwr',
+  'screen--color-3bwy',
+  'screen--color-4bwry',
+  'screen--color-6a',
+  'screen--color-7a',
+] as const
+export type CustomPaletteFrameworkClass = typeof CUSTOM_PALETTE_FRAMEWORK_CLASSES[number]
+
 @Entity()
 export class Palette {
   @PrimaryColumn('text')
@@ -7,6 +19,9 @@ export class Palette {
 
   @Column('text')
   name: string
+
+  @Column('text', { default: 'official' })
+  kind: PaletteKind = 'official'
 
   @Column('int')
   grays: number

--- a/packages/api/src/device-models/trmnl-payloads.ts
+++ b/packages/api/src/device-models/trmnl-payloads.ts
@@ -38,7 +38,7 @@ export type DeviceModelAttributes = Omit<DeviceModel, 'deprecated' | 'syncedAt'>
 export type PaletteAttributes = Omit<Palette, 'deprecated' | 'syncedAt'>
 
 const ID_PATTERN = /^[\w.-]+$/
-const HEX_COLOR_PATTERN = /^#[0-9a-f]{6}$/i
+export const HEX_COLOR_PATTERN = /^#[0-9a-f]{6}$/i
 const CSS_CLASS_PATTERN = /^[\w-]+$/
 const MODEL_NUMERIC_FIELDS = ['width', 'height', 'colors', 'bit_depth', 'scale_factor', 'rotation', 'offset_x', 'offset_y'] as const
 
@@ -106,6 +106,7 @@ export function toPaletteAttributes(payload: TrmnlPalettePayload): PaletteAttrib
   return {
     id: payload.id,
     name: payload.name,
+    kind: 'official',
     grays: payload.grays,
     colors: payload.colors ?? null,
     frameworkClass: payload.framework_class,

--- a/packages/api/src/devices/__test__/devices.service.spec.ts
+++ b/packages/api/src/devices/__test__/devices.service.spec.ts
@@ -3,7 +3,7 @@ import type { MockDeviceModelsService } from '../../device-models/__test__/mockD
 import type { Device } from '../devices.entity'
 import { BadRequestException } from '@nestjs/common'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { BW, createMockDeviceModelsService, GRAY_4, GRAY_16, OG_PLUS, V2 } from '../../device-models/__test__/mockDeviceModelsService'
+import { BW, createMockDeviceModelsService, CUSTOM_RED_3BWR, GRAY_4, GRAY_16, OG_PLUS, V2 } from '../../device-models/__test__/mockDeviceModelsService'
 import { DevicesService } from '../devices.service'
 
 interface MockRepository {
@@ -170,6 +170,23 @@ describe('devicesService', () => {
       const result = await service.update('1', { name: 'renamed' } as any)
       expect(result.name).toBe('renamed')
       expect(result.palette).toBe(GRAY_4)
+    })
+
+    it('accepts a custom palette whose colour family is compatible with the device model', async () => {
+      repo.findOneBy.mockResolvedValue({ ...baseDevice, deviceModel: OG_PLUS, palette: GRAY_4 })
+      deviceModels.findPalette.mockResolvedValue(CUSTOM_RED_3BWR)
+      deviceModels.compatibleFamiliesFor.mockResolvedValue(new Set(['screen--color-3bwr']))
+      const result = await service.update('1', { paletteId: CUSTOM_RED_3BWR.id } as any)
+      expect(deviceModels.compatibleFamiliesFor).toHaveBeenCalledWith(OG_PLUS)
+      expect(result.palette).toBe(CUSTOM_RED_3BWR)
+    })
+
+    it('rejects a custom palette whose colour family is not compatible with the device model', async () => {
+      repo.findOneBy.mockResolvedValue({ ...baseDevice, deviceModel: OG_PLUS, palette: GRAY_4 })
+      deviceModels.findPalette.mockResolvedValue(CUSTOM_RED_3BWR)
+      deviceModels.compatibleFamiliesFor.mockResolvedValue(new Set())
+      await expect(service.update('1', { paletteId: CUSTOM_RED_3BWR.id } as any)).rejects.toThrow(BadRequestException)
+      expect(repo.save).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/api/src/devices/devices.service.ts
+++ b/packages/api/src/devices/devices.service.ts
@@ -1,4 +1,6 @@
 import type { Repository } from 'typeorm'
+import type { DeviceModel } from '../device-models/entities/device-model.entity'
+import type { Palette } from '../device-models/entities/palette.entity'
 import type { UpdateDeviceDto } from './dto/update-device.dto'
 import { BadRequestException, Injectable } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
@@ -67,11 +69,23 @@ export class DevicesService {
       if (!device.deviceModel)
         throw new BadRequestException('Cannot set a palette on a device with no assigned device model')
       const palette = await this.deviceModels.findPalette(paletteId)
-      if (!palette || !device.deviceModel.paletteIds.includes(paletteId))
+      if (!palette || !(await this.paletteSupportedBy(palette, device.deviceModel)))
         throw new BadRequestException(`Palette ${paletteId} is not supported by device model ${device.deviceModel.name}`)
       device.palette = palette
     }
     if (device.deviceModel && !device.palette)
       device.palette = await this.deviceModels.defaultPaletteFor(device.deviceModel)
+  }
+
+  /**
+   * Official palettes are validated against the model's curated `paletteIds`;
+   * custom palettes have no per-model list, so compatibility is derived from
+   * whether the palette's colour family is already represented on the model.
+   */
+  private async paletteSupportedBy(palette: Palette, model: DeviceModel): Promise<boolean> {
+    if (palette.kind === 'official')
+      return model.paletteIds.includes(palette.id)
+    const compatibleFamilies = await this.deviceModels.compatibleFamiliesFor(model)
+    return compatibleFamilies.has(palette.frameworkClass)
   }
 }

--- a/packages/api/src/migrations/1787110000000-AddPaletteKind.ts
+++ b/packages/api/src/migrations/1787110000000-AddPaletteKind.ts
@@ -1,0 +1,21 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddPaletteKind1787110000000 implements MigrationInterface {
+  name = 'AddPaletteKind1787110000000'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "palette" ADD "kind" text NOT NULL DEFAULT 'official'
+    `)
+
+    await queryRunner.query(`
+      ALTER TABLE "palette"
+        ADD CONSTRAINT "CHK_palette_kind" CHECK ("kind" IN ('official', 'custom'))
+    `)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "palette" DROP CONSTRAINT "CHK_palette_kind"`)
+    await queryRunner.query(`ALTER TABLE "palette" DROP COLUMN "kind"`)
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a `kind: 'official' | 'custom'` column to `Palette` so the daily TRMNL sync (`DeviceModelSyncService`) never upserts, deprecates, or otherwise touches an admin-created custom palette.
- New `CustomPalettesService` lets an admin create a custom palette (restricted to one of the 5 colour families: `color-3bwr`, `color-3bwy`, `color-4bwry`, `color-6a`, `color-7a`) with an opaque generated id, and hard-delete one — rejecting deletion of `kind: 'official'` rows.
- New `DeviceModelsController` endpoints: `POST /device-models/palettes` and `DELETE /device-models/palettes/:id`.
- New `DeviceModelsService.compatibleFamiliesFor(model)` derives which colour families a Device Model supports from its existing curated official `paletteIds`, with no separate per-model list to maintain.
- `DevicesService.applyModelChanges` now branches on the target palette's `kind`: official palettes are still validated via `paletteIds` membership; custom palettes are validated via family-match against `compatibleFamiliesFor`.
- New migration `AddPaletteKind` (NOT NULL, default `'official'`, backfilling existing rows).

Implements #803, per the design decisions recorded in ADR-0014 and ADR-0015 (`docs/adr/`).

## Out of scope (per spec)
- Admin UI for palette creation/deletion (backend/API only).
- Editing an existing custom palette (create + delete only).
- Per-Screen/per-playlist-item palette override.
- Custom grayscale/full-color palettes.

## Test plan
- [x] `pnpm test` — full API suite (64 files / 605 tests) passes
- [x] `pnpm run lint` passes
- [x] `/code-review medium` — no findings
- [ ] Manual verification of `POST`/`DELETE /device-models/palettes` against a running instance (backend-only change; no admin UI to click through yet)

https://claude.ai/code/session_01XJmDP1vsCrTqCGHBj7idXi