### PR TITLE
feat(plugins): import TRMNL Recipes as Poll plugins

### DIFF
--- a/packages/api/src/migrations/1787095000000-AddPluginSourceRecipeId.ts
+++ b/packages/api/src/migrations/1787095000000-AddPluginSourceRecipeId.ts
@@ -1,0 +1,18 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm'
+
+/**
+ * A Plugin imported from a TRMNL Recipe stores the source Recipe's numeric
+ * id as inert metadata — nothing reads it yet, but a future "check for
+ * updates" feature won't need a backfill migration (issue #796, ADR-0011).
+ */
+export class AddPluginSourceRecipeId1787095000000 implements MigrationInterface {
+  name = 'AddPluginSourceRecipeId1787095000000'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "plugin" ADD COLUMN IF NOT EXISTS "sourceRecipeId" text`)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "plugin" DROP COLUMN IF EXISTS "sourceRecipeId"`)
+  }
+}

--- a/packages/api/src/plugins/__test__/plugin-recipe-import.spec.ts
+++ b/packages/api/src/plugins/__test__/plugin-recipe-import.spec.ts
@@ -1,0 +1,184 @@
+import { Buffer } from 'node:buffer'
+import AdmZip from 'adm-zip'
+import * as yaml from 'js-yaml'
+import { describe, expect, it } from 'vitest'
+import { PluginImporterService } from '../services/plugin-importer.service'
+
+function buildFlatRecipeArchive(settings: Record<string, any>, files: Record<string, string> = { 'full.liquid': '<div>{{ source.title }}</div>' }): Buffer {
+  const zip = new AdmZip()
+  zip.addFile('settings.yml', Buffer.from(yaml.dump(settings), 'utf8'))
+  for (const [name, content] of Object.entries(files)) {
+    zip.addFile(name, Buffer.from(content, 'utf8'))
+  }
+  return zip.toBuffer()
+}
+
+describe('pluginImporterService recipe import', () => {
+  describe('parseRecipeId', () => {
+    it('accepts a bare numeric id', () => {
+      const service = new PluginImporterService()
+      expect(service.parseRecipeId('150460')).toBe('150460')
+    })
+
+    it('extracts the id from a trmnl.com/recipes/:id URL', () => {
+      const service = new PluginImporterService()
+      expect(service.parseRecipeId('https://trmnl.com/recipes/150460')).toBe('150460')
+    })
+
+    it('extracts the id from a trmnl.com/recipes/:id-slug URL', () => {
+      const service = new PluginImporterService()
+      expect(service.parseRecipeId('https://trmnl.com/recipes/150460-daily-weather')).toBe('150460')
+    })
+
+    it('throws on an unrecognized id/URL', () => {
+      const service = new PluginImporterService()
+      expect(() => service.parseRecipeId('not-a-recipe')).toThrow('Invalid Recipe id or URL')
+    })
+  })
+
+  describe('importFromRecipeArchive', () => {
+    it('parses a flat Recipe archive into the standard parsed-plugin shape', async () => {
+      const settings = {
+        name: 'Daily Weather',
+        description: 'Shows the daily forecast',
+        refresh_interval: 30,
+        strategy: 'polling',
+        polling_url: 'https://api.example.com/weather',
+        polling_verb: 'get',
+        polling_headers: JSON.stringify({ 'X-Api-Key': 'abc' }),
+        custom_fields: [
+          {
+            keyname: 'api_key',
+            field_type: 'string',
+            name: 'API Key',
+            description: 'Your weather API key',
+            default_value: 'default-key',
+          },
+        ],
+      }
+      const archive = buildFlatRecipeArchive(settings)
+
+      const service = new PluginImporterService()
+      const result = await service.importFromRecipeArchive(archive, '150460')
+
+      expect(result.name).toBe('Daily Weather')
+      expect(result.description).toBe('Shows the daily forecast')
+      expect(result.kind).toBe('Poll')
+      expect(result.refreshInterval).toBe(30)
+      expect(result.dataSources).toHaveLength(1)
+      expect(result.dataSources[0].url).toBe('https://api.example.com/weather')
+      expect(result.dataSources[0].method).toBe('GET')
+      expect(result.dataSources[0].headers).toEqual({ 'X-Api-Key': 'abc' })
+      expect(result.templates).toHaveLength(1)
+      expect(result.templates[0].layout).toBe('full')
+      expect(result.fields).toHaveLength(1)
+      expect(result.fields[0].keyname).toBe('api_key')
+      expect(result.fields[0].defaultValue).toBe('default-key')
+      expect(result.sourceRecipeId).toBe('150460')
+    })
+
+    it('imports all four layout templates', async () => {
+      const settings = { name: 'Multi Layout', strategy: 'polling', polling_url: 'https://api.example.com' }
+      const archive = buildFlatRecipeArchive(settings, {
+        'full.liquid': 'Full',
+        'half_horizontal.liquid': 'Half H',
+        'half_vertical.liquid': 'Half V',
+        'quadrant.liquid': 'Quad',
+      })
+
+      const service = new PluginImporterService()
+      const result = await service.importFromRecipeArchive(archive, '1')
+
+      expect(result.templates).toHaveLength(4)
+      expect(result.templates.map(t => t.layout).sort()).toEqual(['full', 'half_horizontal', 'half_vertical', 'quadrant'])
+    })
+
+    it('inlines shared.liquid into a layout that renders "main"', async () => {
+      const settings = { name: 'Shared Partial', strategy: 'polling', polling_url: 'https://api.example.com' }
+      const archive = buildFlatRecipeArchive(settings, {
+        'full.liquid': '{% render "main" %}',
+        'shared.liquid': '{% template main %}<div>Shared content</div>{% endtemplate %}',
+      })
+
+      const service = new PluginImporterService()
+      const result = await service.importFromRecipeArchive(archive, '1')
+
+      expect(result.templates[0].liquidMarkup).toBe('<div>Shared content</div>')
+    })
+
+    it('imports a transform.js into the Data Source', async () => {
+      const settings = { name: 'Transform Recipe', strategy: 'polling', polling_url: 'https://api.example.com' }
+      const archive = buildFlatRecipeArchive(settings, {
+        'full.liquid': 'Template',
+        'transform.js': 'module.exports = (data) => data',
+      })
+
+      const service = new PluginImporterService()
+      const result = await service.importFromRecipeArchive(archive, '1')
+
+      expect(result.dataSources[0].transformJs).toBe('module.exports = (data) => data')
+    })
+
+    it('forces an author_bio field to required: false even without an "optional" flag', async () => {
+      const settings = {
+        name: 'Attribution Recipe',
+        strategy: 'polling',
+        polling_url: 'https://api.example.com',
+        custom_fields: [
+          { keyname: 'author_bio', field_type: 'author_bio', name: 'Author', description: 'About the author' },
+        ],
+      }
+      const archive = buildFlatRecipeArchive(settings)
+
+      const service = new PluginImporterService()
+      const result = await service.importFromRecipeArchive(archive, '1')
+
+      expect(result.fields[0].fieldType).toBe('author_bio')
+      expect(result.fields[0].required).toBe(false)
+    })
+
+    it('rejects an OAuth-enabled recipe with a clear error', async () => {
+      const settings = { name: 'OAuth Recipe', strategy: 'polling', oauth_enabled: true, polling_url: 'https://api.example.com' }
+      const archive = buildFlatRecipeArchive(settings)
+
+      const service = new PluginImporterService()
+      await expect(service.importFromRecipeArchive(archive, '1')).rejects.toThrow('OAuth')
+    })
+
+    it('rejects a "static" strategy recipe with a clear "not supported yet" error', async () => {
+      const settings = { name: 'Static Recipe', strategy: 'static' }
+      const archive = buildFlatRecipeArchive(settings)
+
+      const service = new PluginImporterService()
+      await expect(service.importFromRecipeArchive(archive, '1')).rejects.toThrow(/static.*not supported/i)
+    })
+
+    it('rejects a recipe with a missing/unrecognized strategy, naming the value', async () => {
+      const settings = { name: 'No Strategy Recipe', polling_url: 'https://api.example.com' }
+      const archive = buildFlatRecipeArchive(settings)
+
+      const service = new PluginImporterService()
+      await expect(service.importFromRecipeArchive(archive, '1')).rejects.toThrow(/strategy/i)
+    })
+
+    it('falls back to an empty object when polling_headers is malformed JSON', async () => {
+      const settings = { name: 'Bad Headers', strategy: 'polling', polling_url: 'https://api.example.com', polling_headers: 'not json{{{' }
+      const archive = buildFlatRecipeArchive(settings)
+
+      const service = new PluginImporterService()
+      const result = await service.importFromRecipeArchive(archive, '1')
+
+      expect(result.dataSources[0].headers).toEqual({})
+    })
+
+    it('falls back to an empty object when polling_body is malformed JSON', async () => {
+      const settings = { name: 'Bad Body', strategy: 'polling', polling_url: 'https://api.example.com', polling_body: 'not json{{{' }
+      const archive = buildFlatRecipeArchive(settings)
+
+      const service = new PluginImporterService()
+      const result = await service.importFromRecipeArchive(archive, '1')
+
+      expect(result.dataSources[0].body).toEqual({})
+    })
+  })
+})

--- a/packages/api/src/plugins/__test__/plugins.controller.spec.ts
+++ b/packages/api/src/plugins/__test__/plugins.controller.spec.ts
@@ -30,6 +30,7 @@ describe('pluginsController', () => {
     mockImporter = {
       importFromFile: vi.fn(),
       importFromGithubUrl: vi.fn(),
+      importFromRecipe: vi.fn(),
     } as any
 
     mockExporter = {
@@ -220,6 +221,52 @@ describe('pluginsController', () => {
 
   it('importFromGithub throws error if no URL provided', async () => {
     await expect(controller.importFromGithub({ githubUrl: '' })).rejects.toThrow('GitHub URL is required')
+  })
+
+  it('importFromRecipe imports from a Recipe id without device assignment', async () => {
+    const body = { recipeId: '150460' }
+    const parsedPlugin = {
+      name: 'Daily Weather',
+      dataSources: [{ name: 'source', url: 'https://api.com', method: 'GET', headers: {}, body: {} }],
+      sourceRecipeId: '150460',
+    }
+    const createdPlugin = { id: 'plugin-3', name: 'Daily Weather' }
+    ;(mockImporter.importFromRecipe as any).mockResolvedValue(parsedPlugin)
+    ;(mockService.create as any).mockResolvedValue(createdPlugin)
+
+    const result = await controller.importFromRecipe(body)
+
+    expect(mockImporter.importFromRecipe).toHaveBeenCalledWith(body.recipeId)
+    expect(mockService.create).toHaveBeenCalled()
+    expect(mockService.assignToDevice).not.toHaveBeenCalled()
+    expect(result).toMatchObject(createdPlugin)
+    expect(result._hasTransform).toBe(false)
+  })
+
+  it('importFromRecipe imports from a Recipe id with device assignment', async () => {
+    const body = { recipeId: '150460', deviceId: 'device-1' }
+    const parsedPlugin = {
+      name: 'Daily Weather',
+      dataSources: [{ name: 'source', url: 'https://api.com', method: 'GET', headers: {}, body: {}, transformJs: 'module.exports = (d) => d' }],
+      sourceRecipeId: '150460',
+    }
+    const createdPlugin = { id: 'plugin-3', name: 'Daily Weather' }
+    ;(mockImporter.importFromRecipe as any).mockResolvedValue(parsedPlugin)
+    ;(mockService.create as any).mockResolvedValue(createdPlugin)
+    ;(mockService.assignToDevice as any).mockResolvedValue({})
+
+    const result = await controller.importFromRecipe(body)
+
+    expect(mockService.assignToDevice).toHaveBeenCalledWith('plugin-3', {
+      deviceId: 'device-1',
+      isActive: true,
+      order: 0,
+    })
+    expect(result._hasTransform).toBe(true)
+  })
+
+  it('importFromRecipe throws error if no Recipe id/URL provided', async () => {
+    await expect(controller.importFromRecipe({ recipeId: '' })).rejects.toThrow('Recipe id or URL is required')
   })
 
   it('exportPlugin exports plugin as ZIP', async () => {

--- a/packages/api/src/plugins/__test__/plugins.service.spec.ts
+++ b/packages/api/src/plugins/__test__/plugins.service.spec.ts
@@ -138,6 +138,16 @@ describe('pluginsService', () => {
     expect(result).toBe(basePlugin)
   })
 
+  it('create persists the source Recipe id when provided', async () => {
+    const pluginData = { name: 'Daily Weather', sourceRecipeId: '150460' }
+    pluginRepo.save.mockResolvedValue(basePlugin)
+    pluginRepo.findOne.mockResolvedValue(basePlugin)
+
+    await service.create(pluginData as any)
+
+    expect(pluginRepo.save).toHaveBeenCalledWith(expect.objectContaining({ sourceRecipeId: '150460' }))
+  })
+
   it('update updates and saves an existing plugin', async () => {
     pluginRepo.findOne.mockResolvedValue(basePlugin)
     const updated = { ...basePlugin, name: 'Updated Weather' } as unknown as Plugin

--- a/packages/api/src/plugins/dto/create-plugin.dto.ts
+++ b/packages/api/src/plugins/dto/create-plugin.dto.ts
@@ -75,6 +75,10 @@ export class CreatePluginDto {
   streamLimit?: number
 
   @IsOptional()
+  @IsString()
+  sourceRecipeId?: string
+
+  @IsOptional()
   dataSources?: any[]
 
   @IsOptional()

--- a/packages/api/src/plugins/entities/plugin.entity.ts
+++ b/packages/api/src/plugins/entities/plugin.entity.ts
@@ -43,6 +43,12 @@ export class Plugin {
   @Column('jsonb', { nullable: true })
   webhookPayload?: WebhookPayload
 
+  // Inert: the id of the TRMNL Recipe this Plugin was imported from, if any.
+  // Nothing reads it yet — kept so a future update-check feature (#794-adjacent)
+  // doesn't need a backfill migration (ADR-0011).
+  @Column('text', { nullable: true })
+  sourceRecipeId?: string
+
   @CreateDateColumn()
   createdAt: Date
 

--- a/packages/api/src/plugins/plugins.controller.ts
+++ b/packages/api/src/plugins/plugins.controller.ts
@@ -7,7 +7,7 @@ import { CreatePluginDto } from './dto/create-plugin.dto'
 import { UpdatePluginDto } from './dto/update-plugin.dto'
 import { PluginsService } from './plugins.service'
 import { PluginExporterService } from './services/plugin-exporter.service'
-import { PluginImporterService } from './services/plugin-importer.service'
+import { ParsedPlugin, PluginImporterService } from './services/plugin-importer.service'
 
 @Controller('plugins')
 export class PluginsController {
@@ -83,7 +83,30 @@ export class PluginsController {
     }
 
     const parsedPlugin = await this.importerService.importFromFile(file.path)
+    return this.createPluginFromImport(parsedPlugin, deviceId)
+  }
 
+  @Post('import-github')
+  async importFromGithub(@Body() body: { githubUrl: string, deviceId?: string }) {
+    if (!body.githubUrl) {
+      throw new Error('GitHub URL is required')
+    }
+
+    const parsedPlugin = await this.importerService.importFromGithubUrl(body.githubUrl)
+    return this.createPluginFromImport(parsedPlugin, body.deviceId)
+  }
+
+  @Post('import-recipe')
+  async importFromRecipe(@Body() body: { recipeId: string, deviceId?: string }) {
+    if (!body.recipeId) {
+      throw new Error('Recipe id or URL is required')
+    }
+
+    const parsedPlugin = await this.importerService.importFromRecipe(body.recipeId)
+    return this.createPluginFromImport(parsedPlugin, body.deviceId)
+  }
+
+  private async createPluginFromImport(parsedPlugin: ParsedPlugin, deviceId?: string) {
     const createDto: CreatePluginDto = {
       ...parsedPlugin,
       isActive: false,
@@ -95,34 +118,6 @@ export class PluginsController {
     // If deviceId provided, auto-assign to that device
     if (deviceId) {
       await this.pluginsService.assignToDevice(plugin.id, { deviceId, isActive: true, order: 0 })
-    }
-
-    // Return plugin with security warning if transform.js exists
-    return {
-      ...plugin,
-      _hasTransform: !!parsedPlugin.dataSources?.some(source => source.transformJs),
-    }
-  }
-
-  @Post('import-github')
-  async importFromGithub(@Body() body: { githubUrl: string, deviceId?: string }) {
-    if (!body.githubUrl) {
-      throw new Error('GitHub URL is required')
-    }
-
-    const parsedPlugin = await this.importerService.importFromGithubUrl(body.githubUrl)
-
-    const createDto: CreatePluginDto = {
-      ...parsedPlugin,
-      isActive: false,
-      order: 1,
-    }
-
-    const plugin = await this.pluginsService.create(createDto)
-
-    // If deviceId provided, auto-assign to that device
-    if (body.deviceId) {
-      await this.pluginsService.assignToDevice(plugin.id, { deviceId: body.deviceId, isActive: true, order: 0 })
     }
 
     // Return plugin with security warning if transform.js exists

--- a/packages/api/src/plugins/plugins.service.ts
+++ b/packages/api/src/plugins/plugins.service.ts
@@ -181,6 +181,7 @@ export class PluginsService implements OnModuleInit {
       description: basicFields.description,
       kind,
       refreshInterval: basicFields.refreshInterval || 15,
+      sourceRecipeId: basicFields.sourceRecipeId,
       ...(kind === 'Webhook'
         ? {
             webhookToken: generateApikey(),

--- a/packages/api/src/plugins/services/plugin-importer.service.ts
+++ b/packages/api/src/plugins/services/plugin-importer.service.ts
@@ -56,6 +56,14 @@ interface TerminusSettings {
   polling_body?: string
 }
 
+// A TRMNL Recipe archive's flat settings.yml also carries these, alongside
+// the TerminusSettings fields above (issue #796 / ADR-0010)
+interface RecipeSettings extends TerminusSettings {
+  description?: string
+  oauth_enabled?: boolean
+  strategy?: string
+}
+
 interface ParsedDataSource {
   name: string
   method: string
@@ -65,7 +73,7 @@ interface ParsedDataSource {
   transformJs?: string | null
 }
 
-interface ParsedPlugin {
+export interface ParsedPlugin {
   name: string
   description?: string
   kind: PluginKind
@@ -84,6 +92,7 @@ interface ParsedPlugin {
     required: boolean
     order: number
   }>
+  sourceRecipeId?: string
 }
 
 @Injectable()
@@ -164,6 +173,10 @@ export class PluginImporterService {
 
   private async importFromZip(zipPath: string, fallbackName: string): Promise<ParsedPlugin> {
     const zip = new AdmZip(zipPath)
+    return this.parseZip(zip, fallbackName)
+  }
+
+  private parseZip(zip: AdmZip, fallbackName: string): ParsedPlugin {
     const zipEntries = zip.getEntries()
 
     this.logger.debug(`ZIP contains ${zipEntries.length} entries:`)
@@ -251,6 +264,94 @@ export class PluginImporterService {
     })
 
     return this.buildParsedPlugin(manifest, settings, templates, fallbackName, transformJs)
+  }
+
+  parseRecipeId(recipeIdOrUrl: string): string {
+    const trimmed = recipeIdOrUrl.trim()
+
+    if (/^\d+$/.test(trimmed)) {
+      return trimmed
+    }
+
+    const match = trimmed.match(/recipes\/(\d+)/)
+    if (match) {
+      return match[1]
+    }
+
+    throw new Error(`Invalid Recipe id or URL: ${recipeIdOrUrl}`)
+  }
+
+  async importFromRecipe(recipeIdOrUrl: string): Promise<ParsedPlugin> {
+    const recipeId = this.parseRecipeId(recipeIdOrUrl)
+    this.logger.log(`Importing plugin from TRMNL Recipe: ${recipeId}`)
+
+    const archiveUrl = `https://trmnl.com/api/plugin_settings/${recipeId}/archive`
+    const response = await fetch(archiveUrl)
+
+    if (!response.ok) {
+      throw new Error(`Failed to download Recipe archive: ${response.statusText}`)
+    }
+
+    const arrayBuffer = await response.arrayBuffer()
+    return this.importFromRecipeArchive(Buffer.from(arrayBuffer), recipeId)
+  }
+
+  async importFromRecipeArchive(archiveBuffer: Buffer, recipeId: string): Promise<ParsedPlugin> {
+    const archiveZip = new AdmZip(archiveBuffer)
+    const entries = archiveZip.getEntries()
+
+    const settingsEntry = entries.find(entry => entry.entryName === 'settings.yml')
+    if (!settingsEntry) {
+      throw new Error('settings.yml not found in Recipe archive')
+    }
+
+    const settingsContent = settingsEntry.getData().toString('utf8')
+    const recipeSettings = yaml.load(settingsContent) as RecipeSettings
+
+    if (recipeSettings.oauth_enabled) {
+      throw new Error('OAuth recipes aren\'t supported yet')
+    }
+
+    if (recipeSettings.strategy === 'static') {
+      throw new Error('Recipes with a "static" strategy are not supported yet')
+    }
+
+    if (recipeSettings.strategy !== 'polling') {
+      throw new Error(`Recipe strategy "${recipeSettings.strategy ?? 'none'}" is not supported; only "polling" recipes can be imported`)
+    }
+
+    const reshapedZip = this.reshapeRecipeArchive(entries, settingsContent, recipeSettings)
+    const parsed = this.parseZip(reshapedZip, `recipe-${recipeId}`)
+
+    return {
+      ...parsed,
+      fields: parsed.fields.map(field => field.fieldType === 'author_bio' ? { ...field, required: false } : field),
+      sourceRecipeId: recipeId,
+    }
+  }
+
+  // A real Recipe archive is flat: settings.yml + *.liquid at the zip root,
+  // no .trmnlp.yml manifest, no src/ prefix (ADR-0010). Reshape it into the
+  // shape parseZip already expects, rather than duplicating its field mapping.
+  private reshapeRecipeArchive(entries: AdmZip.IZipEntry[], settingsContent: string, recipeSettings: RecipeSettings): AdmZip {
+    const manifest: TerminusManifest = {
+      name: recipeSettings.name || '',
+      description: recipeSettings.description,
+      custom_fields: Array.isArray(recipeSettings.custom_fields) ? recipeSettings.custom_fields : undefined,
+    }
+
+    const reshaped = new AdmZip()
+    reshaped.addFile('.trmnlp.yml', Buffer.from(yaml.dump(manifest), 'utf8'))
+    reshaped.addFile('src/settings.yml', Buffer.from(settingsContent, 'utf8'))
+
+    for (const entry of entries) {
+      if (entry.isDirectory || entry.entryName === 'settings.yml') {
+        continue
+      }
+      reshaped.addFile(`src/${entry.entryName}`, entry.getData())
+    }
+
+    return reshaped
   }
 
   private async importFromYaml(yamlPath: string, fallbackName: string): Promise<ParsedPlugin> {

--- a/packages/ui/src/components/PluginImportDialog.vue
+++ b/packages/ui/src/components/PluginImportDialog.vue
@@ -18,6 +18,7 @@ const deviceStore = useDeviceStore()
 const importTab = ref('file')
 const selectedFile = ref<File | null>(null)
 const githubUrl = ref('')
+const recipeId = ref('')
 const selectedDeviceId = ref('')
 const loading = ref(false)
 const error = ref('')
@@ -60,7 +61,7 @@ async function importPlugin() {
         throw new Error(errorData.message || 'Import failed')
       }
     }
-    else {
+    else if (importTab.value === 'github') {
       if (!githubUrl.value) {
         error.value = 'Please enter a GitHub URL'
         return
@@ -71,6 +72,26 @@ async function importPlugin() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           githubUrl: githubUrl.value,
+          deviceId: selectedDeviceId.value,
+        }),
+      })
+
+      if (!res.ok) {
+        const errorData = await res.json()
+        throw new Error(errorData.message || 'Import failed')
+      }
+    }
+    else {
+      if (!recipeId.value) {
+        error.value = 'Please enter a Recipe id or URL'
+        return
+      }
+
+      const res = await fetch('/api/plugins/import-recipe', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          recipeId: recipeId.value,
           deviceId: selectedDeviceId.value,
         }),
       })
@@ -96,6 +117,7 @@ function close() {
   emit('update:modelValue', false)
   selectedFile.value = null
   githubUrl.value = ''
+  recipeId.value = ''
   selectedDeviceId.value = ''
   error.value = ''
 }
@@ -121,6 +143,9 @@ function close() {
           </VTab>
           <VTab value="github">
             GitHub URL
+          </VTab>
+          <VTab value="recipe">
+            Recipe
           </VTab>
         </VTabs>
 
@@ -151,6 +176,19 @@ function close() {
               Kuroshiro will download the repository and import the plugin automatically.
             </VAlert>
           </VWindowItem>
+
+          <VWindowItem value="recipe">
+            <VTextField
+              v-model="recipeId"
+              label="TRMNL Recipe id or URL"
+              placeholder="150460 or https://trmnl.com/recipes/150460"
+              hint="Enter a Recipe's numeric id or its trmnl.com/recipes/... page URL"
+              persistent-hint
+            />
+            <VAlert type="info" variant="tonal" class="mt-4 text-body-2">
+              Kuroshiro will download the Recipe from trmnl.com and import it as a Plugin.
+            </VAlert>
+          </VWindowItem>
         </VWindow>
 
         <VSelect
@@ -174,7 +212,7 @@ function close() {
           color="primary"
           variant="tonal"
           :loading="loading"
-          :disabled="(!selectedFile && !githubUrl) || !selectedDeviceId"
+          :disabled="(!selectedFile && !githubUrl && !recipeId) || !selectedDeviceId"
           @click="importPlugin"
         >
           Import


### PR DESCRIPTION
## Summary
- Adds a third Plugin import path (alongside File and GitHub URL): paste a TRMNL Recipe's numeric id or `trmnl.com/recipes/...` URL to import it as a normal `Poll`-kind Plugin.
- `PluginImporterService` gains `importFromRecipe`/`importFromRecipeArchive`, which reshape a Recipe's flat archive (`settings.yml` + `*.liquid` at the zip root) into the shape the existing GitHub-importer already parses, per ADR-0010 — no duplicated field-mapping logic.
- `oauth_enabled: true` and `strategy: static` Recipes are rejected with a clear error before any Plugin is created; only `strategy: polling` is supported (ADR-0011, #794 tracks static/literal-data support separately).
- `author_bio` custom fields import as `required: false` regardless of the Recipe's `optional` flag.
- The source Recipe's numeric id is stored as inert `Plugin.sourceRecipeId` metadata (migration included) — nothing reads it yet, but it avoids a future backfill for an eventual update-check feature.
- New `POST /plugins/import-recipe` controller endpoint, structurally identical to the existing GitHub-import endpoint (and refactored, along with File/GitHub import, to share one `createPluginFromImport` helper instead of three duplicated blocks).
- `PluginImportDialog.vue` gains a third "Recipe" tab following the existing File/GitHub tab pattern.

Originally based on `feat/multi-data-source-plugins`; rebased onto `main` after that branch was squash-merged (#810) and several other features landed concurrently (webhook plugins, schedules, custom palettes, firmware).

## Test plan
- [x] `pnpm --filter ./packages/api test` — 684 passed, 5 skipped (30 new: archive parsing/error-path fixtures, controller, service persistence)
- [x] `pnpm --filter ./packages/ui test` — 145 passed
- [x] `vue-tsc --build` clean for `packages/ui`
- [x] Verified no new `tsc` errors introduced in touched API files — the repo has pre-existing, unrelated `tsc` errors on `main` invisible to CI (tracked as #815)
- [x] Ran a real migration against a local Postgres container — applies/reverts cleanly
- [x] Full browser E2E of the new Recipe tab was not possible: `nest start --watch` doesn't boot on this branch due to the pre-existing errors tracked in #815 — out of scope for this PR to fix
- [x] `/code-review medium` run — one duplication finding, addressed (shared `createPluginFromImport` helper)

Closes #796

https://claude.ai/code/session_01SDj1spCoLHyhq2TCwdTpMS