### PR TITLE
feat(firmware): custom OTA hosting and official-release sync

### DIFF
--- a/packages/api/src/app.module.ts
+++ b/packages/api/src/app.module.ts
@@ -11,6 +11,8 @@ import { DeviceModel } from './device-models/entities/device-model.entity'
 import { Palette } from './device-models/entities/palette.entity'
 import { Device } from './devices/devices.entity'
 import { DevicesModule } from './devices/devices.module'
+import { Firmware } from './firmware/entities/firmware.entity'
+import { FirmwareModule } from './firmware/firmware.module'
 import { LogEntry } from './logs/logs.entity'
 import { LogsModule } from './logs/logs.module'
 import { MaintenanceModule } from './maintenance/maintenance.module'
@@ -49,7 +51,7 @@ const conf = config()
       username: conf.database.user,
       password: conf.database.password,
       database: conf.database.database,
-      entities: [Device, DeviceModel, Palette, Screen, LogEntry, Plugin, DevicePlugin, PluginDataSource, PluginTemplate, PluginField, PluginFieldValue, PluginVariable, MashupConfiguration, MashupSlot, Schedule],
+      entities: [Device, DeviceModel, Palette, Screen, LogEntry, Plugin, DevicePlugin, PluginDataSource, PluginTemplate, PluginField, PluginFieldValue, PluginVariable, MashupConfiguration, MashupSlot, Schedule, Firmware],
       migrations: (() => {
         const dir = path.join(process.cwd(), 'dist', 'src', 'migrations')
         if (!fs.existsSync(dir))
@@ -67,6 +69,7 @@ const conf = config()
     ScreensModule,
     LogsModule,
     DeviceModelsModule,
+    FirmwareModule,
     DevicesModule,
     PluginsModule,
     MashupModule,

--- a/packages/api/src/config/typeorm.config.ts
+++ b/packages/api/src/config/typeorm.config.ts
@@ -3,6 +3,7 @@ import { DataSource } from 'typeorm'
 import { DeviceModel } from '../device-models/entities/device-model.entity'
 import { Palette } from '../device-models/entities/palette.entity'
 import { Device } from '../devices/devices.entity'
+import { Firmware } from '../firmware/entities/firmware.entity'
 import { LogEntry } from '../logs/logs.entity'
 import { MashupConfiguration } from '../mashup/entities/mashup-configuration.entity'
 import { MashupSlot } from '../mashup/entities/mashup-slot.entity'
@@ -23,7 +24,7 @@ const AppDataSource = new DataSource({
   username: process.env.KUROSHIRO_DB_USER || 'root',
   password: process.env.KUROSHIRO_DB_PASSWORD || 'root',
   database: process.env.KUROSHIRO_DB_DB || 'test',
-  entities: [Device, DeviceModel, Palette, Screen, LogEntry, Plugin, DevicePlugin, PluginDataSource, PluginTemplate, PluginField, PluginFieldValue, PluginVariable, MashupConfiguration, MashupSlot, Schedule],
+  entities: [Device, DeviceModel, Palette, Screen, LogEntry, Plugin, DevicePlugin, PluginDataSource, PluginTemplate, PluginField, PluginFieldValue, PluginVariable, MashupConfiguration, MashupSlot, Schedule, Firmware],
   migrations: ['dist/src/migrations/*.js'],
   migrationsTableName: 'migrations',
   synchronize: false,

--- a/packages/api/src/devices/__test__/devices.service.spec.ts
+++ b/packages/api/src/devices/__test__/devices.service.spec.ts
@@ -28,13 +28,15 @@ describe('devicesService', () => {
   let service: DevicesService
   let repo: MockRepository
   let deviceModels: MockDeviceModelsService
+  let firmwareService: { findById: ReturnType<typeof vi.fn> }
   let screensService: { reconvertImageScreens: ReturnType<typeof vi.fn> }
 
   beforeEach(() => {
     repo = createMockRepository()
     deviceModels = createMockDeviceModelsService()
+    firmwareService = { findById: vi.fn() }
     screensService = { reconvertImageScreens: vi.fn().mockResolvedValue(0) }
-    service = new DevicesService(repo as unknown as Repository<Device>, deviceModels as any, screensService as any)
+    service = new DevicesService(repo as unknown as Repository<Device>, deviceModels as any, firmwareService as any, screensService as any)
   })
 
   const baseDevice = {
@@ -170,6 +172,50 @@ describe('devicesService', () => {
       const result = await service.update('1', { name: 'renamed' } as any)
       expect(result.name).toBe('renamed')
       expect(result.palette).toBe(GRAY_4)
+    })
+  })
+
+  describe('update with target firmware', () => {
+    const compatibleFirmware = { id: 'fw-1', version: '1.5.6', kind: 'official-synced', compatibleModels: ['og_plus'] }
+    const universalFirmware = { id: 'fw-2', version: '1.0.0', kind: 'custom', compatibleModels: [] }
+
+    beforeEach(() => {
+      repo.save.mockImplementation(async (device: Device) => device)
+    })
+
+    it('assigns a firmware compatible with the device model', async () => {
+      repo.findOneBy.mockResolvedValue({ ...baseDevice, deviceModel: OG_PLUS })
+      firmwareService.findById.mockResolvedValue(compatibleFirmware)
+      const result = await service.update('1', { targetFirmwareId: 'fw-1' } as any)
+      expect(firmwareService.findById).toHaveBeenCalledWith('fw-1')
+      expect(result.targetFirmware).toBe(compatibleFirmware)
+    })
+
+    it('assigns a universal firmware (empty compatibleModels) regardless of device model', async () => {
+      repo.findOneBy.mockResolvedValue({ ...baseDevice, deviceModel: null })
+      firmwareService.findById.mockResolvedValue(universalFirmware)
+      const result = await service.update('1', { targetFirmwareId: 'fw-2' } as any)
+      expect(result.targetFirmware).toBe(universalFirmware)
+    })
+
+    it('rejects a firmware incompatible with the device model', async () => {
+      repo.findOneBy.mockResolvedValue({ ...baseDevice, deviceModel: V2 })
+      firmwareService.findById.mockResolvedValue(compatibleFirmware)
+      await expect(service.update('1', { targetFirmwareId: 'fw-1' } as any)).rejects.toThrow(BadRequestException)
+      expect(repo.save).not.toHaveBeenCalled()
+    })
+
+    it('rejects an unknown firmware id', async () => {
+      repo.findOneBy.mockResolvedValue({ ...baseDevice, deviceModel: OG_PLUS })
+      firmwareService.findById.mockResolvedValue(null)
+      await expect(service.update('1', { targetFirmwareId: 'nope' } as any)).rejects.toThrow(BadRequestException)
+      expect(repo.save).not.toHaveBeenCalled()
+    })
+
+    it('is a no-op when targetFirmwareId is not provided', async () => {
+      repo.findOneBy.mockResolvedValue({ ...baseDevice, deviceModel: OG_PLUS })
+      await service.update('1', { name: 'renamed' } as any)
+      expect(firmwareService.findById).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/api/src/devices/__test__/display.service.spec.ts
+++ b/packages/api/src/devices/__test__/display.service.spec.ts
@@ -65,6 +65,7 @@ describe('deviceDisplayService', () => {
   let configService: { get: ReturnType<typeof vi.fn> }
   let deviceModels: MockDeviceModelsService
   let fallbackScreens: MockFallbackScreensService
+  let firmwareService: { verifyChecksum: ReturnType<typeof vi.fn>, fileUrl: ReturnType<typeof vi.fn> }
 
   beforeEach(() => {
     deviceRepo = createMockRepo()
@@ -72,12 +73,14 @@ describe('deviceDisplayService', () => {
     configService = { get: vi.fn() }
     deviceModels = createMockDeviceModelsService()
     fallbackScreens = createMockFallbackScreensService()
+    firmwareService = { verifyChecksum: vi.fn(), fileUrl: vi.fn() }
     service = new DeviceDisplayService(
       deviceRepo as any,
       screenRepo as any,
       configService as any,
       deviceModels as any,
       fallbackScreens as any,
+      firmwareService as any,
     )
     vi.resetAllMocks()
     primeMockDeviceModelsService(deviceModels)
@@ -461,6 +464,74 @@ describe('deviceDisplayService', () => {
       expect(result.touchbar_mode).toBeUndefined()
       expect(result.maximum_compatibility).toBeUndefined()
       expect(result.image_url_timeout).toBeUndefined()
+    })
+  })
+
+  describe('firmware push', () => {
+    const targetFirmware = { id: 'fw-1', version: '1.5.6', checksum: 'abc123' }
+
+    function primeNoScreen(device: Record<string, unknown>) {
+      deviceRepo.findOneBy.mockResolvedValue(device)
+      screenRepo.find.mockResolvedValue([])
+      configService.get.mockReturnValue('http://api')
+    }
+
+    it('serves the target firmware url and clears the flag when the checksum matches', async () => {
+      const device = { ...baseDevice, deviceModel: OG_PLUS, updateFirmware: true, targetFirmware }
+      primeNoScreen(device)
+      firmwareService.verifyChecksum.mockResolvedValue(true)
+      firmwareService.fileUrl.mockReturnValue('http://api/firmware/fw-1.bin')
+
+      const result = await service.getCurrentImage(headers as any)
+
+      expect(firmwareService.verifyChecksum).toHaveBeenCalledWith(targetFirmware)
+      expect(result.firmware_url).toBe('http://api/firmware/fw-1.bin')
+      expect(result.update_firmware).toBe(true)
+      expect(deviceRepo.save).toHaveBeenCalledWith(expect.objectContaining({ updateFirmware: false }))
+    })
+
+    it('skips serving the url and leaves the flag set when the checksum does not match', async () => {
+      const device = { ...baseDevice, deviceModel: OG_PLUS, updateFirmware: true, targetFirmware }
+      primeNoScreen(device)
+      firmwareService.verifyChecksum.mockResolvedValue(false)
+
+      const result = await service.getCurrentImage(headers as any)
+
+      expect(result.firmware_url).toBe('')
+      expect(result.update_firmware).toBe(false)
+      expect(deviceRepo.save).toHaveBeenCalledWith(expect.objectContaining({ updateFirmware: true }))
+    })
+
+    it('does nothing when updateFirmware is false', async () => {
+      primeNoScreen({ ...baseDevice, deviceModel: OG_PLUS, updateFirmware: false, targetFirmware })
+
+      const result = await service.getCurrentImage(headers as any)
+
+      expect(firmwareService.verifyChecksum).not.toHaveBeenCalled()
+      expect(result.firmware_url).toBe('')
+      expect(result.update_firmware).toBe(false)
+    })
+
+    it('does nothing when no firmware is targeted', async () => {
+      primeNoScreen({ ...baseDevice, deviceModel: OG_PLUS, updateFirmware: true, targetFirmware: null })
+
+      const result = await service.getCurrentImage(headers as any)
+
+      expect(firmwareService.verifyChecksum).not.toHaveBeenCalled()
+      expect(result.update_firmware).toBe(false)
+    })
+
+    it('leaves a mirrored device unaffected by any firmware assignment', async () => {
+      const device = { ...baseDevice, deviceModel: OG_PLUS, mirrorEnabled: true, mirrorMac: 'different-mac', updateFirmware: true, targetFirmware }
+      deviceRepo.findOneBy.mockResolvedValue(device)
+      configService.get.mockReturnValue('http://api')
+      mockFetch.mockResolvedValueOnce({ json: () => Promise.resolve({ filename: 'mirror.png', image_url: 'http://example.com/image.jpg' }) })
+
+      const result = await service.getCurrentImage(headers as any)
+
+      expect(firmwareService.verifyChecksum).not.toHaveBeenCalled()
+      expect(result.firmware_url).toBeNull()
+      expect(result.update_firmware).toBe(false)
     })
   })
 

--- a/packages/api/src/devices/devices.entity.ts
+++ b/packages/api/src/devices/devices.entity.ts
@@ -1,6 +1,7 @@
 import { Column, Entity, JoinColumn, ManyToOne, OneToMany, PrimaryGeneratedColumn } from 'typeorm'
 import { DeviceModel } from '../device-models/entities/device-model.entity'
 import { Palette } from '../device-models/entities/palette.entity'
+import { Firmware } from '../firmware/entities/firmware.entity'
 import { LogEntry } from '../logs/logs.entity'
 import { Screen } from '../screens/screens.entity'
 
@@ -70,6 +71,10 @@ export class Device {
 
   @Column('boolean', { default: false })
   updateFirmware: boolean
+
+  @ManyToOne(() => Firmware, { nullable: true, eager: true, onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'targetFirmwareId' })
+  targetFirmware?: Firmware | null
 
   @Column('timestamptz', { default: new Date() })
   lastSeen: Date

--- a/packages/api/src/devices/devices.module.ts
+++ b/packages/api/src/devices/devices.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common'
 import { ConfigModule } from '@nestjs/config'
 import { TypeOrmModule } from '@nestjs/typeorm'
 import { DeviceModelsModule } from '../device-models/device-models.module'
+import { FirmwareModule } from '../firmware/firmware.module'
 import { LogEntry } from '../logs/logs.entity'
 import { PluginsModule } from '../plugins/plugins.module'
 import { Screen } from '../screens/screens.entity'
@@ -15,7 +16,7 @@ import { SetupController } from './setup.controller'
 import { DeviceSetupService } from './setup.service'
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Device, Screen, LogEntry]), ConfigModule, PluginsModule, DeviceModelsModule, ScreensModule],
+  imports: [TypeOrmModule.forFeature([Device, Screen, LogEntry]), ConfigModule, PluginsModule, DeviceModelsModule, FirmwareModule, ScreensModule],
   controllers: [DevicesController, DisplayController, SetupController],
   providers: [DevicesService, DeviceDisplayService, DeviceSetupService],
   exports: [DevicesService],

--- a/packages/api/src/devices/devices.service.ts
+++ b/packages/api/src/devices/devices.service.ts
@@ -3,6 +3,7 @@ import type { UpdateDeviceDto } from './dto/update-device.dto'
 import { BadRequestException, Injectable } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
 import { DeviceModelsService } from '../device-models/device-models.service'
+import { FirmwareService } from '../firmware/firmware.service'
 import { ScreensService } from '../screens/screens.service'
 import generateApikey from '../utils/generateApikey'
 import generateFriendlyName from '../utils/generateFriendlyName'
@@ -15,6 +16,7 @@ export class DevicesService {
     @InjectRepository(Device)
     private deviceRepository: Repository<Device>,
     private deviceModels: DeviceModelsService,
+    private firmwareService: FirmwareService,
     private screensService: ScreensService,
   ) {}
 
@@ -37,10 +39,11 @@ export class DevicesService {
     const dbDevice = await this.deviceRepository.findOneBy({ id })
     if (!dbDevice)
       return null
-    const { deviceModelName, paletteId, ...attributes } = changes
+    const { deviceModelName, paletteId, targetFirmwareId, ...attributes } = changes
     Object.assign(dbDevice, attributes)
     const before = { model: dbDevice.deviceModel?.name, palette: dbDevice.palette?.id }
     await this.applyModelChanges(dbDevice, deviceModelName, paletteId)
+    await this.applyFirmwareChanges(dbDevice, targetFirmwareId)
     const saved = await this.deviceRepository.save(dbDevice)
     if (before.model !== saved.deviceModel?.name || before.palette !== saved.palette?.id)
       await this.screensService.reconvertImageScreens(saved)
@@ -73,5 +76,16 @@ export class DevicesService {
     }
     if (device.deviceModel && !device.palette)
       device.palette = await this.deviceModels.defaultPaletteFor(device.deviceModel)
+  }
+
+  private async applyFirmwareChanges(device: Device, targetFirmwareId?: string): Promise<void> {
+    if (targetFirmwareId === undefined)
+      return
+    const firmware = await this.firmwareService.findById(targetFirmwareId)
+    if (!firmware)
+      throw new BadRequestException(`Unknown firmware: ${targetFirmwareId}`)
+    if (firmware.compatibleModels.length > 0 && !firmware.compatibleModels.includes(device.deviceModel?.name ?? ''))
+      throw new BadRequestException(`Firmware ${targetFirmwareId} is not compatible with device model ${device.deviceModel?.name ?? 'unknown'}`)
+    device.targetFirmware = firmware
   }
 }

--- a/packages/api/src/devices/display.service.ts
+++ b/packages/api/src/devices/display.service.ts
@@ -11,6 +11,7 @@ import { DeviceModelsService } from '../device-models/device-models.service'
 import { FallbackScreensService } from '../device-models/fallback-screens.service'
 import { renderHtmlToPng } from '../device-models/render-html-to-png'
 import { viewFull, wrapInScreenShell } from '../device-models/screen-shell'
+import { FirmwareService } from '../firmware/firmware.service'
 import { PluginDataFetcherService } from '../plugins/services/plugin-data-fetcher.service'
 import { PluginRendererService } from '../plugins/services/plugin-renderer.service'
 import { PluginTransformService } from '../plugins/services/plugin-transform.service'
@@ -48,6 +49,7 @@ export class DeviceDisplayService {
     private configService: ConfigService,
     private deviceModels: DeviceModelsService,
     private fallbackScreens: FallbackScreensService,
+    private firmwareService: FirmwareService,
     private pluginDataFetcher: PluginDataFetcherService,
     private pluginRenderer: PluginRendererService,
     private pluginTransformer: PluginTransformService,
@@ -98,7 +100,7 @@ export class DeviceDisplayService {
     // A Special Function fires once: this response acknowledges it, the next poll gets 'none'
     const specialFunction = device.specialFunction ?? 'none'
     device.specialFunction = 'none'
-    const updateFirmware = false
+    const { firmwareUrl: pushedFirmwareUrl, updateFirmware: pushedUpdateFirmware } = await this.resolveFirmwarePush(device)
     device.lastSeen = new Date()
     await this.deviceRepository.save(device)
     this.logger.log(`Device info updated for MAC: ${headers.id}`)
@@ -117,13 +119,13 @@ export class DeviceDisplayService {
         return new Display({
           action: specialFunction,
           filename: 'noScreen.png',
-          firmware_url: '',
+          firmware_url: pushedFirmwareUrl,
           image_url: await this.fallbackImageUrl('noScreen', device),
           refresh_rate: device.refreshRate,
           reset_firmware: resetDevice,
           special_function: specialFunction,
           temperature_profile: 'default',
-          update_firmware: updateFirmware,
+          update_firmware: pushedUpdateFirmware,
         })
       }
       nextScreen.isActive = true
@@ -135,13 +137,13 @@ export class DeviceDisplayService {
       return new Display({
         action: specialFunction,
         filename: `${nextScreen.filename}_${nextScreen.generatedAt.toISOString()}`,
-        firmware_url: '',
+        firmware_url: pushedFirmwareUrl,
         image_url: imgUrl,
         refresh_rate: device.refreshRate,
         reset_firmware: false,
         special_function: specialFunction,
         temperature_profile: 'default',
-        update_firmware: false,
+        update_firmware: pushedUpdateFirmware,
       })
     }
     else {
@@ -190,6 +192,27 @@ export class DeviceDisplayService {
         update_firmware: updateFirmware,
       })
     }
+  }
+
+  /**
+   * A non-mirrored Device's own OTA push: a one-shot pull of its assigned target
+   * Firmware, triggered only by an explicit admin assignment (never inferred from
+   * `fwVersion`). The flag only clears once the binary is actually served, so a
+   * checksum mismatch (a corrupted file on disk) leaves it set to retry on the
+   * Device's next poll instead of silently skipping the update for good. A
+   * mirrored Device is left untouched — its firmware comes from TRMNL's own
+   * pass-through instead.
+   */
+  private async resolveFirmwarePush(device: Device): Promise<{ firmwareUrl: string, updateFirmware: boolean }> {
+    if (device.mirrorEnabled || !device.updateFirmware || !device.targetFirmware)
+      return { firmwareUrl: '', updateFirmware: false }
+    const target = device.targetFirmware
+    if (!await this.firmwareService.verifyChecksum(target)) {
+      this.logger.warn(`Firmware ${target.id} (${target.version}) failed checksum verification, skipping OTA push for device ${device.id}`)
+      return { firmwareUrl: '', updateFirmware: false }
+    }
+    device.updateFirmware = false
+    return { firmwareUrl: this.firmwareService.fileUrl(target.id), updateFirmware: true }
   }
 
   /**

--- a/packages/api/src/devices/dto/update-device.dto.ts
+++ b/packages/api/src/devices/dto/update-device.dto.ts
@@ -69,4 +69,8 @@ export class UpdateDeviceDto {
   @IsOptional()
   @IsBoolean()
   updateFirmware: boolean
+
+  @IsOptional()
+  @IsString()
+  targetFirmwareId?: string
 }

--- a/packages/api/src/firmware/__test__/firmware-sync.service.spec.ts
+++ b/packages/api/src/firmware/__test__/firmware-sync.service.spec.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { FirmwareSyncService } from '../firmware-sync.service'
+
+const { fsMock, cronMock } = vi.hoisted(() => ({
+  fsMock: {
+    mkdir: vi.fn().mockResolvedValue(undefined),
+    writeFile: vi.fn().mockResolvedValue(undefined),
+  },
+  cronMock: { schedule: vi.fn() },
+}))
+
+vi.mock('node:fs', () => ({
+  promises: fsMock,
+}))
+
+vi.mock('node-cron', () => ({
+  default: cronMock,
+}))
+
+const mockFetch = vi.fn()
+globalThis.fetch = mockFetch
+
+function createMockRepo() {
+  return {
+    findOne: vi.fn(),
+    insert: vi.fn(),
+    update: vi.fn(),
+  }
+}
+
+function jsonResponse(data: unknown, ok = true) {
+  return { ok, status: ok ? 200 : 502, statusText: ok ? 'OK' : 'Bad Gateway', json: async () => data }
+}
+
+function binaryResponse(ok = true) {
+  return { ok, status: ok ? 200 : 502, statusText: ok ? 'OK' : 'Bad Gateway', arrayBuffer: async () => new Uint8Array([1, 2, 3]).buffer }
+}
+
+const latestPayload = { url: 'https://trmnl-fw.example.com/trmnl_og/FW1.5.6.bin', version: '1.5.6' }
+
+describe('firmwareSyncService', () => {
+  let service: FirmwareSyncService
+  let firmwareRepo: ReturnType<typeof createMockRepo>
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+    fsMock.mkdir.mockResolvedValue(undefined)
+    fsMock.writeFile.mockResolvedValue(undefined)
+    firmwareRepo = createMockRepo()
+    service = new FirmwareSyncService(firmwareRepo as any)
+  })
+
+  describe('onApplicationBootstrap', () => {
+    it('schedules the daily sync and swallows a boot-time sync failure instead of throwing', async () => {
+      mockFetch.mockResolvedValue(jsonResponse(null, false))
+      await expect(service.onApplicationBootstrap()).resolves.toBeUndefined()
+      expect(cronMock.schedule).toHaveBeenCalledWith('0 4 * * *', expect.any(Function))
+    })
+  })
+
+  describe('sync', () => {
+    it('inserts a new row when the upstream version changed', async () => {
+      mockFetch
+        .mockResolvedValueOnce(jsonResponse(latestPayload))
+        .mockResolvedValueOnce(binaryResponse())
+      firmwareRepo.findOne.mockResolvedValue({ id: 'old', version: '1.5.5' })
+
+      const result = await service.sync()
+
+      expect(mockFetch).toHaveBeenNthCalledWith(1, 'https://usetrmnl.com/api/firmware/latest', { signal: expect.any(AbortSignal) })
+      expect(mockFetch).toHaveBeenNthCalledWith(2, latestPayload.url)
+      expect(firmwareRepo.update).toHaveBeenCalledWith({ kind: 'official-synced', deprecated: false }, { deprecated: true })
+      expect(firmwareRepo.insert).toHaveBeenCalledWith(expect.objectContaining({
+        version: '1.5.6',
+        kind: 'official-synced',
+        checksum: expect.any(String),
+        compatibleModels: ['og_png', 'og_plus', 'og_bwry'],
+        deprecated: false,
+      }))
+      expect(result).toMatchObject({ inserted: true, version: '1.5.6' })
+    })
+
+    it('is a no-op when the version matches the newest existing row', async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse(latestPayload))
+      firmwareRepo.findOne.mockResolvedValue({ id: 'current', version: '1.5.6' })
+
+      const result = await service.sync()
+
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      expect(firmwareRepo.insert).not.toHaveBeenCalled()
+      expect(firmwareRepo.update).not.toHaveBeenCalled()
+      expect(result).toEqual({ inserted: false, version: '1.5.6' })
+    })
+
+    it('inserts without deprecating anything on the first-ever sync', async () => {
+      mockFetch
+        .mockResolvedValueOnce(jsonResponse(latestPayload))
+        .mockResolvedValueOnce(binaryResponse())
+      firmwareRepo.findOne.mockResolvedValue(null)
+
+      await service.sync()
+
+      expect(firmwareRepo.update).not.toHaveBeenCalled()
+      expect(firmwareRepo.insert).toHaveBeenCalled()
+    })
+
+    it('coalesces concurrent sync() calls into a single run', async () => {
+      mockFetch.mockResolvedValue(jsonResponse(latestPayload))
+      firmwareRepo.findOne.mockResolvedValue({ id: 'current', version: '1.5.6' })
+
+      const [first, second] = await Promise.all([service.sync(), service.sync()])
+
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      expect(first).toBe(second)
+
+      await service.sync()
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('throws and writes nothing when TRMNL is unreachable', async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse(null, false))
+      await expect(service.sync()).rejects.toThrow(/request failed/)
+      expect(firmwareRepo.insert).not.toHaveBeenCalled()
+    })
+
+    it('throws when the response is missing url/version', async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ url: 'https://example.com/fw.bin' }))
+      await expect(service.sync()).rejects.toThrow(/missing url\/version/)
+    })
+
+    it('surfaces a clear error when the fetch times out', async () => {
+      mockFetch.mockImplementation(async () => {
+        throw new DOMException('The operation was aborted due to timeout', 'TimeoutError')
+      })
+      await expect(service.sync()).rejects.toThrow(/request timed out/)
+    })
+
+    it('throws when downloading the binary fails', async () => {
+      mockFetch
+        .mockResolvedValueOnce(jsonResponse(latestPayload))
+        .mockResolvedValueOnce(binaryResponse(false))
+      firmwareRepo.findOne.mockResolvedValue({ id: 'old', version: '1.5.5' })
+
+      await expect(service.sync()).rejects.toThrow(/Failed to download firmware binary/)
+      expect(firmwareRepo.insert).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/api/src/firmware/__test__/firmware.controller.spec.ts
+++ b/packages/api/src/firmware/__test__/firmware.controller.spec.ts
@@ -1,0 +1,63 @@
+import buffer from 'node:buffer'
+import { BadRequestException, ServiceUnavailableException } from '@nestjs/common'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { FirmwareController } from '../firmware.controller'
+
+describe('firmwareController', () => {
+  let controller: FirmwareController
+  let firmwareService: { findAll: ReturnType<typeof vi.fn>, upload: ReturnType<typeof vi.fn>, delete: ReturnType<typeof vi.fn> }
+  let syncService: { sync: ReturnType<typeof vi.fn> }
+
+  beforeEach(() => {
+    firmwareService = { findAll: vi.fn(), upload: vi.fn(), delete: vi.fn() }
+    syncService = { sync: vi.fn() }
+    controller = new FirmwareController(firmwareService as any, syncService as any)
+  })
+
+  it('lists firmware', async () => {
+    const rows = [{ id: 'fw-1' }]
+    firmwareService.findAll.mockResolvedValue(rows)
+    await expect(controller.getAll()).resolves.toBe(rows)
+  })
+
+  it('returns the sync result', async () => {
+    const result = { inserted: true, version: '1.5.6' }
+    syncService.sync.mockResolvedValue(result)
+    await expect(controller.sync()).resolves.toBe(result)
+  })
+
+  it('maps a failed sync to 503', async () => {
+    syncService.sync.mockRejectedValue(new Error('TRMNL firmware/latest request failed: 502 Bad Gateway'))
+    await expect(controller.sync()).rejects.toThrow(ServiceUnavailableException)
+  })
+
+  describe('upload', () => {
+    const file = { buffer: buffer.Buffer.from('x'), originalname: 'og.bin', mimetype: 'application/octet-stream', size: 1 } as Express.Multer.File
+
+    it('rejects when no file is provided', async () => {
+      await expect(controller.upload(undefined as any, '1.0.0')).rejects.toThrow(BadRequestException)
+      expect(firmwareService.upload).not.toHaveBeenCalled()
+    })
+
+    it('uploads with an unparsed compatibleModels field', async () => {
+      firmwareService.upload.mockResolvedValue({ id: 'fw-1' })
+      await controller.upload(file, '1.0.0', 'My Label', '["og_plus","og_bwry"]')
+      expect(firmwareService.upload).toHaveBeenCalledWith(file, { version: '1.0.0', label: 'My Label', compatibleModels: ['og_plus', 'og_bwry'] })
+    })
+
+    it('rejects an invalid compatibleModels payload', async () => {
+      await expect(controller.upload(file, '1.0.0', undefined, 'not-json')).rejects.toThrow(BadRequestException)
+      expect(firmwareService.upload).not.toHaveBeenCalled()
+    })
+
+    it('rejects a compatibleModels payload that is not a string array', async () => {
+      await expect(controller.upload(file, '1.0.0', undefined, '[1,2]')).rejects.toThrow(BadRequestException)
+      expect(firmwareService.upload).not.toHaveBeenCalled()
+    })
+  })
+
+  it('deletes a firmware', async () => {
+    await controller.delete('fw-1')
+    expect(firmwareService.delete).toHaveBeenCalledWith('fw-1')
+  })
+})

--- a/packages/api/src/firmware/__test__/firmware.service.spec.ts
+++ b/packages/api/src/firmware/__test__/firmware.service.spec.ts
@@ -1,0 +1,166 @@
+import nodeBuffer from 'node:buffer'
+import * as crypto from 'node:crypto'
+import { BadRequestException, NotFoundException } from '@nestjs/common'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { FirmwareService } from '../firmware.service'
+
+const { fsMock, fileExistsMock } = vi.hoisted(() => ({
+  fsMock: {
+    mkdir: vi.fn().mockResolvedValue(undefined),
+    writeFile: vi.fn().mockResolvedValue(undefined),
+    readFile: vi.fn(),
+    unlink: vi.fn().mockResolvedValue(undefined),
+  },
+  fileExistsMock: vi.fn(),
+}))
+
+vi.mock('node:fs', () => ({
+  promises: fsMock,
+}))
+
+vi.mock('../../utils/fileExists', () => ({
+  fileExists: fileExistsMock,
+}))
+
+function createMockRepo() {
+  const queryBuilder = {
+    orderBy: vi.fn(),
+    getMany: vi.fn(),
+  }
+  queryBuilder.orderBy.mockReturnValue(queryBuilder)
+  return {
+    find: vi.fn(),
+    findOneBy: vi.fn(),
+    create: vi.fn(),
+    save: vi.fn(),
+    remove: vi.fn(),
+    createQueryBuilder: vi.fn().mockReturnValue(queryBuilder),
+    queryBuilder,
+  }
+}
+
+describe('firmwareService', () => {
+  let service: FirmwareService
+  let repo: ReturnType<typeof createMockRepo>
+  let configService: { get: ReturnType<typeof vi.fn> }
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+    fsMock.mkdir.mockResolvedValue(undefined)
+    fsMock.writeFile.mockResolvedValue(undefined)
+    fsMock.unlink.mockResolvedValue(undefined)
+    repo = createMockRepo()
+    configService = { get: vi.fn().mockReturnValue('http://api') }
+    service = new FirmwareService(repo as any, configService as any)
+  })
+
+  describe('upload', () => {
+    const file = { buffer: nodeBuffer.Buffer.from('binary-content'), originalname: 'og.bin', mimetype: 'application/octet-stream', size: 14 }
+
+    it('computes and stores a correct checksum', async () => {
+      repo.create.mockImplementation(attrs => attrs)
+      repo.save.mockImplementation(async attrs => attrs)
+
+      const result = await service.upload(file, { version: '1.0.0' })
+
+      const expectedChecksum = crypto.createHash('sha256').update(file.buffer).digest('hex')
+      expect(result.checksum).toBe(expectedChecksum)
+      expect(result.kind).toBe('custom')
+      expect(result.version).toBe('1.0.0')
+      expect(fsMock.writeFile).toHaveBeenCalledWith(expect.stringContaining('.bin'), file.buffer)
+    })
+
+    it('defaults the label to the original filename and compatibleModels to empty', async () => {
+      repo.create.mockImplementation(attrs => attrs)
+      repo.save.mockImplementation(async attrs => attrs)
+
+      const result = await service.upload(file, { version: '1.0.0' })
+
+      expect(result.label).toBe('og.bin')
+      expect(result.compatibleModels).toEqual([])
+    })
+
+    it('rejects a file over the size limit', async () => {
+      await expect(service.upload({ ...file, size: 999_999_999 }, { version: '1.0.0' })).rejects.toThrow(BadRequestException)
+      expect(repo.save).not.toHaveBeenCalled()
+    })
+
+    it('rejects a file that is not a .bin', async () => {
+      await expect(service.upload({ ...file, originalname: 'og.zip' }, { version: '1.0.0' })).rejects.toThrow(BadRequestException)
+      expect(repo.save).not.toHaveBeenCalled()
+    })
+
+    it('rejects a missing version', async () => {
+      await expect(service.upload(file, { version: '' })).rejects.toThrow(BadRequestException)
+      expect(repo.save).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('delete', () => {
+    it('deletes a custom firmware', async () => {
+      const firmware = { id: 'fw-1', kind: 'custom' }
+      repo.findOneBy.mockResolvedValue(firmware)
+
+      await service.delete('fw-1')
+
+      expect(repo.remove).toHaveBeenCalledWith(firmware)
+      expect(fsMock.unlink).toHaveBeenCalledWith(expect.stringContaining('fw-1.bin'))
+    })
+
+    it('refuses to delete an official-synced firmware', async () => {
+      repo.findOneBy.mockResolvedValue({ id: 'fw-1', kind: 'official-synced' })
+      await expect(service.delete('fw-1')).rejects.toThrow(BadRequestException)
+      expect(repo.remove).not.toHaveBeenCalled()
+    })
+
+    it('throws NotFoundException for an unknown id', async () => {
+      repo.findOneBy.mockResolvedValue(null)
+      await expect(service.delete('nope')).rejects.toThrow(NotFoundException)
+    })
+  })
+
+  describe('findAll / findById', () => {
+    it('lists firmware ordered by most recent first, coalescing uploadedAt and syncedAt', async () => {
+      const rows = [{ id: 'fw-1' }]
+      repo.queryBuilder.getMany.mockResolvedValue(rows)
+      await expect(service.findAll()).resolves.toBe(rows)
+      expect(repo.queryBuilder.orderBy).toHaveBeenCalledWith('COALESCE(firmware.uploadedAt, firmware.syncedAt)', 'DESC')
+    })
+
+    it('finds a firmware by id', async () => {
+      const firmware = { id: 'fw-1' }
+      repo.findOneBy.mockResolvedValue(firmware)
+      await expect(service.findById('fw-1')).resolves.toBe(firmware)
+    })
+  })
+
+  describe('verifyChecksum', () => {
+    it('returns true when the on-disk checksum matches', async () => {
+      const fileBuffer = nodeBuffer.Buffer.from('binary-content')
+      const checksum = crypto.createHash('sha256').update(fileBuffer).digest('hex')
+      fileExistsMock.mockResolvedValue(true)
+      fsMock.readFile.mockResolvedValue(fileBuffer)
+
+      await expect(service.verifyChecksum({ id: 'fw-1', checksum } as any)).resolves.toBe(true)
+    })
+
+    it('returns false when the on-disk checksum does not match', async () => {
+      fileExistsMock.mockResolvedValue(true)
+      fsMock.readFile.mockResolvedValue(nodeBuffer.Buffer.from('corrupted'))
+
+      await expect(service.verifyChecksum({ id: 'fw-1', checksum: 'deadbeef' } as any)).resolves.toBe(false)
+    })
+
+    it('returns false when the binary is missing on disk', async () => {
+      fileExistsMock.mockResolvedValue(false)
+      await expect(service.verifyChecksum({ id: 'fw-1', checksum: 'deadbeef' } as any)).resolves.toBe(false)
+      expect(fsMock.readFile).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('fileUrl', () => {
+    it('builds the url from api_url and the firmware id', () => {
+      expect(service.fileUrl('fw-1')).toBe('http://api/firmware/fw-1.bin')
+    })
+  })
+})

--- a/packages/api/src/firmware/entities/firmware.entity.ts
+++ b/packages/api/src/firmware/entities/firmware.entity.ts
@@ -1,0 +1,33 @@
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm'
+
+export type FirmwareKind = 'official-synced' | 'custom'
+
+@Entity()
+export class Firmware {
+  @PrimaryGeneratedColumn('uuid')
+  id: string
+
+  @Column('text')
+  version: string
+
+  @Column('text')
+  kind: FirmwareKind
+
+  @Column('text')
+  checksum: string
+
+  @Column('text', { array: true, default: '{}' })
+  compatibleModels: string[]
+
+  @Column('boolean', { default: false })
+  deprecated: boolean
+
+  @Column('text', { nullable: true })
+  label?: string | null
+
+  @Column('timestamptz', { nullable: true })
+  syncedAt?: Date | null
+
+  @Column('timestamptz', { nullable: true })
+  uploadedAt?: Date | null
+}

--- a/packages/api/src/firmware/firmware-paths.ts
+++ b/packages/api/src/firmware/firmware-paths.ts
@@ -1,0 +1,9 @@
+import { resolveAppPath } from '../utils/pathHelper'
+
+export function firmwareFilePath(id: string): string {
+  return resolveAppPath('public', 'firmware', `${id}.bin`)
+}
+
+export function firmwareFileUrl(id: string, apiUrl: string): string {
+  return `${apiUrl}/firmware/${id}.bin`
+}

--- a/packages/api/src/firmware/firmware-sync.service.ts
+++ b/packages/api/src/firmware/firmware-sync.service.ts
@@ -1,0 +1,117 @@
+import type { OnApplicationBootstrap } from '@nestjs/common'
+import buffer from 'node:buffer'
+import * as crypto from 'node:crypto'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { Injectable, Logger } from '@nestjs/common'
+import { InjectRepository } from '@nestjs/typeorm'
+import cron from 'node-cron'
+import { Repository } from 'typeorm'
+import { TRMNL_API_URL } from '../device-models/trmnl-payloads'
+import { Firmware } from './entities/firmware.entity'
+import { firmwareFilePath } from './firmware-paths'
+
+export interface FirmwareSyncResult {
+  inserted: boolean
+  version: string
+  syncedAt?: Date
+}
+
+interface TrmnlFirmwarePayload {
+  url: string
+  version: string
+}
+
+// TRMNL's public firmware endpoint only ever returns the OG binary (see
+// docs/adr/0015-firmware-compatibility-enforced-og-only-sync.md).
+const OFFICIAL_SYNC_COMPATIBLE_MODELS = ['og_png', 'og_plus', 'og_bwry']
+
+const DAILY_AT_4AM = '0 4 * * *'
+const TRMNL_FETCH_TIMEOUT_MS = 15_000
+
+@Injectable()
+export class FirmwareSyncService implements OnApplicationBootstrap {
+  private readonly logger = new Logger(FirmwareSyncService.name)
+  private syncing: Promise<FirmwareSyncResult> | null = null
+
+  constructor(
+    @InjectRepository(Firmware)
+    private readonly firmwareRepository: Repository<Firmware>,
+  ) {}
+
+  async onApplicationBootstrap(): Promise<void> {
+    void this.sync().catch(err => this.logger.warn(`Initial firmware sync skipped: ${err.message}`))
+    cron.schedule(DAILY_AT_4AM, () => {
+      void this.sync().catch(err => this.logger.warn(`Scheduled firmware sync failed: ${err.message}`))
+    })
+  }
+
+  /**
+   * A scheduled run and a manual sync request share the same in-flight
+   * promise instead of racing on the same insert.
+   */
+  sync(): Promise<FirmwareSyncResult> {
+    this.syncing ??= this.runSync().finally(() => {
+      this.syncing = null
+    })
+    return this.syncing
+  }
+
+  private async runSync(): Promise<FirmwareSyncResult> {
+    this.logger.log('Syncing firmware from TRMNL')
+    const payload = await this.fetchLatest()
+    const newest = await this.firmwareRepository.findOne({ where: { kind: 'official-synced' }, order: { syncedAt: 'DESC' } })
+    if (newest && newest.version === payload.version) {
+      this.logger.log(`Firmware ${payload.version} already synced, nothing to do`)
+      return { inserted: false, version: payload.version }
+    }
+
+    const binary = await this.downloadBinary(payload.url)
+    const checksum = crypto.createHash('sha256').update(binary).digest('hex')
+    const id = crypto.randomUUID()
+    const syncedAt = new Date()
+    const filePath = firmwareFilePath(id)
+    await fs.promises.mkdir(path.dirname(filePath), { recursive: true })
+    await fs.promises.writeFile(filePath, binary)
+
+    if (newest)
+      await this.firmwareRepository.update({ kind: 'official-synced', deprecated: false }, { deprecated: true })
+    await this.firmwareRepository.insert({
+      id,
+      version: payload.version,
+      kind: 'official-synced',
+      checksum,
+      compatibleModels: OFFICIAL_SYNC_COMPATIBLE_MODELS,
+      deprecated: false,
+      syncedAt,
+    })
+
+    this.logger.log(`Synced firmware ${payload.version} (${id})`)
+    return { inserted: true, version: payload.version, syncedAt }
+  }
+
+  private async fetchLatest(): Promise<TrmnlFirmwarePayload> {
+    let res: Response
+    try {
+      res = await fetch(`${TRMNL_API_URL}/firmware/latest`, { signal: AbortSignal.timeout(TRMNL_FETCH_TIMEOUT_MS) })
+    }
+    catch (err) {
+      if (err instanceof Error && err.name === 'TimeoutError')
+        throw new Error('TRMNL firmware/latest request timed out')
+      throw err
+    }
+    if (!res.ok)
+      throw new Error(`TRMNL firmware/latest request failed: ${res.status} ${res.statusText}`)
+    const body = await res.json()
+    if (typeof body?.url !== 'string' || typeof body?.version !== 'string')
+      throw new Error('TRMNL firmware/latest response is missing url/version')
+    return { url: body.url, version: body.version }
+  }
+
+  private async downloadBinary(url: string): Promise<buffer.Buffer> {
+    const res = await fetch(url)
+    if (!res.ok)
+      throw new Error(`Failed to download firmware binary: ${res.status} ${res.statusText}`)
+    return buffer.Buffer.from(await res.arrayBuffer())
+  }
+}

--- a/packages/api/src/firmware/firmware.controller.ts
+++ b/packages/api/src/firmware/firmware.controller.ts
@@ -1,0 +1,66 @@
+import { BadRequestException, Body, Controller, Delete, Get, Logger, Param, Post, ServiceUnavailableException, UploadedFile, UseInterceptors } from '@nestjs/common'
+import { FileInterceptor } from '@nestjs/platform-express'
+import { Firmware } from './entities/firmware.entity'
+import { FirmwareSyncResult, FirmwareSyncService } from './firmware-sync.service'
+import { FirmwareService, MAX_FIRMWARE_UPLOAD_BYTES } from './firmware.service'
+
+@Controller('firmware')
+export class FirmwareController {
+  private readonly logger = new Logger(FirmwareController.name)
+
+  constructor(
+    private readonly firmwareService: FirmwareService,
+    private readonly syncService: FirmwareSyncService,
+  ) {}
+
+  @Get()
+  getAll(): Promise<Firmware[]> {
+    return this.firmwareService.findAll()
+  }
+
+  @Post('sync')
+  async sync(): Promise<FirmwareSyncResult> {
+    try {
+      return await this.syncService.sync()
+    }
+    catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      this.logger.error(`Firmware sync failed: ${message}`)
+      throw new ServiceUnavailableException(`Could not sync firmware from TRMNL: ${message}`)
+    }
+  }
+
+  @Post('upload')
+  @UseInterceptors(FileInterceptor('file', { limits: { fileSize: MAX_FIRMWARE_UPLOAD_BYTES } }))
+  async upload(
+    @UploadedFile() file: Express.Multer.File,
+    @Body('version') version?: string,
+    @Body('label') label?: string,
+    @Body('compatibleModels') compatibleModels?: string,
+  ): Promise<Firmware> {
+    if (!file)
+      throw new BadRequestException('No file uploaded')
+    return this.firmwareService.upload(file, {
+      version,
+      label,
+      compatibleModels: compatibleModels ? this.parseCompatibleModels(compatibleModels) : undefined,
+    })
+  }
+
+  private parseCompatibleModels(raw: string): string[] {
+    try {
+      const parsed = JSON.parse(raw)
+      if (!Array.isArray(parsed) || !parsed.every(item => typeof item === 'string'))
+        throw new Error('not a string array')
+      return parsed
+    }
+    catch {
+      throw new BadRequestException('compatibleModels must be a JSON array of strings')
+    }
+  }
+
+  @Delete(':id')
+  async delete(@Param('id') id: string): Promise<void> {
+    await this.firmwareService.delete(id)
+  }
+}

--- a/packages/api/src/firmware/firmware.module.ts
+++ b/packages/api/src/firmware/firmware.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common'
+import { ConfigModule } from '@nestjs/config'
+import { TypeOrmModule } from '@nestjs/typeorm'
+import { Firmware } from './entities/firmware.entity'
+import { FirmwareSyncService } from './firmware-sync.service'
+import { FirmwareController } from './firmware.controller'
+import { FirmwareService } from './firmware.service'
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Firmware]), ConfigModule],
+  controllers: [FirmwareController],
+  providers: [FirmwareService, FirmwareSyncService],
+  exports: [FirmwareService],
+})
+export class FirmwareModule {}

--- a/packages/api/src/firmware/firmware.service.ts
+++ b/packages/api/src/firmware/firmware.service.ts
@@ -1,0 +1,108 @@
+import buffer from 'node:buffer'
+import * as crypto from 'node:crypto'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { BadRequestException, Injectable, Logger, NotFoundException } from '@nestjs/common'
+import { ConfigService } from '@nestjs/config'
+import { InjectRepository } from '@nestjs/typeorm'
+import { Repository } from 'typeorm'
+import { fileExists } from '../utils/fileExists'
+import { Firmware } from './entities/firmware.entity'
+import { firmwareFilePath, firmwareFileUrl } from './firmware-paths'
+
+// ESP32 OTA images from usetrmnl/firmware run well under this; a generous
+// ceiling still catches an obviously-wrong upload without inspecting the binary.
+export const MAX_FIRMWARE_UPLOAD_BYTES = 8 * 1024 * 1024
+
+export interface UploadFirmwareInput {
+  version: string
+  label?: string
+  compatibleModels?: string[]
+}
+
+@Injectable()
+export class FirmwareService {
+  private readonly logger = new Logger(FirmwareService.name)
+
+  constructor(
+    @InjectRepository(Firmware)
+    private readonly firmwareRepository: Repository<Firmware>,
+    private readonly configService: ConfigService,
+  ) {}
+
+  /**
+   * A custom row's uploadedAt and an official-synced row's syncedAt are mutually
+   * exclusive, so ordering by either column alone lets Postgres' NULLS-FIRST
+   * default on DESC push every row of the other kind above it regardless of
+   * actual recency — COALESCE compares them on one shared timeline instead.
+   */
+  findAll(): Promise<Firmware[]> {
+    return this.firmwareRepository
+      .createQueryBuilder('firmware')
+      .orderBy('COALESCE(firmware.uploadedAt, firmware.syncedAt)', 'DESC')
+      .getMany()
+  }
+
+  findById(id: string): Promise<Firmware | null> {
+    return this.firmwareRepository.findOneBy({ id })
+  }
+
+  async upload(file: { buffer: buffer.Buffer, originalname: string, mimetype: string, size: number }, input: UploadFirmwareInput): Promise<Firmware> {
+    if (!input.version)
+      throw new BadRequestException('Firmware version is required')
+    if (file.size > MAX_FIRMWARE_UPLOAD_BYTES)
+      throw new BadRequestException(`Firmware upload exceeds the ${MAX_FIRMWARE_UPLOAD_BYTES / (1024 * 1024)}MB limit`)
+    if (path.extname(file.originalname).toLowerCase() !== '.bin')
+      throw new BadRequestException('Firmware upload must be a .bin file')
+
+    const id = crypto.randomUUID()
+    const checksum = crypto.createHash('sha256').update(file.buffer).digest('hex')
+    await fs.promises.mkdir(path.dirname(this.filePath(id)), { recursive: true })
+    await fs.promises.writeFile(this.filePath(id), file.buffer)
+
+    const firmware = this.firmwareRepository.create({
+      id,
+      version: input.version,
+      kind: 'custom',
+      checksum,
+      compatibleModels: input.compatibleModels ?? [],
+      deprecated: false,
+      label: input.label ?? file.originalname,
+      uploadedAt: new Date(),
+    })
+    const saved = await this.firmwareRepository.save(firmware)
+    this.logger.log(`Uploaded custom firmware ${saved.id} (${saved.version})`)
+    return saved
+  }
+
+  async delete(id: string): Promise<void> {
+    const firmware = await this.firmwareRepository.findOneBy({ id })
+    if (!firmware)
+      throw new NotFoundException(`Firmware ${id} not found`)
+    if (firmware.kind !== 'custom')
+      throw new BadRequestException('Only custom firmware can be deleted')
+    await this.firmwareRepository.remove(firmware)
+    await fs.promises.unlink(this.filePath(id)).catch(() => {})
+    this.logger.log(`Deleted custom firmware ${id}`)
+  }
+
+  /** Recomputes the on-disk binary's checksum and compares it against the recorded one, so a corrupted file is never served. */
+  async verifyChecksum(firmware: Firmware): Promise<boolean> {
+    const filePath = this.filePath(firmware.id)
+    if (!await fileExists(filePath)) {
+      this.logger.warn(`Firmware ${firmware.id} (${firmware.version}) is missing its binary on disk at ${filePath}`)
+      return false
+    }
+    const buffer = await fs.promises.readFile(filePath)
+    const checksum = crypto.createHash('sha256').update(buffer).digest('hex')
+    return checksum === firmware.checksum
+  }
+
+  filePath(id: string): string {
+    return firmwareFilePath(id)
+  }
+
+  fileUrl(id: string): string {
+    return firmwareFileUrl(id, this.configService.get<string>('api_url'))
+  }
+}

--- a/packages/api/src/migrations/1787120000000-AddFirmware.ts
+++ b/packages/api/src/migrations/1787120000000-AddFirmware.ts
@@ -1,0 +1,37 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddFirmware1787120000000 implements MigrationInterface {
+  name = 'AddFirmware1787120000000'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "firmware" (
+        "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+        "version" text NOT NULL,
+        "kind" text NOT NULL,
+        "checksum" text NOT NULL,
+        "compatibleModels" text[] NOT NULL DEFAULT '{}',
+        "deprecated" boolean NOT NULL DEFAULT false,
+        "label" text,
+        "syncedAt" timestamptz,
+        "uploadedAt" timestamptz
+      )
+    `)
+
+    await queryRunner.query(`
+      ALTER TABLE "device"
+      ADD COLUMN "targetFirmwareId" uuid,
+      ADD CONSTRAINT "FK_device_target_firmware"
+        FOREIGN KEY ("targetFirmwareId") REFERENCES "firmware"("id") ON DELETE SET NULL
+    `)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "device"
+      DROP CONSTRAINT "FK_device_target_firmware",
+      DROP COLUMN "targetFirmwareId"
+    `)
+    await queryRunner.query(`DROP TABLE "firmware"`)
+  }
+}

--- a/packages/ui/src/components/DeviceInformationCard.vue
+++ b/packages/ui/src/components/DeviceInformationCard.vue
@@ -32,6 +32,7 @@ import { useRouter } from 'vue-router'
 import { VBtn, VCard, VCardText, VCardTitle, VChip, VCol, VDivider, VExpansionPanel, VExpansionPanels, VExpansionPanelText, VExpansionPanelTitle, VIcon, VNumberInput, VRow, VSelect, VSwitch, VTextField, VTooltip } from 'vuetify/components'
 import { useDeviceStore } from '@/stores/device'
 import { useDeviceModelsStore } from '@/stores/deviceModels'
+import { useFirmwareStore } from '@/stores/firmware'
 import { DEFAULT_RENDER_SIZE } from '@/utils/deviceRenderSize'
 import { formatDate } from '@/utils/formatDate'
 import { isValidMac } from '@/utils/getRandomMac'
@@ -41,18 +42,48 @@ const props = defineProps<{ deviceId: string }>()
 
 const deviceStore = useDeviceStore()
 const deviceModelsStore = useDeviceModelsStore()
+const firmwareStore = useFirmwareStore()
 
 const device = computed(() => deviceStore.getById(props.deviceId))
 
-onMounted(() => deviceModelsStore.ensureLoaded())
+onMounted(() => {
+  deviceModelsStore.ensureLoaded()
+  firmwareStore.ensureLoaded()
+})
 
 const selectedModelName = ref<string | null>(null)
 const selectedPaletteId = ref<string | null>(null)
+const selectedFirmwareId = ref<string | null>(null)
 
 watch(device, (current) => {
   selectedModelName.value = current?.deviceModel?.name ?? null
   selectedPaletteId.value = current?.palette?.id ?? null
+  selectedFirmwareId.value = current?.targetFirmware?.id ?? null
 }, { immediate: true })
+
+const firmwareOptions = computed(() => {
+  const assigned = device.value?.targetFirmware
+  const compatible = firmwareStore.compatibleWith(device.value?.deviceModel?.name)
+  const firmwareList = assigned && !compatible.some(fw => fw.id === assigned.id) ? [assigned, ...compatible] : compatible
+  return firmwareList.map(fw => ({
+    title: `${fw.version}${fw.label ? ` — ${fw.label}` : ''} (${fw.kind === 'official-synced' ? 'official' : 'custom'})${fw.deprecated ? ' — deprecated' : ''}`,
+    value: fw.id,
+  }))
+})
+
+const firmwareUpdating = ref(false)
+
+async function triggerFirmwareUpdate() {
+  if (!device.value || !selectedFirmwareId.value)
+    return
+  firmwareUpdating.value = true
+  try {
+    await deviceStore.updateDevice(device.value.id, { targetFirmwareId: selectedFirmwareId.value, updateFirmware: true })
+  }
+  finally {
+    firmwareUpdating.value = false
+  }
+}
 
 const selectedModel = computed(() => deviceModelsStore.getByName(selectedModelName.value))
 
@@ -397,9 +428,6 @@ const nameEditing = ref(false)
                 <VCol cols="12" sm="4" md="4" lg="4">
                   <VSwitch v-model="device.resetDevice" color="secondary" density="compact" label="Reset device" />
                 </VCol>
-                <VCol cols="12" sm="4" md="4" lg="4">
-                  <VSwitch v-model="device.updateFirmware" color="secondary" density="compact" label="Automatic updates" disabled />
-                </VCol>
               </VRow>
               <VRow class="mb-2" density="comfortable">
                 <VCol cols="12" sm="6" md="4">
@@ -426,6 +454,36 @@ const nameEditing = ref(false)
                 <VCol v-if="device.deviceModel?.deprecated" cols="12" sm="12" md="4" class="d-flex align-center">
                   <VChip color="warning" size="small" variant="tonal">
                     Assigned model no longer exists upstream
+                  </VChip>
+                </VCol>
+              </VRow>
+              <VRow class="mb-2" density="comfortable">
+                <VCol cols="12" sm="8" md="6">
+                  <VSelect
+                    v-model="selectedFirmwareId"
+                    :items="firmwareOptions"
+                    density="compact"
+                    label="Target firmware"
+                    placeholder="None"
+                    persistent-placeholder
+                    data-test-id="device-firmware-select"
+                  />
+                </VCol>
+                <VCol cols="12" sm="4" md="6" class="d-flex align-center ga-3">
+                  <span class="text-caption text-medium-emphasis">Reported: {{ device.fwVersion || 'N/A' }}</span>
+                  <VBtn
+                    size="small"
+                    color="secondary"
+                    variant="tonal"
+                    :loading="firmwareUpdating"
+                    :disabled="!selectedFirmwareId"
+                    data-test-id="device-firmware-update-btn"
+                    @click="triggerFirmwareUpdate"
+                  >
+                    Update now
+                  </VBtn>
+                  <VChip v-if="device.updateFirmware" color="info" size="small" variant="tonal">
+                    Update pending
                   </VChip>
                 </VCol>
               </VRow>

--- a/packages/ui/src/components/__test__/DeviceInformationCard.spec.ts
+++ b/packages/ui/src/components/__test__/DeviceInformationCard.spec.ts
@@ -52,6 +52,17 @@ vi.mock('@/stores/deviceModels', () => ({
   }),
 }))
 
+const OFFICIAL_FW = { id: 'fw-1', version: '1.5.6', kind: 'official-synced' as const, compatibleModels: ['og_plus'], checksum: 'x', deprecated: false }
+const CUSTOM_FW = { id: 'fw-2', version: '1.0.0', kind: 'custom' as const, compatibleModels: ['v2'], checksum: 'y', deprecated: false }
+
+vi.mock('@/stores/firmware', () => ({
+  useFirmwareStore: () => ({
+    ensureLoaded: vi.fn(),
+    firmware: [OFFICIAL_FW, CUSTOM_FW],
+    compatibleWith: (modelName: string | null | undefined) => [OFFICIAL_FW, CUSTOM_FW].filter(fw => !fw.deprecated && fw.compatibleModels.includes(modelName ?? '')),
+  }),
+}))
+
 globalThis.ResizeObserver = rop
 
 globalThis.window.matchMedia = globalThis.window.matchMedia || function () {
@@ -151,5 +162,48 @@ describe('deviceInformationCard', () => {
     await vm.saveDevice()
     expect(updateDevice).toHaveBeenCalledWith('device1', expect.objectContaining({ deviceModelName: 'og_plus' }))
     expect(updateDevice.mock.calls[0][1]).not.toHaveProperty('paletteId')
+  })
+
+  describe('firmware section', () => {
+    it('pre-selects the device\'s currently assigned target firmware', () => {
+      mockDevice.current = baseDevice({ deviceModel: OG_PLUS, targetFirmware: OFFICIAL_FW })
+      const wrapper = mountCard()
+      const vm = wrapper.vm as any
+      expect(vm.selectedFirmwareId).toBe('fw-1')
+    })
+
+    it('does nothing when triggered without a selected firmware', async () => {
+      mockDevice.current = baseDevice({ deviceModel: OG_PLUS })
+      const wrapper = mountCard()
+      const vm = wrapper.vm as any
+      await vm.triggerFirmwareUpdate()
+      expect(updateDevice).not.toHaveBeenCalled()
+    })
+
+    it('assigns the firmware and flips the update flag in a single call', async () => {
+      mockDevice.current = baseDevice({ deviceModel: OG_PLUS })
+      const wrapper = mountCard()
+      const vm = wrapper.vm as any
+      vm.selectedFirmwareId = 'fw-1'
+      await vm.triggerFirmwareUpdate()
+      expect(updateDevice).toHaveBeenCalledWith('device1', { targetFirmwareId: 'fw-1', updateFirmware: true })
+    })
+
+    it('keeps a deprecated assigned firmware selectable so a stale target is still visible', () => {
+      const deprecatedFw = { ...OFFICIAL_FW, deprecated: true }
+      mockDevice.current = baseDevice({ deviceModel: OG_PLUS, targetFirmware: deprecatedFw })
+      const wrapper = mountCard()
+      const vm = wrapper.vm as any
+      expect(vm.selectedFirmwareId).toBe('fw-1')
+      expect(vm.firmwareOptions.some((opt: any) => opt.value === 'fw-1')).toBe(true)
+    })
+
+    it('shows an update pending chip while the flag is set', async () => {
+      mockDevice.current = baseDevice({ deviceModel: OG_PLUS, updateFirmware: true, targetFirmware: OFFICIAL_FW })
+      const wrapper = mountCard()
+      await wrapper.find('.v-expansion-panel-title').trigger('click')
+      await wrapper.vm.$nextTick()
+      expect(wrapper.text()).toContain('Update pending')
+    })
   })
 })

--- a/packages/ui/src/stores/__test__/firmware.spec.ts
+++ b/packages/ui/src/stores/__test__/firmware.spec.ts
@@ -1,0 +1,121 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useFirmwareStore } from '../firmware'
+
+const OFFICIAL = { id: 'fw-1', version: '1.5.6', kind: 'official-synced', compatibleModels: ['og_png', 'og_plus', 'og_bwry'], deprecated: false }
+const CUSTOM_UNIVERSAL = { id: 'fw-2', version: '1.0.0', kind: 'custom', compatibleModels: [], deprecated: false }
+const CUSTOM_V2 = { id: 'fw-3', version: '2.0.0', kind: 'custom', compatibleModels: ['v2'], deprecated: false }
+const DEPRECATED = { id: 'fw-0', version: '1.5.5', kind: 'official-synced', compatibleModels: ['og_png'], deprecated: true }
+
+function jsonResponse(body: unknown, ok = true) {
+  return { ok, status: ok ? 200 : 503, statusText: ok ? 'OK' : 'Service Unavailable', json: async () => body }
+}
+
+describe('firmware store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    globalThis.fetch = vi.fn()
+  })
+
+  it('fetchAll loads firmware and exposes only active rows', async () => {
+    ;(globalThis.fetch as any).mockResolvedValue(jsonResponse([OFFICIAL, DEPRECATED]))
+    const store = useFirmwareStore()
+    await store.fetchAll()
+    expect(store.firmware).toHaveLength(2)
+    expect(store.activeFirmware).toEqual([OFFICIAL])
+    expect(store.loaded).toBe(true)
+  })
+
+  it('ensureLoaded dedupes concurrent calls into a single fetchAll', async () => {
+    ;(globalThis.fetch as any).mockResolvedValue(jsonResponse([]))
+    const store = useFirmwareStore()
+    await Promise.all([store.ensureLoaded(), store.ensureLoaded(), store.ensureLoaded()])
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('fetchAll records the status and statusText when a response is not ok', async () => {
+    ;(globalThis.fetch as any).mockResolvedValue(jsonResponse(null, false))
+    const store = useFirmwareStore()
+    await store.fetchAll()
+    expect(store.loaded).toBe(false)
+    expect(store.error).toBe('503 Service Unavailable')
+  })
+
+  it('compatibleWith returns universal and model-matching firmware, excluding other models and deprecated rows', async () => {
+    ;(globalThis.fetch as any).mockResolvedValue(jsonResponse([OFFICIAL, CUSTOM_UNIVERSAL, CUSTOM_V2, DEPRECATED]))
+    const store = useFirmwareStore()
+    await store.fetchAll()
+    expect(store.compatibleWith('og_plus')).toEqual([OFFICIAL, CUSTOM_UNIVERSAL])
+    expect(store.compatibleWith('v2')).toEqual([CUSTOM_UNIVERSAL, CUSTOM_V2])
+    expect(store.compatibleWith(null)).toEqual([CUSTOM_UNIVERSAL])
+  })
+
+  it('getById finds a firmware row by id', async () => {
+    ;(globalThis.fetch as any).mockResolvedValue(jsonResponse([OFFICIAL]))
+    const store = useFirmwareStore()
+    await store.fetchAll()
+    expect(store.getById('fw-1')).toEqual(OFFICIAL)
+    expect(store.getById(undefined)).toBeUndefined()
+  })
+
+  it('sync posts to the sync endpoint and refreshes the list', async () => {
+    const result = { inserted: true, version: '1.5.7' }
+    ;(globalThis.fetch as any).mockImplementation(async (url: string, init?: RequestInit) =>
+      init?.method === 'POST' ? jsonResponse(result) : jsonResponse([OFFICIAL]))
+    const store = useFirmwareStore()
+    await expect(store.sync()).resolves.toEqual(result)
+    expect(globalThis.fetch).toHaveBeenCalledWith('/api/firmware/sync', { method: 'POST' })
+    expect(store.firmware).toEqual([OFFICIAL])
+  })
+
+  it('sync records the server error message and returns null on failure', async () => {
+    ;(globalThis.fetch as any).mockResolvedValue(jsonResponse({ message: 'Could not sync firmware from TRMNL: boom' }, false))
+    const store = useFirmwareStore()
+    await expect(store.sync()).resolves.toBeNull()
+    expect(store.error).toBe('Could not sync firmware from TRMNL: boom')
+    expect(store.syncing).toBe(false)
+  })
+
+  it('upload posts multipart form data and refreshes the list', async () => {
+    let capturedBody: FormData | undefined
+    ;(globalThis.fetch as any).mockImplementation(async (url: string, init?: RequestInit) => {
+      if (init?.method === 'POST') {
+        capturedBody = init.body as FormData
+        return jsonResponse({ id: 'fw-2' })
+      }
+      return jsonResponse([CUSTOM_UNIVERSAL])
+    })
+    const store = useFirmwareStore()
+    const file = new File(['binary'], 'og.bin')
+    const result = await store.upload(file, '1.0.0', 'My Label', ['og_plus'])
+    expect(result).toBe(true)
+    expect(capturedBody?.get('version')).toBe('1.0.0')
+    expect(capturedBody?.get('label')).toBe('My Label')
+    expect(capturedBody?.get('compatibleModels')).toBe('["og_plus"]')
+    expect(store.firmware).toEqual([CUSTOM_UNIVERSAL])
+  })
+
+  it('upload records the server error and returns false on failure', async () => {
+    ;(globalThis.fetch as any).mockResolvedValue(jsonResponse({ message: 'Firmware upload must be a .bin file' }, false))
+    const store = useFirmwareStore()
+    const file = new File(['binary'], 'og.zip')
+    await expect(store.upload(file, '1.0.0')).resolves.toBe(false)
+    expect(store.error).toBe('Firmware upload must be a .bin file')
+    expect(store.uploading).toBe(false)
+  })
+
+  it('remove deletes a firmware and refreshes the list', async () => {
+    ;(globalThis.fetch as any).mockImplementation(async (url: string, init?: RequestInit) =>
+      init?.method === 'DELETE' ? jsonResponse({}) : jsonResponse([]))
+    const store = useFirmwareStore()
+    await expect(store.remove('fw-2')).resolves.toBe(true)
+    expect(globalThis.fetch).toHaveBeenCalledWith('/api/firmware/fw-2', { method: 'DELETE' })
+  })
+
+  it('remove records the server error and returns false on failure', async () => {
+    ;(globalThis.fetch as any).mockResolvedValue(jsonResponse({ message: 'Only custom firmware can be deleted' }, false))
+    const store = useFirmwareStore()
+    await expect(store.remove('fw-1')).resolves.toBe(false)
+    expect(store.error).toBe('Only custom firmware can be deleted')
+  })
+})

--- a/packages/ui/src/stores/device.ts
+++ b/packages/ui/src/stores/device.ts
@@ -3,7 +3,7 @@ import { defineStore } from 'pinia'
 import { ref } from 'vue'
 
 export type CreateDevice = Pick<Device, 'mac' | 'name'>
-export type UpdateDevice = Partial<Omit<Device, 'id' | 'mac' | 'friendlyId' | 'deviceModel' | 'palette'>> & { deviceModelName?: string, paletteId?: string }
+export type UpdateDevice = Partial<Omit<Device, 'id' | 'mac' | 'friendlyId' | 'deviceModel' | 'palette' | 'targetFirmware'>> & { deviceModelName?: string, paletteId?: string, targetFirmwareId?: string }
 
 export const useDeviceStore = defineStore('device', () => {
   const devices = ref<Device[]>([])

--- a/packages/ui/src/stores/firmware.ts
+++ b/packages/ui/src/stores/firmware.ts
@@ -1,0 +1,115 @@
+import type { Firmware, FirmwareSyncResult } from '../types'
+import { defineStore } from 'pinia'
+import { computed, ref } from 'vue'
+
+export const useFirmwareStore = defineStore('firmware', () => {
+  const firmware = ref<Firmware[]>([])
+  const loaded = ref(false)
+  const syncing = ref(false)
+  const uploading = ref(false)
+  const error = ref<string | null>(null)
+
+  const activeFirmware = computed(() => firmware.value.filter(fw => !fw.deprecated))
+
+  let inFlight: Promise<void> | null = null
+
+  async function fetchAll() {
+    try {
+      const res = await fetch('/api/firmware')
+      if (!res.ok)
+        throw new Error(`${res.status} ${res.statusText}`)
+      firmware.value = await res.json()
+      loaded.value = true
+      error.value = null
+    }
+    catch (err) {
+      error.value = err instanceof Error ? err.message : 'Failed to load firmware'
+      loaded.value = false
+    }
+  }
+
+  function ensureLoaded() {
+    if (loaded.value)
+      return Promise.resolve()
+    inFlight ??= fetchAll().finally(() => {
+      inFlight = null
+    })
+    return inFlight
+  }
+
+  function getById(id: string | null | undefined) {
+    return firmware.value.find(fw => fw.id === id)
+  }
+
+  function compatibleWith(modelName: string | null | undefined) {
+    return activeFirmware.value.filter(fw => fw.compatibleModels.length === 0 || (modelName && fw.compatibleModels.includes(modelName)))
+  }
+
+  async function sync(): Promise<FirmwareSyncResult | null> {
+    syncing.value = true
+    error.value = null
+    try {
+      const res = await fetch('/api/firmware/sync', { method: 'POST' })
+      if (!res.ok) {
+        const body = await res.json().catch(() => null)
+        throw new Error(body?.message ?? `Sync failed: ${res.statusText}`)
+      }
+      const result: FirmwareSyncResult = await res.json()
+      await fetchAll()
+      return result
+    }
+    catch (err) {
+      error.value = err instanceof Error ? err.message : 'Failed to sync firmware'
+      return null
+    }
+    finally {
+      syncing.value = false
+    }
+  }
+
+  async function upload(file: File, version: string, label?: string, compatibleModels?: string[]): Promise<boolean> {
+    uploading.value = true
+    error.value = null
+    try {
+      const body = new FormData()
+      body.append('file', file)
+      body.append('version', version)
+      if (label)
+        body.append('label', label)
+      if (compatibleModels)
+        body.append('compatibleModels', JSON.stringify(compatibleModels))
+      const res = await fetch('/api/firmware/upload', { method: 'POST', body })
+      if (!res.ok) {
+        const errBody = await res.json().catch(() => null)
+        throw new Error(errBody?.message ?? `Upload failed: ${res.statusText}`)
+      }
+      await fetchAll()
+      return true
+    }
+    catch (err) {
+      error.value = err instanceof Error ? err.message : 'Failed to upload firmware'
+      return false
+    }
+    finally {
+      uploading.value = false
+    }
+  }
+
+  async function remove(id: string): Promise<boolean> {
+    try {
+      const res = await fetch(`/api/firmware/${id}`, { method: 'DELETE' })
+      if (!res.ok) {
+        const body = await res.json().catch(() => null)
+        throw new Error(body?.message ?? `Delete failed: ${res.statusText}`)
+      }
+      await fetchAll()
+      return true
+    }
+    catch (err) {
+      error.value = err instanceof Error ? err.message : 'Failed to delete firmware'
+      return false
+    }
+  }
+
+  return { firmware, activeFirmware, loaded, syncing, uploading, error, fetchAll, ensureLoaded, getById, compatibleWith, sync, upload, remove }
+})

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -39,6 +39,24 @@ export interface DeviceModelSyncResult {
   syncedAt: string
 }
 
+export interface Firmware {
+  id: string
+  version: string
+  kind: 'official-synced' | 'custom'
+  checksum: string
+  compatibleModels: string[]
+  deprecated: boolean
+  label?: string | null
+  syncedAt?: string | null
+  uploadedAt?: string | null
+}
+
+export interface FirmwareSyncResult {
+  inserted: boolean
+  version: string
+  syncedAt?: string
+}
+
 export interface Device {
   id: string
   name: string
@@ -61,6 +79,7 @@ export interface Device {
   specialFunction: string
   resetDevice: boolean
   updateFirmware: boolean
+  targetFirmware?: Firmware | null
   lastSeen: string
 }
 

--- a/packages/ui/src/views/MaintenanceView.vue
+++ b/packages/ui/src/views/MaintenanceView.vue
@@ -1,14 +1,16 @@
 <script setup lang="ts">
-import type { DeviceModelSyncResult } from '../types'
-import { mdiAlertCircle, mdiCheckCircle, mdiCloudSync, mdiDelete, mdiRefresh } from '@mdi/js'
+import type { DeviceModelSyncResult, FirmwareSyncResult } from '../types'
+import { mdiAlertCircle, mdiCheckCircle, mdiCloudSync, mdiDelete, mdiRefresh, mdiUpload } from '@mdi/js'
 import { computed, onMounted, ref } from 'vue'
-import { VAlert, VBtn, VCard, VCardText, VCardTitle, VCheckbox, VChip, VCol, VContainer, VDialog, VDivider, VList, VListItem, VListItemSubtitle, VListItemTitle, VProgressCircular, VRow, VSwitch } from 'vuetify/components'
+import { VAlert, VBtn, VCard, VCardText, VCardTitle, VCheckbox, VChip, VCol, VContainer, VDialog, VDivider, VFileInput, VList, VListItem, VListItemSubtitle, VListItemTitle, VProgressCircular, VRow, VSelect, VSwitch, VTextField } from 'vuetify/components'
 import { useDeviceModelsStore } from '../stores/deviceModels'
+import { useFirmwareStore } from '../stores/firmware'
 import { useMaintenanceStore } from '../stores/maintenance'
 import { formatDate } from '../utils/formatDate'
 
 const maintenanceStore = useMaintenanceStore()
 const deviceModelsStore = useDeviceModelsStore()
+const firmwareStore = useFirmwareStore()
 
 const syncResult = ref<DeviceModelSyncResult | null>(null)
 
@@ -23,6 +25,44 @@ const modelError = computed(() => (syncResult.value ? null : deviceModelsStore.e
 
 async function handleModelSync() {
   syncResult.value = await deviceModelsStore.sync()
+}
+
+const firmwareSyncResult = ref<FirmwareSyncResult | null>(null)
+const firmwareError = computed(() => (firmwareSyncResult.value ? null : firmwareStore.error))
+
+const lastFirmwareSync = computed(() => {
+  const dates = firmwareStore.firmware.map(fw => fw.syncedAt).filter((date): date is string => !!date).sort()
+  return dates.at(-1) ?? null
+})
+
+async function handleFirmwareSync() {
+  firmwareSyncResult.value = await firmwareStore.sync()
+}
+
+const uploadVersion = ref('')
+const uploadLabel = ref('')
+const uploadCompatibleModels = ref<string[]>([])
+const uploadFile = ref<File[]>([])
+
+const deviceModelOptions = computed(() => deviceModelsStore.activeModels.map(model => ({ title: model.label, value: model.name })))
+
+const canUpload = computed(() => !!uploadVersion.value && uploadFile.value.length > 0)
+
+async function handleFirmwareUpload() {
+  const file = uploadFile.value[0]
+  if (!file)
+    return
+  const ok = await firmwareStore.upload(file, uploadVersion.value, uploadLabel.value || undefined, uploadCompatibleModels.value.length > 0 ? uploadCompatibleModels.value : undefined)
+  if (ok) {
+    uploadVersion.value = ''
+    uploadLabel.value = ''
+    uploadCompatibleModels.value = []
+    uploadFile.value = []
+  }
+}
+
+async function handleFirmwareDelete(id: string) {
+  await firmwareStore.remove(id)
 }
 
 const selectedOrphanedFiles = ref<string[]>([])
@@ -71,7 +111,7 @@ const totalSelectedSize = computed(() => {
 })
 
 onMounted(async () => {
-  await Promise.all([maintenanceStore.scanSystem(), deviceModelsStore.ensureLoaded()])
+  await Promise.all([maintenanceStore.scanSystem(), deviceModelsStore.ensureLoaded(), firmwareStore.ensureLoaded()])
 })
 
 async function handleScan() {
@@ -237,6 +277,111 @@ async function executeCleanup() {
                 ({{ syncResult.deprecatedModels }} models, {{ syncResult.deprecatedPalettes }} palettes newly deprecated)
               </span>
             </VAlert>
+          </VCardText>
+        </VCard>
+
+        <VCard elevation="1" class="mb-4" data-test-id="firmware-card">
+          <VCardTitle class="d-flex align-center justify-space-between flex-wrap ga-2">
+            Firmware
+            <VBtn
+              :prepend-icon="mdiCloudSync"
+              variant="tonal"
+              color="secondary"
+              :loading="firmwareStore.syncing"
+              data-test-id="sync-firmware-btn"
+              @click="handleFirmwareSync"
+            >
+              Sync from TRMNL
+            </VBtn>
+          </VCardTitle>
+          <VDivider />
+          <VCardText>
+            <p class="text-body-2 text-medium-emphasis mb-2">
+              OTA binaries a Device can be pushed to — official-synced daily from usetrmnl.com, or uploaded directly. A push is always an explicit per-Device action from the Device's own settings.
+            </p>
+            <div class="text-body-2 mb-3">
+              {{ firmwareStore.activeFirmware.length }} firmware
+              <span v-if="firmwareStore.firmware.length - firmwareStore.activeFirmware.length > 0">
+                ({{ firmwareStore.firmware.length - firmwareStore.activeFirmware.length }} deprecated)
+              </span>
+              · Last synced: {{ lastFirmwareSync ? formatDate(lastFirmwareSync) : 'never' }}
+            </div>
+            <VAlert v-if="firmwareError" type="error" variant="tonal" class="mb-3" :icon="mdiAlertCircle">
+              {{ firmwareError }}
+            </VAlert>
+            <VAlert v-else-if="firmwareSyncResult" type="success" variant="tonal" class="mb-3" :icon="mdiCheckCircle" closable @click:close="firmwareSyncResult = null">
+              <span v-if="firmwareSyncResult.inserted">Synced firmware {{ firmwareSyncResult.version }}</span>
+              <span v-else>Already up to date at {{ firmwareSyncResult.version }}</span>
+            </VAlert>
+
+            <VList v-if="firmwareStore.activeFirmware.length > 0" density="compact" class="mb-4">
+              <VListItem v-for="fw in firmwareStore.activeFirmware" :key="fw.id" :data-test-id="`firmware-row-${fw.id}`">
+                <VListItemTitle class="text-body-2">
+                  {{ fw.version }}
+                  <VChip size="x-small" class="ml-2">
+                    {{ fw.kind === 'official-synced' ? 'official' : 'custom' }}
+                  </VChip>
+                  <VChip v-if="fw.label" size="x-small" variant="tonal" class="ml-1">
+                    {{ fw.label }}
+                  </VChip>
+                </VListItemTitle>
+                <VListItemSubtitle class="text-caption">
+                  {{ fw.compatibleModels.length > 0 ? fw.compatibleModels.join(', ') : 'Universal (all models)' }}
+                </VListItemSubtitle>
+                <template v-if="fw.kind === 'custom'" #append>
+                  <VBtn
+                    :icon="mdiDelete"
+                    size="small"
+                    variant="text"
+                    color="error"
+                    :data-test-id="`firmware-delete-${fw.id}`"
+                    @click="handleFirmwareDelete(fw.id)"
+                  />
+                </template>
+              </VListItem>
+            </VList>
+
+            <VDivider class="mb-4" />
+
+            <div class="text-subtitle-2 mb-2">
+              Upload custom firmware
+            </div>
+            <VRow dense>
+              <VCol cols="12" sm="4">
+                <VTextField v-model="uploadVersion" density="compact" label="Version" hide-details data-test-id="firmware-upload-version" />
+              </VCol>
+              <VCol cols="12" sm="4">
+                <VTextField v-model="uploadLabel" density="compact" label="Label (optional)" hide-details />
+              </VCol>
+              <VCol cols="12" sm="4">
+                <VSelect
+                  v-model="uploadCompatibleModels"
+                  :items="deviceModelOptions"
+                  density="compact"
+                  label="Compatible models"
+                  placeholder="Universal"
+                  persistent-placeholder
+                  multiple
+                  hide-details
+                />
+              </VCol>
+              <VCol cols="12" sm="8">
+                <VFileInput v-model="uploadFile" density="compact" label="Binary (.bin)" accept=".bin" hide-details data-test-id="firmware-upload-file" />
+              </VCol>
+              <VCol cols="12" sm="4" class="d-flex align-center">
+                <VBtn
+                  :prepend-icon="mdiUpload"
+                  color="primary"
+                  variant="tonal"
+                  :disabled="!canUpload"
+                  :loading="firmwareStore.uploading"
+                  data-test-id="firmware-upload-btn"
+                  @click="handleFirmwareUpload"
+                >
+                  Upload
+                </VBtn>
+              </VCol>
+            </VRow>
           </VCardText>
         </VCard>
 


### PR DESCRIPTION
## Summary
- Adds a `Firmware` module: a `Firmware` entity that's either `official-synced` (mirrored daily from `usetrmnl.com/api/firmware/latest`, superseded-not-deleted on a new sync) or `custom` (admin-uploaded, checksum-verified, `.bin`-only, size-capped), each with an optional `compatibleModels` set enforced as a hard block on assignment.
- Extends `UpdateDeviceDto`/`devices.service.ts` with `targetFirmwareId` + `applyFirmwareChanges` (mirrors the existing `applyModelChanges` pattern), and wires the existing but previously dead `device.updateFirmware` flag into `DeviceDisplayService.getCurrentImage`: a non-mirrored Device with a pending update gets `firmware_url` populated (after a checksum re-verify) and the flag cleared once actually served. Mirrored Devices are untouched.
- Admin UI: a Firmware card in the Maintenance view (list, manual sync, custom upload with compatible-model tagging, delete for custom rows) and a Firmware picker + "Update now" action on the Device settings page, replacing the previously-disabled "Automatic updates" switch.
- Migration `AddFirmware`, new `firmware` table + `device.targetFirmwareId` FK.

Implements #799, per the design recorded in `docs/adr/0014`–`0016`.

## Test plan
- [x] `pnpm -r run test` — 65 API test files (617 tests) + 24 UI test files (143 tests), all passing
- [x] `pnpm -r run lint` — clean
- [x] `pnpm -r run build` — both packages build cleanly (tsup + migrations tsc; vue-tsc + vite)
- [x] Self code-reviewed (`/code-review medium`); both findings (NULLS-FIRST ordering bug in `FirmwareService.findAll`, stale-deprecated-target missing from the Device firmware picker) fixed with regression tests

https://claude.ai/code/session_017g3iEwKndX43PULBKWV1eP