### PR TITLE
fix(api): add type-check script and fix accumulated tsc errors

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -13,6 +13,7 @@
     "test:coverage": "vitest run --coverage",
     "lint": "eslint",
     "lint:fix": "eslint --fix",
+    "type-check": "tsc --noEmit -p tsconfig.json",
     "prepare": "puppeteer browsers install chrome",
     "migration:generate": "typeorm-ts-node-commonjs migration:generate -d src/config/typeorm.config.ts",
     "migration:create": "typeorm-ts-node-commonjs migration:create",

--- a/packages/api/src/config/config.ts
+++ b/packages/api/src/config/config.ts
@@ -1,7 +1,7 @@
 import process from 'node:process'
 
 export default () => ({
-  port: Number.parseInt(process.env.KUROSHIRO_PORT, 10) || 3000,
+  port: Number.parseInt(process.env.KUROSHIRO_PORT || '', 10) || 3000,
   api_url: process.env.KUROSHIRO_API_URL || 'http://localhost:5173',
   demo_mode: process.env.KUROSHIRO_DEMO_MODE === 'true' || false,
   database: {

--- a/packages/api/src/device-models/device-models.controller.ts
+++ b/packages/api/src/device-models/device-models.controller.ts
@@ -1,4 +1,5 @@
 import { Body, Controller, Delete, Get, Logger, Param, Post, ServiceUnavailableException, UsePipes, ValidationPipe } from '@nestjs/common'
+import { getErrorMessage } from '../utils/getErrorMessage'
 import { CustomPalettesService } from './custom-palettes.service'
 import { DeviceModelSyncResult, DeviceModelSyncService } from './device-model-sync.service'
 import { DeviceModelsService } from './device-models.service'
@@ -43,7 +44,7 @@ export class DeviceModelsController {
       return await this.syncService.sync()
     }
     catch (err) {
-      const message = err instanceof Error ? err.message : String(err)
+      const message = getErrorMessage(err)
       this.logger.error(`Device model sync failed: ${message}`)
       throw new ServiceUnavailableException(`Could not sync device models from TRMNL: ${message}`)
     }

--- a/packages/api/src/device-models/fallback-screens.service.ts
+++ b/packages/api/src/device-models/fallback-screens.service.ts
@@ -2,6 +2,7 @@ import type { DeviceRenderTarget } from './device-models.service'
 import * as fs from 'node:fs'
 import { Injectable, Logger } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
+import { getErrorMessage } from '../utils/getErrorMessage'
 import { resolveAppPath } from '../utils/pathHelper'
 import { FALLBACK_SCREEN_TEMPLATE_VERSION, fallbackScreenBody } from './fallback-screen-templates'
 import { renderHtmlToPng } from './render-html-to-png'
@@ -32,7 +33,8 @@ export class FallbackScreensService {
       return `${this.apiUrl()}/${relativePath.join('/')}`
     }
     catch (err) {
-      this.logger.error(`Could not generate ${kind} screen for ${target.model.name}/${target.palette.id}, serving the static image: ${err.message}`)
+      const message = getErrorMessage(err)
+      this.logger.error(`Could not generate ${kind} screen for ${target.model.name}/${target.palette.id}, serving the static image: ${message}`)
       return `${this.apiUrl()}/screens/${kind}.png`
     }
   }
@@ -48,6 +50,6 @@ export class FallbackScreensService {
   }
 
   private apiUrl(): string {
-    return this.configService.get<string>('api_url')
+    return this.configService.get<string>('api_url', 'http://localhost:5173')
   }
 }

--- a/packages/api/src/device-models/render-html-to-png.ts
+++ b/packages/api/src/device-models/render-html-to-png.ts
@@ -3,7 +3,6 @@ import type { DeviceRenderTarget } from './device-models.service'
 import buffer from 'node:buffer'
 import * as fs from 'node:fs'
 import * as path from 'node:path'
-import puppeteer from 'puppeteer'
 import { convertToPng } from '../utils/imageUtils'
 
 /**
@@ -11,6 +10,7 @@ import { convertToPng } from '../utils/imageUtils'
  * pixel size and converts the screenshot to the target's PNG at `outputPath`.
  */
 export async function renderHtmlToPng(html: string, target: DeviceRenderTarget, outputPath: string, logger: Logger): Promise<void> {
+  const { default: puppeteer } = await import('puppeteer')
   const browser = await puppeteer.launch({ args: ['--no-sandbox', '--disable-web-security'] })
   const tmpPath = `${outputPath}.tmp-source`
   try {

--- a/packages/api/src/devices/__test__/devices.controller.spec.ts
+++ b/packages/api/src/devices/__test__/devices.controller.spec.ts
@@ -59,7 +59,7 @@ describe('devicesController', () => {
   it('update updates a device if found and valid', async () => {
     const id = '1'
     const dbDevice = { id, apikey: 'key' }
-    const dto: UpdateDeviceDto = { id, apikey: 'key', specialFunction: 'identify', resetDevice: false, updateFirmware: false }
+    const dto: UpdateDeviceDto = { specialFunction: 'identify', resetDevice: false, updateFirmware: false }
     service.findById.mockResolvedValue(dbDevice)
     service.update.mockResolvedValue({ ...dbDevice, ...dto })
     await expect(controller.update(id, dto)).resolves.toBeUndefined()
@@ -68,7 +68,7 @@ describe('devicesController', () => {
 
   it('update throws NotFoundException if device not found', async () => {
     service.findById.mockResolvedValue(null)
-    const dto: UpdateDeviceDto = { id: '1', apikey: 'key', specialFunction: 'identify', resetDevice: false, updateFirmware: false }
+    const dto: UpdateDeviceDto = { specialFunction: 'identify', resetDevice: false, updateFirmware: false }
     await expect(controller.update('1', dto)).rejects.toThrow(NotFoundException)
   })
 })

--- a/packages/api/src/devices/__test__/devices.service.spec.ts
+++ b/packages/api/src/devices/__test__/devices.service.spec.ts
@@ -80,7 +80,7 @@ describe('devicesService', () => {
     const device: Partial<Device> = { mac: '00:11:22:33:44:55' }
     repo.create.mockReturnValue(baseDevice)
     repo.save.mockResolvedValue(baseDevice)
-    const result = await service.create(device)
+    const result = await service.create(device as any)
     expect(repo.create).toHaveBeenCalled()
     expect(repo.save).toHaveBeenCalledWith(baseDevice)
     expect(result).toBe(baseDevice)
@@ -111,7 +111,7 @@ describe('devicesService', () => {
       repo.findOneBy.mockResolvedValue({ ...baseDevice, deviceModel: OG_PLUS, palette: GRAY_4 })
       deviceModels.findByName.mockResolvedValue(V2)
       deviceModels.defaultPaletteFor.mockResolvedValue(GRAY_16)
-      const result = await service.update('1', { deviceModelName: 'v2' } as any)
+      const result = (await service.update('1', { deviceModelName: 'v2' } as any))!
       expect(deviceModels.findByName).toHaveBeenCalledWith('v2')
       expect(result.deviceModel).toBe(V2)
       expect(result.palette).toBe(GRAY_16)
@@ -122,7 +122,7 @@ describe('devicesService', () => {
       repo.findOneBy.mockResolvedValue({ ...baseDevice, deviceModel: OG_PLUS, palette: GRAY_4 })
       deviceModels.findByName.mockResolvedValue(V2)
       deviceModels.findPalette.mockResolvedValue(BW)
-      const result = await service.update('1', { deviceModelName: 'v2', paletteId: 'bw' } as any)
+      const result = (await service.update('1', { deviceModelName: 'v2', paletteId: 'bw' } as any))!
       expect(result.deviceModel).toBe(V2)
       expect(result.palette).toBe(BW)
       expect(deviceModels.defaultPaletteFor).not.toHaveBeenCalled()
@@ -131,7 +131,7 @@ describe('devicesService', () => {
     it('changes only the palette when the model stays the same', async () => {
       repo.findOneBy.mockResolvedValue({ ...baseDevice, deviceModel: OG_PLUS, palette: GRAY_4 })
       deviceModels.findPalette.mockResolvedValue(BW)
-      const result = await service.update('1', { deviceModelName: 'og_plus', paletteId: 'bw' } as any)
+      const result = (await service.update('1', { deviceModelName: 'og_plus', paletteId: 'bw' } as any))!
       expect(deviceModels.findByName).not.toHaveBeenCalled()
       expect(result.deviceModel).toBe(OG_PLUS)
       expect(result.palette).toBe(BW)
@@ -169,7 +169,7 @@ describe('devicesService', () => {
     it('fills in the default palette for a device that has a model but no palette', async () => {
       repo.findOneBy.mockResolvedValue({ ...baseDevice, deviceModel: OG_PLUS, palette: null })
       deviceModels.defaultPaletteFor.mockResolvedValue(GRAY_4)
-      const result = await service.update('1', { name: 'renamed' } as any)
+      const result = (await service.update('1', { name: 'renamed' } as any))!
       expect(result.name).toBe('renamed')
       expect(result.palette).toBe(GRAY_4)
     })
@@ -178,7 +178,7 @@ describe('devicesService', () => {
       repo.findOneBy.mockResolvedValue({ ...baseDevice, deviceModel: OG_PLUS, palette: GRAY_4 })
       deviceModels.findPalette.mockResolvedValue(CUSTOM_RED_3BWR)
       deviceModels.compatibleFamiliesFor.mockResolvedValue(new Set(['screen--color-3bwr']))
-      const result = await service.update('1', { paletteId: CUSTOM_RED_3BWR.id } as any)
+      const result = (await service.update('1', { paletteId: CUSTOM_RED_3BWR.id } as any))!
       expect(deviceModels.compatibleFamiliesFor).toHaveBeenCalledWith(OG_PLUS)
       expect(result.palette).toBe(CUSTOM_RED_3BWR)
     })
@@ -203,7 +203,7 @@ describe('devicesService', () => {
     it('assigns a firmware compatible with the device model', async () => {
       repo.findOneBy.mockResolvedValue({ ...baseDevice, deviceModel: OG_PLUS })
       firmwareService.findById.mockResolvedValue(compatibleFirmware)
-      const result = await service.update('1', { targetFirmwareId: 'fw-1' } as any)
+      const result = (await service.update('1', { targetFirmwareId: 'fw-1' } as any))!
       expect(firmwareService.findById).toHaveBeenCalledWith('fw-1')
       expect(result.targetFirmware).toBe(compatibleFirmware)
     })
@@ -211,7 +211,7 @@ describe('devicesService', () => {
     it('assigns a universal firmware (empty compatibleModels) regardless of device model', async () => {
       repo.findOneBy.mockResolvedValue({ ...baseDevice, deviceModel: null })
       firmwareService.findById.mockResolvedValue(universalFirmware)
-      const result = await service.update('1', { targetFirmwareId: 'fw-2' } as any)
+      const result = (await service.update('1', { targetFirmwareId: 'fw-2' } as any))!
       expect(result.targetFirmware).toBe(universalFirmware)
     })
 

--- a/packages/api/src/devices/__test__/display.service.spec.ts
+++ b/packages/api/src/devices/__test__/display.service.spec.ts
@@ -81,6 +81,9 @@ describe('deviceDisplayService', () => {
       deviceModels as any,
       fallbackScreens as any,
       firmwareService as any,
+      {} as any,
+      {} as any,
+      {} as any,
     )
     vi.resetAllMocks()
     primeMockDeviceModelsService(deviceModels)
@@ -172,7 +175,7 @@ describe('deviceDisplayService', () => {
       expect(html).toContain('class="screen screen--v2 screen--lg screen--density-2x screen--4bit"')
       expect(html).toContain('--screen-w: 1040px;')
       expect(html).toContain('<div class="view view--full"><p>hi</p></div>')
-      const { convertToPng } = await import('../../utils/imageUtils')
+      const { convertToPng } = await import('../../utils/imageUtils.js')
       expect(convertToPng).toHaveBeenCalledWith(expect.any(String), expect.stringContaining('screen2.png'), { model: V2, palette: GRAY_16 }, expect.any(Object))
       expect(result.image_url).toBe('http://api/screens/devices/1/screen2.png')
       expect(fs.unlink).toHaveBeenCalledWith(expect.stringContaining('tmp-source'))
@@ -195,8 +198,8 @@ describe('deviceDisplayService', () => {
       const device = { ...baseDevice, deviceModel: OG_PLUS }
       const plugin = { id: 'p1', name: 'P', dataSources: [{ name: 'source', method: 'GET', url: 'http://x' }], templates: [{ layout: 'full', liquidMarkup: '{{ v }}' }] }
       primeRotation({ id: 'screen2', type: 'plugin', order: 2, device, plugin, filename: 'x', generatedAt: new Date() }, device)
-      service.pluginDataFetcher = { fetchData: vi.fn().mockResolvedValue({ v: 1 }) } as any
-      service.pluginRenderer = { render: vi.fn().mockResolvedValue('<b>1</b>') } as any
+      ;(service as any).pluginDataFetcher = { fetchData: vi.fn().mockResolvedValue({ v: 1 }) } as any
+      ;(service as any).pluginRenderer = { render: vi.fn().mockResolvedValue('<b>1</b>') } as any
 
       await service.getCurrentImage(headers as any)
 
@@ -208,7 +211,7 @@ describe('deviceDisplayService', () => {
     it('places cached mashup markup directly inside the shell', async () => {
       const device = { ...baseDevice, deviceModel: OG_PLUS }
       primeRotation({ id: 'screen2', type: 'mashup', order: 2, device, cachedPluginOutput: '<div class="mashup mashup--1Lx1R">m</div>', mashupConfiguration: { id: 'c' }, filename: 'x', generatedAt: new Date() }, device)
-      service.mashupRenderer = { renderMashup: vi.fn() } as any
+      ;(service as any).mashupRenderer = { renderMashup: vi.fn() } as any
 
       await service.getCurrentImage(headers as any)
 
@@ -304,7 +307,7 @@ describe('deviceDisplayService', () => {
       json: () => Promise.resolve(mockResponse),
     })
 
-    const { downloadImage, convertToPng } = await import('../../utils/imageUtils')
+    const { downloadImage, convertToPng } = await import('../../utils/imageUtils.js')
 
     vi.mocked(fs.unlink).mockResolvedValueOnce()
     const result = await service.getCurrentImage(testHeaders as any)
@@ -344,7 +347,7 @@ describe('deviceDisplayService', () => {
       json: () => Promise.resolve(mockResponse),
     })
 
-    const { downloadImage, convertToPng } = await import('../../utils/imageUtils')
+    const { downloadImage, convertToPng } = await import('../../utils/imageUtils.js')
 
     vi.mocked(fs.unlink).mockResolvedValueOnce()
     const result = await service.getCurrentImage(testHeaders as any)
@@ -590,7 +593,7 @@ describe('deviceDisplayService', () => {
         json: () => Promise.resolve({ filename: 'remote.png', image_url: 'http://example.com/image.jpg' }),
       })
 
-      const { downloadImage, convertToPng } = await import('../../utils/imageUtils')
+      const { downloadImage, convertToPng } = await import('../../utils/imageUtils.js')
 
       const result = await service.getCurrentImageWithoutProgressing(headers)
       expect(mockFetch).toHaveBeenCalledWith('https://usetrmnl.com/api/current_screen', {
@@ -655,7 +658,7 @@ describe('deviceDisplayService', () => {
       configService.get.mockReturnValue('http://api')
       fileExists.mockResolvedValue(false)
 
-      const { downloadImage, convertToPng } = await import('../../utils/imageUtils')
+      const { downloadImage, convertToPng } = await import('../../utils/imageUtils.js')
 
       const result = await service.getCurrentImageWithoutProgressing(headers)
       expect(downloadImage).toHaveBeenCalledWith('http://example.com/image.jpg', expect.any(String), expect.any(Object))
@@ -711,9 +714,9 @@ describe('deviceDisplayService', () => {
   describe('mashup screen rendering', () => {
     beforeEach(() => {
       // Inject services needed for mashup
-      service.pluginDataFetcher = { fetchData: vi.fn() } as any
-      service.pluginRenderer = { render: vi.fn() } as any
-      service.pluginTransformer = { transform: vi.fn() } as any
+      ;(service as any).pluginDataFetcher = { fetchData: vi.fn() } as any
+      ;(service as any).pluginRenderer = { render: vi.fn() } as any
+      ;(service as any).pluginTransformer = { transform: vi.fn() } as any
     })
 
     it('should detect mashup screen and call renderer', async () => {
@@ -759,7 +762,7 @@ describe('deviceDisplayService', () => {
       const mockMashupRenderer = {
         renderMashup: vi.fn().mockResolvedValue('<html>Mashup HTML</html>'),
       }
-      service.mashupRenderer = mockMashupRenderer
+      ;(service as any).mashupRenderer = mockMashupRenderer
 
       const result = await service.getCurrentImage({ ...headers, width: 800, height: 480 } as any)
 
@@ -822,7 +825,7 @@ describe('deviceDisplayService', () => {
       const mockMashupRenderer = {
         renderMashup: vi.fn().mockRejectedValue(new Error('Render failed')),
       }
-      service.mashupRenderer = mockMashupRenderer
+      ;(service as any).mashupRenderer = mockMashupRenderer
 
       const result = await service.getCurrentImage({ ...headers, width: 800, height: 480 } as any)
 

--- a/packages/api/src/devices/devices.service.ts
+++ b/packages/api/src/devices/devices.service.ts
@@ -37,7 +37,7 @@ export class DevicesService {
     return this.deviceRepository.save(newDevice)
   }
 
-  async update(id: string, changes: UpdateDeviceDto): Promise<Device> {
+  async update(id: string, changes: UpdateDeviceDto): Promise<Device | null> {
     const dbDevice = await this.deviceRepository.findOneBy({ id })
     if (!dbDevice)
       return null

--- a/packages/api/src/devices/display.service.ts
+++ b/packages/api/src/devices/display.service.ts
@@ -18,6 +18,7 @@ import { PluginTransformService } from '../plugins/services/plugin-transform.ser
 import { isScheduleEligible } from '../schedule/schedule-eligibility'
 import { Screen } from '../screens/screens.entity'
 import { fileExists } from '../utils/fileExists'
+import { getErrorMessage } from '../utils/getErrorMessage'
 import { convertToPng, downloadImage } from '../utils/imageUtils'
 import { parseHeaderInt } from '../utils/parseHeaderInt'
 import { resolveAppPath } from '../utils/pathHelper'
@@ -159,7 +160,7 @@ export class DeviceDisplayService {
       let refreshRate = device.refreshRate
       let filename = 'error.png'
       let localImageUrl = await this.fallbackImageUrl('error', device)
-      let firmwareUrl = null
+      let firmwareUrl: string | null = null
       let resetFirmware = false
       let mirrorSpecialFunction = specialFunction
       let mirrorAction = specialFunction
@@ -167,17 +168,18 @@ export class DeviceDisplayService {
       try {
         const { response, localImageUrl: localImage } = await this.fetchAndStoreMirrorImage(device, proxy ? headers : undefined)
 
-        refreshRate = proxy ? response.refresh_rate : refreshRate
-        firmwareUrl = proxy ? response.firmware_url : firmwareUrl
-        resetFirmware = proxy ? response.reset_firmware : resetFirmware
+        refreshRate = proxy ? (response.refresh_rate ?? refreshRate) : refreshRate
+        firmwareUrl = proxy ? (response.firmware_url ?? firmwareUrl) : firmwareUrl
+        resetFirmware = proxy ? (response.reset_firmware ?? resetFirmware) : resetFirmware
         mirrorSpecialFunction = proxy ? (response.special_function ?? 'none') : mirrorSpecialFunction
         mirrorAction = proxy ? (response.action ?? mirrorSpecialFunction) : mirrorAction
-        updateFirmware = proxy ? response.update_firmware : updateFirmware
+        updateFirmware = proxy ? (response.update_firmware ?? updateFirmware) : updateFirmware
         localImageUrl = localImage
         filename = response.filename
       }
       catch (err) {
-        this.logger.error(`Failed to process image: ${err.message}`)
+        const message = getErrorMessage(err)
+        this.logger.error(`Failed to process image: ${message}`)
       }
       this.logger.log(`Returning mirrored screen for device ${device.id}`)
       return new Display({
@@ -255,7 +257,11 @@ export class DeviceDisplayService {
       })
     }
     let imgUrl = await this.fallbackImageUrl('error', device)
+    let filename: string
+    let renderedAt: Date | undefined
     if (device.mirrorEnabled) {
+      filename = `mirror_${new Date().toISOString()}`
+      renderedAt = undefined
       this.logger.log(`Mirroring enabled for device ${device.id}, checking for image...`)
       if (await fileExists(resolveAppPath('public', 'screens', 'devices', device.id, 'mirror.png'))) {
         this.logger.log(`Image found returning`)
@@ -268,11 +274,14 @@ export class DeviceDisplayService {
           imgUrl = localImageUrl
         }
         catch (err) {
-          this.logger.error(`Failed to fetch mirror image on demand: ${err.message}`)
+          const message = getErrorMessage(err)
+          this.logger.error(`Failed to fetch mirror image on demand: ${message}`)
         }
       }
     }
     else {
+      if (!activeScreen)
+        throw new NotFoundException('No active screen found for device')
       this.logger.log(`Returning screen ${activeScreen.id} for device ${device.id}`)
       if (await fileExists(this.screenImagePath(device, activeScreen))) {
         imgUrl = this.screenImageUrl(device, activeScreen)
@@ -281,12 +290,14 @@ export class DeviceDisplayService {
         this.logger.log(`Screen image for ${activeScreen.id} missing on disk, generating on demand`)
         imgUrl = await this.generateScreenImage(activeScreen, device)
       }
+      filename = `${activeScreen.filename}_${activeScreen.generatedAt.toISOString()}`
+      renderedAt = activeScreen.generatedAt
     }
     return new DisplayScreen({
-      filename: device.mirrorEnabled ? `mirror_${new Date().toISOString()}` : `${activeScreen.filename}_${activeScreen.generatedAt.toISOString()}`,
+      filename,
       image_url: imgUrl,
       refresh_rate: device.refreshRate,
-      rendered_at: device.mirrorEnabled ? undefined : activeScreen.generatedAt,
+      rendered_at: renderedAt,
     })
   }
 
@@ -296,7 +307,7 @@ export class DeviceDisplayService {
       : { 'access-token': device.mirrorApikey, 'ID': device.mirrorMac }
     this.logger.debug(`Sending headers: ${JSON.stringify(mirrorHeaders)}`)
     const res = await fetch(`https://usetrmnl.com/api/${proxyHeaders ? 'display' : 'current_screen'}`, {
-      headers: mirrorHeaders,
+      headers: mirrorHeaders as Record<string, string>,
     })
     const response: TrmnlScreenResponse = await res.json()
     this.logger.debug(`Got this from TRMNL ${JSON.stringify(response)}`)
@@ -352,7 +363,8 @@ export class DeviceDisplayService {
         }
       }
       catch (err) {
-        this.logger.error(`Failed to render mashup: ${err.message}`)
+        const message = getErrorMessage(err)
+        this.logger.error(`Failed to render mashup: ${message}`)
         imgUrl = await this.fallbackImageUrl('error', device)
       }
     }
@@ -374,7 +386,8 @@ export class DeviceDisplayService {
             imgUrl = await this.renderBodyToScreenPng(viewFull(screenWithPlugin.cachedPluginOutput), screen, device)
           }
           catch (err) {
-            this.logger.error(`Failed to render cached plugin output: ${err.message}`)
+            const message = getErrorMessage(err)
+            this.logger.error(`Failed to render cached plugin output: ${message}`)
             imgUrl = await this.fallbackImageUrl('error', device)
           }
         }
@@ -386,7 +399,8 @@ export class DeviceDisplayService {
               imgUrl = await this.renderBodyToScreenPng(viewFull(renderedHtml), screen, device)
           }
           catch (err) {
-            this.logger.error(`Failed to render plugin: ${err.message}`)
+            const message = getErrorMessage(err)
+            this.logger.error(`Failed to render plugin: ${message}`)
             imgUrl = await this.fallbackImageUrl('error', device)
           }
         }
@@ -409,7 +423,8 @@ export class DeviceDisplayService {
         imgUrl = this.screenImageUrl(device, screen)
       }
       catch (err) {
-        this.logger.error(`Failed to process image: ${err.message}`)
+        const message = getErrorMessage(err)
+        this.logger.error(`Failed to process image: ${message}`)
         imgUrl = await this.fallbackImageUrl('error', device)
       }
       finally {

--- a/packages/api/src/devices/display.ts
+++ b/packages/api/src/devices/display.ts
@@ -1,7 +1,7 @@
 export class Display {
   action: string
   filename: string
-  firmware_url: string
+  firmware_url: string | null
   image_url: string
   refresh_rate: number
   reset_firmware: boolean

--- a/packages/api/src/devices/displayScreen.ts
+++ b/packages/api/src/devices/displayScreen.ts
@@ -2,7 +2,7 @@ export class DisplayScreen {
   filename: string
   image_url: string
   refresh_rate: number
-  rendered_at: Date
+  rendered_at?: Date
 
   constructor(display: DisplayScreen) {
     Object.assign(this, display)

--- a/packages/api/src/devices/dto/__test__/update-device.dto.spec.ts
+++ b/packages/api/src/devices/dto/__test__/update-device.dto.spec.ts
@@ -14,14 +14,10 @@ describe('update-device dto', () => {
     dto.batteryVoltage = '3.7V'
     dto.fwVersion = '1.0.0'
     dto.rssi = '-60'
-    dto.width = 800
-    dto.height = 480
 
     expect(dto.batteryVoltage).toBe('3.7V')
     expect(dto.fwVersion).toBe('1.0.0')
     expect(dto.rssi).toBe('-60')
-    expect(dto.width).toBe(800)
-    expect(dto.height).toBe(480)
   })
 
   it('includes mirror configuration fields', () => {

--- a/packages/api/src/devices/dto/update-device.dto.ts
+++ b/packages/api/src/devices/dto/update-device.dto.ts
@@ -3,7 +3,7 @@ import { IsBoolean, IsIn, IsNumber, IsOptional, IsString } from 'class-validator
 export class UpdateDeviceDto {
   @IsOptional()
   @IsString()
-  name: string
+  name?: string
 
   @IsOptional()
   @IsString()
@@ -60,15 +60,15 @@ export class UpdateDeviceDto {
   @IsOptional()
   @IsString()
   @IsIn(['none', 'identify', 'sleep', 'add_wifi', 'restart_playlist', 'rewind', 'send_to_me'])
-  specialFunction: string
+  specialFunction?: string
 
   @IsOptional()
   @IsBoolean()
-  resetDevice: boolean
+  resetDevice?: boolean
 
   @IsOptional()
   @IsBoolean()
-  updateFirmware: boolean
+  updateFirmware?: boolean
 
   @IsOptional()
   @IsString()

--- a/packages/api/src/firmware/firmware.controller.ts
+++ b/packages/api/src/firmware/firmware.controller.ts
@@ -1,5 +1,6 @@
 import { BadRequestException, Body, Controller, Delete, Get, Logger, Param, Post, ServiceUnavailableException, UploadedFile, UseInterceptors } from '@nestjs/common'
 import { FileInterceptor } from '@nestjs/platform-express'
+import { getErrorMessage } from '../utils/getErrorMessage'
 import { Firmware } from './entities/firmware.entity'
 import { FirmwareSyncResult, FirmwareSyncService } from './firmware-sync.service'
 import { FirmwareService, MAX_FIRMWARE_UPLOAD_BYTES } from './firmware.service'
@@ -24,7 +25,7 @@ export class FirmwareController {
       return await this.syncService.sync()
     }
     catch (err) {
-      const message = err instanceof Error ? err.message : String(err)
+      const message = getErrorMessage(err)
       this.logger.error(`Firmware sync failed: ${message}`)
       throw new ServiceUnavailableException(`Could not sync firmware from TRMNL: ${message}`)
     }

--- a/packages/api/src/firmware/firmware.service.ts
+++ b/packages/api/src/firmware/firmware.service.ts
@@ -15,7 +15,7 @@ import { firmwareFilePath, firmwareFileUrl } from './firmware-paths'
 export const MAX_FIRMWARE_UPLOAD_BYTES = 8 * 1024 * 1024
 
 export interface UploadFirmwareInput {
-  version: string
+  version?: string
   label?: string
   compatibleModels?: string[]
 }
@@ -103,6 +103,6 @@ export class FirmwareService {
   }
 
   fileUrl(id: string): string {
-    return firmwareFileUrl(id, this.configService.get<string>('api_url'))
+    return firmwareFileUrl(id, this.configService.get<string>('api_url', 'http://localhost:5173'))
   }
 }

--- a/packages/api/src/logs/__test__/logs.service.spec.ts
+++ b/packages/api/src/logs/__test__/logs.service.spec.ts
@@ -41,7 +41,7 @@ describe('logsService', () => {
 
   it('addLogToDevice is not saving duplicate log entries', async () => {
     const dto: CreateLogDto = { log: { logs_array: [{ log_id: 1 }, { log_id: 2 }] } }
-    const device = { id: 'dev', screens: [], width: 100, height: 100, logs: [{ logId: 1 }, { logId: 2 }] } as Device
+    const device = { id: 'dev', screens: [], width: 100, height: 100, logs: [{ logId: 1 }, { logId: 2 }] } as unknown as Device
     devicesRepo.findOne.mockResolvedValue(device)
     await service.addLogToDevice(deviceMac, dto)
     expect(logsRepo.save).not.toHaveBeenCalled()
@@ -49,7 +49,7 @@ describe('logsService', () => {
 
   it('addLogToDevice saves new log entries', async () => {
     const dto: CreateLogDto = { log: { logs_array: [{ log_id: 1 }, { log_id: 2 }, { log_id: 3 }] } }
-    const device = { id: 'dev', screens: [], width: 100, height: 100, logs: [{ logId: 1 }, { logId: 2 }] } as Device
+    const device = { id: 'dev', screens: [], width: 100, height: 100, logs: [{ logId: 1 }, { logId: 2 }] } as unknown as Device
     devicesRepo.findOne.mockResolvedValue(device)
     await service.addLogToDevice(deviceMac, dto)
     expect(logsRepo.save).toHaveBeenCalledOnce()

--- a/packages/api/src/maintenance/maintenance.service.ts
+++ b/packages/api/src/maintenance/maintenance.service.ts
@@ -5,6 +5,7 @@ import { InjectRepository } from '@nestjs/typeorm'
 import { Repository } from 'typeorm'
 import { Device } from '../devices/devices.entity'
 import { Screen } from '../screens/screens.entity'
+import { getErrorMessage } from '../utils/getErrorMessage'
 import { resolveAppPath } from '../utils/pathHelper'
 
 export interface OrphanedScreenFile {
@@ -243,7 +244,8 @@ export class MaintenanceService {
         result.bytesFreed += stat.size
       }
       catch (err) {
-        result.errors.push(`Failed to delete ${filePath}: ${err.message}`)
+        const message = getErrorMessage(err)
+        result.errors.push(`Failed to delete ${filePath}: ${message}`)
       }
     }
 
@@ -263,7 +265,8 @@ export class MaintenanceService {
         result.bytesFreed += stat.size
       }
       catch (err) {
-        result.errors.push(`Failed to delete ${filePath}: ${err.message}`)
+        const message = getErrorMessage(err)
+        result.errors.push(`Failed to delete ${filePath}: ${message}`)
       }
     }
 
@@ -283,7 +286,8 @@ export class MaintenanceService {
         result.bytesFreed += size
       }
       catch (err) {
-        result.errors.push(`Failed to delete ${dirPath}: ${err.message}`)
+        const message = getErrorMessage(err)
+        result.errors.push(`Failed to delete ${dirPath}: ${message}`)
       }
     }
 
@@ -296,7 +300,8 @@ export class MaintenanceService {
         result.screensDeleted++
       }
       catch (err) {
-        result.errors.push(`Failed to delete screen ${screenId}: ${err.message}`)
+        const message = getErrorMessage(err)
+        result.errors.push(`Failed to delete screen ${screenId}: ${message}`)
       }
     }
 

--- a/packages/api/src/mashup/__test__/mashup.integration.spec.ts
+++ b/packages/api/src/mashup/__test__/mashup.integration.spec.ts
@@ -38,14 +38,14 @@ describe('mashup Integration Tests', () => {
         name: 'Weather Plugin',
         template: {
           html: '<div class="plugin-weather">{{weather}}</div>',
-        } as PluginTemplate,
+        } as unknown as PluginTemplate,
       },
       {
         id: 'plugin-2',
         name: 'Calendar Plugin',
         template: {
           html: '<div class="plugin-calendar">{{events}}</div>',
-        } as PluginTemplate,
+        } as unknown as PluginTemplate,
       },
     ]
 
@@ -256,7 +256,7 @@ describe('mashup Integration Tests', () => {
             name: 'Weather Plugin',
             dataSource: { type: 'static', config: {} },
             templates: [{ html: '<div>test</div>' }],
-          } as Plugin,
+          } as unknown as Plugin,
         },
         {
           id: 'slot-2',
@@ -268,7 +268,7 @@ describe('mashup Integration Tests', () => {
             name: 'Calendar Plugin',
             dataSource: { type: 'static', config: {} },
             templates: [{ html: '<div>test</div>' }],
-          } as Plugin,
+          } as unknown as Plugin,
         },
       ],
     } as MashupConfiguration

--- a/packages/api/src/mashup/__test__/mashup.service.spec.ts
+++ b/packages/api/src/mashup/__test__/mashup.service.spec.ts
@@ -75,7 +75,7 @@ describe('mashupService', () => {
       screenRepo.save.mockResolvedValue(screen)
       screenRepo.update.mockResolvedValue(undefined)
 
-      const config = { id: 'config-1', screen, layout: dto.layout, slots: [] } as MashupConfiguration
+      const config = { id: 'config-1', screen, layout: dto.layout, slots: [] } as unknown as MashupConfiguration
       mashupConfigRepo.create.mockReturnValue(config)
       mashupConfigRepo.save.mockResolvedValue(config)
 

--- a/packages/api/src/mashup/mashup.service.ts
+++ b/packages/api/src/mashup/mashup.service.ts
@@ -197,7 +197,10 @@ export class MashupService {
     }
 
     this.logger.log(`Mashup updated: ${screenId}`)
-    return this.screenRepository.findOne({ where: { id: screenId } })
+    const updated = await this.screenRepository.findOne({ where: { id: screenId } })
+    if (!updated)
+      throw new NotFoundException('Mashup screen not found')
+    return updated
   }
 
   async delete(screenId: string): Promise<void> {

--- a/packages/api/src/mashup/services/mashup-renderer.service.ts
+++ b/packages/api/src/mashup/services/mashup-renderer.service.ts
@@ -6,6 +6,7 @@ import { ConfigService } from '@nestjs/config'
 import { PluginDataFetcherService } from '../../plugins/services/plugin-data-fetcher.service'
 import { PluginRendererService } from '../../plugins/services/plugin-renderer.service'
 import { PluginTransformService } from '../../plugins/services/plugin-transform.service'
+import { getErrorMessage } from '../../utils/getErrorMessage'
 
 @Injectable()
 export class MashupRendererService {
@@ -30,7 +31,8 @@ export class MashupRendererService {
         slotHtmls.push({ slot, html })
       }
       catch (err) {
-        this.logger.error(`Failed to render plugin ${slot.plugin.id} in slot ${slot.id}: ${err.message}`)
+        const message = getErrorMessage(err)
+        this.logger.error(`Failed to render plugin ${slot.plugin.id} in slot ${slot.id}: ${message}`)
         const errorHtml = this.errorPlaceholder(slot.plugin.name)
         slotHtmls.push({ slot, html: errorHtml })
       }

--- a/packages/api/src/plugins/__test__/plugin-exporter.service.spec.ts
+++ b/packages/api/src/plugins/__test__/plugin-exporter.service.spec.ts
@@ -76,7 +76,7 @@ describe('pluginExporterService', () => {
 
     const buffer = await service.exportToZip(plugin)
     const zip = new AdmZip(buffer)
-    const manifestEntry = zip.getEntry('.trmnlp.yml')
+    const manifestEntry = zip.getEntry('.trmnlp.yml')!
     const manifestContent = manifestEntry.getData().toString('utf8')
     const manifest = yaml.load(manifestContent) as any
 
@@ -106,7 +106,7 @@ describe('pluginExporterService', () => {
 
     const buffer = await service.exportToZip(plugin)
     const zip = new AdmZip(buffer)
-    const settingsEntry = zip.getEntry('src/settings.yml')
+    const settingsEntry = zip.getEntry('src/settings.yml')!
     const settingsContent = settingsEntry.getData().toString('utf8')
     const settings = yaml.load(settingsContent) as any
 
@@ -133,7 +133,7 @@ describe('pluginExporterService', () => {
 
     const buffer = await service.exportToZip(plugin)
     const zip = new AdmZip(buffer)
-    const settings = yaml.load(zip.getEntry('src/settings.yml').getData().toString('utf8')) as any
+    const settings = yaml.load(zip.getEntry('src/settings.yml')!.getData().toString('utf8')) as any
 
     expect(settings.data_sources).toHaveLength(2)
     expect(settings.data_sources[0].name).toBe('weather')
@@ -168,7 +168,7 @@ describe('pluginExporterService', () => {
     expect(zip.getEntry('src/half_horizontal.liquid')).toBeTruthy()
     expect(zip.getEntry('src/quadrant.liquid')).toBeTruthy()
 
-    const fullContent = zip.getEntry('src/full.liquid').getData().toString('utf8')
+    const fullContent = zip.getEntry('src/full.liquid')!.getData().toString('utf8')
     expect(fullContent).toBe('Full layout')
   })
 
@@ -241,7 +241,7 @@ describe('pluginExporterService', () => {
 
     const buffer = await service.exportToZip(plugin)
     const zip = new AdmZip(buffer)
-    const manifestEntry = zip.getEntry('.trmnlp.yml')
+    const manifestEntry = zip.getEntry('.trmnlp.yml')!
     const manifest = yaml.load(manifestEntry.getData().toString('utf8')) as any
 
     expect(manifest.description).toBe('')

--- a/packages/api/src/plugins/__test__/plugin-importer.service.spec.ts
+++ b/packages/api/src/plugins/__test__/plugin-importer.service.spec.ts
@@ -232,8 +232,8 @@ describe('pluginImporterService', () => {
       expect(result.refreshInterval).toBe(45)
       expect(result.dataSources[0].url).toBe('https://terminus.com/api')
       expect(result.dataSources[0].method).toBe('POST')
-      expect(result.dataSources[0].headers['X-API-Key']).toBe('key')
-      expect(result.dataSources[0].body.query).toBe('data')
+      expect(result.dataSources[0].headers!['X-API-Key']).toBe('key')
+      expect(result.dataSources[0].body!.query).toBe('data')
 
       fs.unlinkSync(tmpPath)
     })

--- a/packages/api/src/plugins/__test__/plugin-render-cache.service.spec.ts
+++ b/packages/api/src/plugins/__test__/plugin-render-cache.service.spec.ts
@@ -53,7 +53,7 @@ describe('pluginRenderCacheService', () => {
       { id: 'slot-1', mashupConfiguration: { screen: { id: 'screen-1' } } },
       { id: 'slot-2', mashupConfiguration: { screen: { id: 'screen-2' } } },
     ])
-    service.mashupSlotRepository = mockMashupSlotRepo
+    ;(service as any).mashupSlotRepository = mockMashupSlotRepo
 
     await service.invalidateMashupCaches('plugin-1')
 
@@ -72,7 +72,7 @@ describe('pluginRenderCacheService', () => {
   })
 
   it('does not fail if mashupSlotRepository not available', async () => {
-    service.mashupSlotRepository = null
+    ;(service as any).mashupSlotRepository = null
 
     await expect(service.invalidateMashupCaches('plugin-1')).resolves.toBeUndefined()
     expect(mockScreenRepo.update).not.toHaveBeenCalled()

--- a/packages/api/src/plugins/__test__/plugin-scheduler.service.spec.ts
+++ b/packages/api/src/plugins/__test__/plugin-scheduler.service.spec.ts
@@ -80,10 +80,10 @@ describe('pluginSchedulerService', () => {
   })
 
   it('converts refresh interval to cron expression', () => {
-    expect(service.getCronExpression(1)).toBe('*/1 * * * *')
-    expect(service.getCronExpression(15)).toBe('*/15 * * * *')
-    expect(service.getCronExpression(30)).toBe('*/30 * * * *')
-    expect(service.getCronExpression(60)).toBe('0 * * * *')
+    expect((service as any).getCronExpression(1)).toBe('*/1 * * * *')
+    expect((service as any).getCronExpression(15)).toBe('*/15 * * * *')
+    expect((service as any).getCronExpression(30)).toBe('*/30 * * * *')
+    expect((service as any).getCronExpression(60)).toBe('0 * * * *')
   })
 
   it('schedules multiple plugins independently', () => {

--- a/packages/api/src/plugins/__test__/plugin-variable.entity.spec.ts
+++ b/packages/api/src/plugins/__test__/plugin-variable.entity.spec.ts
@@ -13,17 +13,15 @@ describe('plugin-variable entity', () => {
     expect(variable.value).toBe('secret-123')
   })
 
-  it('has relationship to device plugin', () => {
+  it('has relationship to plugin', () => {
     const variable = new PluginVariable()
-    expect(variable.devicePlugin).toBeUndefined()
+    expect(variable.plugin).toBeUndefined()
   })
 
-  it('has timestamps', () => {
+  it('has an isSecret flag', () => {
     const variable = new PluginVariable()
-    variable.createdAt = new Date('2026-01-01')
-    variable.updatedAt = new Date('2026-01-02')
+    variable.isSecret = true
 
-    expect(variable.createdAt).toEqual(new Date('2026-01-01'))
-    expect(variable.updatedAt).toEqual(new Date('2026-01-02'))
+    expect(variable.isSecret).toBe(true)
   })
 })

--- a/packages/api/src/plugins/__test__/plugins.controller.spec.ts
+++ b/packages/api/src/plugins/__test__/plugins.controller.spec.ts
@@ -82,7 +82,7 @@ describe('pluginsController', () => {
   })
 
   it('create creates a new plugin', async () => {
-    const createDto = { name: 'Weather Plugin', deviceId: 'device-1' }
+    const createDto = { name: 'Weather Plugin', deviceId: 'device-1', kind: 'Poll' as const }
     ;(mockService.create as any).mockResolvedValue(basePlugin)
 
     const result = await controller.create(createDto)

--- a/packages/api/src/plugins/__test__/plugins.service.spec.ts
+++ b/packages/api/src/plugins/__test__/plugins.service.spec.ts
@@ -16,7 +16,8 @@ interface MockRepository {
   save: ReturnType<typeof vi.fn>
   remove: ReturnType<typeof vi.fn>
   update: ReturnType<typeof vi.fn>
-  maximum?: ReturnType<typeof vi.fn>
+  maximum: ReturnType<typeof vi.fn>
+  delete?: ReturnType<typeof vi.fn>
 }
 
 function createMockRepository(): MockRepository {

--- a/packages/api/src/plugins/dto/__test__/assign-to-device.dto.spec.ts
+++ b/packages/api/src/plugins/dto/__test__/assign-to-device.dto.spec.ts
@@ -13,14 +13,11 @@ describe('assign-plugin-to-device dto', () => {
     expect(dto.order).toBe(1)
   })
 
-  it('includes field values', () => {
+  it('allows optional order', () => {
     const dto = new AssignPluginToDeviceDto()
-    dto.fieldValues = [
-      { fieldId: 'field-1', value: 'test-value' },
-    ]
+    dto.deviceId = 'device-123'
 
-    expect(dto.fieldValues).toHaveLength(1)
-    expect(dto.fieldValues?.[0].fieldId).toBe('field-1')
+    expect(dto.order).toBeUndefined()
   })
 
   it('allows optional isActive', () => {

--- a/packages/api/src/plugins/plugins.service.ts
+++ b/packages/api/src/plugins/plugins.service.ts
@@ -248,7 +248,10 @@ export class PluginsService implements OnModuleInit {
       relations: { dataSources: true, templates: true, fields: true },
     })
 
-    if (created && created.dataSources && created.dataSources.length > 0 && created.templates && created.templates.length > 0) {
+    if (!created)
+      throw new Error(`Failed to load newly created plugin: ${savedPlugin.id}`)
+
+    if (created.dataSources && created.dataSources.length > 0 && created.templates && created.templates.length > 0) {
       this.scheduler.schedulePlugin(created)
       this.logger.log(`Scheduled new plugin: ${created.name}`)
     }
@@ -447,7 +450,7 @@ export class PluginsService implements OnModuleInit {
     return {
       inMashups: mashupsWithPlugin.map(slot => ({
         screenId: slot.mashupConfiguration.screen.id,
-        screenName: slot.mashupConfiguration.screen.filename,
+        screenName: slot.mashupConfiguration.screen.filename ?? 'Untitled Screen',
       })),
     }
   }

--- a/packages/api/src/plugins/services/plugin-importer.service.ts
+++ b/packages/api/src/plugins/services/plugin-importer.service.ts
@@ -250,7 +250,7 @@ export class PluginImporterService {
       }
     })
 
-    return this.buildParsedPlugin(manifest, settings, templates, fallbackName, transformJs)
+    return this.buildParsedPlugin(manifest, settings, templates, fallbackName, transformJs ?? undefined)
   }
 
   private async importFromYaml(yamlPath: string, fallbackName: string): Promise<ParsedPlugin> {
@@ -303,7 +303,7 @@ export class PluginImporterService {
       }
     }
 
-    return this.buildParsedPlugin(manifest, settings, templates, fallbackName, transformJs)
+    return this.buildParsedPlugin(manifest, settings, templates, fallbackName, transformJs ?? undefined)
   }
 
   private buildParsedPlugin(

--- a/packages/api/src/plugins/services/plugin-render-cache.service.ts
+++ b/packages/api/src/plugins/services/plugin-render-cache.service.ts
@@ -4,6 +4,7 @@ import { Injectable, Logger } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
 import { Repository } from 'typeorm'
 import { Screen } from '../../screens/screens.entity'
+import { getErrorMessage } from '../../utils/getErrorMessage'
 import { PluginRendererService } from './plugin-renderer.service'
 
 @Injectable()
@@ -68,7 +69,8 @@ export class PluginRenderCacheService {
       }
     }
     catch (error) {
-      this.logger.error(`Failed to invalidate mashup caches for plugin ${pluginId}: ${error.message}`)
+      const message = getErrorMessage(error)
+      this.logger.error(`Failed to invalidate mashup caches for plugin ${pluginId}: ${message}`)
     }
   }
 }

--- a/packages/api/src/plugins/services/plugin-transform.service.ts
+++ b/packages/api/src/plugins/services/plugin-transform.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common'
 import { VM } from 'vm2'
+import { getErrorMessage } from '../../utils/getErrorMessage'
 
 @Injectable()
 export class PluginTransformService {
@@ -46,7 +47,8 @@ export class PluginTransformService {
       return result
     }
     catch (error) {
-      this.logger.error(`Transform execution failed: ${error.message}`)
+      const message = getErrorMessage(error)
+      this.logger.error(`Transform execution failed: ${message}`)
       this.logger.warn('Returning raw data without transformation')
       return rawData
     }

--- a/packages/api/src/screens/__test__/screens.service.spec.ts
+++ b/packages/api/src/screens/__test__/screens.service.spec.ts
@@ -77,7 +77,7 @@ describe('screensService', () => {
   })
 
   it('add creates a screen with file', async () => {
-    const device = { id: 'dev', screens: [], width: 100, height: 100 } as Device
+    const device = { id: 'dev', screens: [], width: 100, height: 100 } as unknown as Device
     devicesRepo.findOne.mockResolvedValue(device)
     const screen = { id: '1', filename: 'file', device, order: 1, isActive: false } as Screen
     screensRepo.create.mockReturnValue(screen)
@@ -95,7 +95,7 @@ describe('screensService', () => {
   })
 
   it('add creates a screen with html', async () => {
-    const device = { id: 'dev', screens: [], width: 100, height: 100 } as Device
+    const device = { id: 'dev', screens: [], width: 100, height: 100 } as unknown as Device
     devicesRepo.findOne.mockResolvedValue(device)
     const screen = { id: '1', html: '<div>hi</div>', device, order: 1, isActive: false } as Screen
     screensRepo.create.mockReturnValue(screen)
@@ -107,7 +107,7 @@ describe('screensService', () => {
   })
 
   it('add creates a screen with externalLink and fetchManual', async () => {
-    const device = { id: 'dev', screens: [], width: 100, height: 100 } as Device
+    const device = { id: 'dev', screens: [], width: 100, height: 100 } as unknown as Device
     devicesRepo.findOne.mockResolvedValue(device)
     const screen = { id: '1', filename: 'file', device, order: 1, isActive: false } as Screen
     screensRepo.create.mockReturnValue(screen)
@@ -152,7 +152,7 @@ describe('screensService', () => {
     const screen = { id: '1', device, externalLink: 'url', fetchManual: true } as Screen
     screensRepo.findOne.mockResolvedValue(screen)
     await expect(service.updateExternalScreen('1')).resolves.toBeUndefined()
-    const { downloadImage, convertToPng } = await import('../../utils/imageUtils')
+    const { downloadImage, convertToPng } = await import('../../utils/imageUtils.js')
     expect(downloadImage).toHaveBeenCalledWith('url', expect.stringContaining('public/screens/devices/dev/1.original'), expect.any(Object))
     expect(convertToPng).toHaveBeenCalledWith(expect.stringContaining('1.original'), expect.stringContaining('1.png'), expect.anything(), expect.any(Object))
   })
@@ -171,7 +171,7 @@ describe('screensService', () => {
       ])
       fileExistsMock.mockImplementation(async (p: string) => !p.endsWith('legacy.original'))
       const renameMock = vi.spyOn(fs.promises, 'rename').mockResolvedValue(undefined)
-      const { convertToPng } = await import('../../utils/imageUtils')
+      const { convertToPng } = await import('../../utils/imageUtils.js')
 
       await expect(service.reconvertImageScreens(device)).resolves.toBe(3)
 
@@ -188,7 +188,7 @@ describe('screensService', () => {
       screensRepo.find.mockResolvedValue([{ id: 'a', type: 'file' }, { id: 'b', type: 'file' }])
       fileExistsMock.mockResolvedValue(true)
       vi.spyOn(fs.promises, 'rename').mockResolvedValue(undefined)
-      const { convertToPng } = await import('../../utils/imageUtils')
+      const { convertToPng } = await import('../../utils/imageUtils.js')
       vi.mocked(convertToPng).mockRejectedValueOnce(new Error('boom')).mockResolvedValueOnce(undefined)
 
       await expect(service.reconvertImageScreens(device)).resolves.toBe(1)

--- a/packages/api/src/screens/dto/create-screen.dto.ts
+++ b/packages/api/src/screens/dto/create-screen.dto.ts
@@ -13,9 +13,9 @@ export class CreateScreenDto {
 
   @IsOptional()
   @IsBoolean()
-  fetchManual: boolean
+  fetchManual?: boolean
 
   @IsOptional()
   @IsString()
-  html: string
+  html?: string
 }

--- a/packages/api/src/screens/screens.service.ts
+++ b/packages/api/src/screens/screens.service.ts
@@ -7,6 +7,7 @@ import { EntityManager, Repository } from 'typeorm'
 import { DeviceModelsService } from '../device-models/device-models.service'
 import { Device } from '../devices/devices.entity'
 import { fileExists } from '../utils/fileExists'
+import { getErrorMessage } from '../utils/getErrorMessage'
 import { convertToPng, downloadImage } from '../utils/imageUtils'
 import { resolveAppPath } from '../utils/pathHelper'
 import { assertPublicUrl } from '../utils/ssrfGuard'
@@ -69,7 +70,8 @@ export class ScreensService {
         this.logger.log('Download and conversion successful')
       }
       catch (err) {
-        this.logger.error(`Failed to process image: ${err.message}. Removing screen again.`)
+        const message = getErrorMessage(err)
+        this.logger.error(`Failed to process image: ${message}. Removing screen again.`)
         await this.screensRepository.remove(saved)
         throw new InternalServerErrorException('Error processing image')
       }
@@ -200,7 +202,8 @@ export class ScreensService {
       this.logger.log('Download and conversion successful')
     }
     catch (err) {
-      this.logger.error(`Failed to process image: ${err.message}. Removing screen again.`)
+      const message = getErrorMessage(err)
+      this.logger.error(`Failed to process image: ${message}. Removing screen again.`)
       throw new InternalServerErrorException('Error processing image')
     }
   }
@@ -230,7 +233,8 @@ export class ScreensService {
         converted++
       }
       catch (err) {
-        this.logger.error(`Failed to reconvert screen ${screen.id}: ${err.message}`)
+        const message = getErrorMessage(err)
+        this.logger.error(`Failed to reconvert screen ${screen.id}: ${message}`)
         await fs.promises.unlink(tempPath).catch(() => {})
       }
     }
@@ -252,10 +256,11 @@ export class ScreensService {
       this.logger.log(`Deleted file: ${filePath}`)
     }
     catch (err) {
-      if (err.code === 'ENOENT')
+      const errno = err as NodeJS.ErrnoException
+      if (errno.code === 'ENOENT')
         this.logger.warn(`File not found for deletion: ${filePath}`)
       else
-        this.logger.error(`Failed to delete file: ${filePath} - ${err.message}`)
+        this.logger.error(`Failed to delete file: ${filePath} - ${errno.message}`)
     }
   }
 }

--- a/packages/api/src/utils/__test__/imageUtils.geometry.integration.spec.ts
+++ b/packages/api/src/utils/__test__/imageUtils.geometry.integration.spec.ts
@@ -22,7 +22,7 @@ const snapshotGeometries = Array.from(
   new Map(
     TRMNL_MODELS_SNAPSHOT.map(m => [
       `${m.width}x${m.height}@${m.rotation}+${m.offset_x}+${m.offset_y}`,
-      { name: m.name, width: m.width, height: m.height, rotation: m.rotation, offsetX: m.offset_x, offsetY: m.offset_y },
+      { name: m.name, width: m.width, height: m.height, rotation: m.rotation, offsetX: m.offset_x, offsetY: m.offset_y } as any,
     ]),
   ).values(),
 )

--- a/packages/api/src/utils/generateApikey.ts
+++ b/packages/api/src/utils/generateApikey.ts
@@ -9,7 +9,7 @@ export default function () {
   const byteArray = new Uint8Array(hexPairs.map(hex => Number.parseInt(hex, 16)))
 
   // Convert to Base64
-  const base64 = btoa(String.fromCharCode.apply(null, byteArray))
+  const base64 = btoa(String.fromCharCode.apply(null, Array.from(byteArray)))
 
   // Make URL-safe by replacing + with - and / with _
   const urlSafe = base64.replace(/\+/g, '-').replace(/\//g, '_')

--- a/packages/api/src/utils/generateFriendlyName.ts
+++ b/packages/api/src/utils/generateFriendlyName.ts
@@ -9,7 +9,7 @@ export default function () {
   const byteArray = new Uint8Array(hexPairs.map(hex => Number.parseInt(hex, 16)))
 
   // Convert to Base64
-  const base64 = btoa(String.fromCharCode.apply(null, byteArray))
+  const base64 = btoa(String.fromCharCode.apply(null, Array.from(byteArray)))
 
   // Make URL-safe by replacing + with - and / with _
   const urlSafe = base64.replace(/\+/g, '-').replace(/\//g, '_')

--- a/packages/api/src/utils/getErrorMessage.ts
+++ b/packages/api/src/utils/getErrorMessage.ts
@@ -1,0 +1,3 @@
+export function getErrorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -14,5 +14,9 @@
     "sourceMap": true,
     "skipLibCheck": true
   },
-  "exclude": ["node_modules", "../../node_modules", "dist"]
+  // screen-shell.spec.ts imports a fixture from the repo-root test/fixtures/
+  // directory (shared with packages/ui) that lies outside this package's
+  // rootDir. With `outDir` set, tsc requires a single rootDir containing every
+  // compiled file, so it's excluded from tsc here; vitest still runs it fine.
+  "exclude": ["node_modules", "../../node_modules", "dist", "src/device-models/__test__/screen-shell.spec.ts"]
 }


### PR DESCRIPTION
## Summary
- `pnpm run -r type-check` silently skipped `packages/api` because it had no `type-check` script, so CI never actually ran `tsc` over the API package — 112 real `tsc --noEmit` errors had accumulated invisibly, and `nest start --watch` never booted (stuck at "Found 112 errors").
- Adds `"type-check": "tsc --noEmit -p tsconfig.json"` to `packages/api/package.json` and fixes every error it surfaces (untyped `catch` bindings, null/undefined narrowing, stale specs that no longer matched their DTOs/entities, a CommonJS/ESM `puppeteer` import, and a couple of DTO fields decorated `@IsOptional()` but typed as required).
- Along the way, fixes a real bug in `generateApikey`/`generateFriendlyName` (passing a `Uint8Array` where `String.fromCharCode.apply` needs a plain array) and extracts the now-common `err instanceof Error ? err.message : String(err)` idiom into a shared `getErrorMessage()` util used across 9 files.

## Test plan
- [x] `pnpm run type-check` (root, both `packages/api` and `packages/ui`) passes clean
- [x] `pnpm run lint` passes clean
- [x] `pnpm run test` — all 666 tests pass
- [x] Verified `nest start --watch` now reports "Found 0 errors" and boots the Nest app (only fails afterward on a missing local Postgres, unrelated)
- [x] Verified `packages/api`'s migrations build (`tsc -p tsconfig.migrations.json`) still produces the same `dist/` output shape

https://claude.ai/code/session_01SDj1spCoLHyhq2TCwdTpMS
