### PR TITLE
feat(devices): ingest Qwiic sensor readings into Plugin templates

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -87,3 +87,7 @@ _Avoid_: Update, OTA package, release, firmware version (bare — reserve for th
 **Firmware Kind**:
 Where a Firmware came from — `official-synced` (Kuroshiro's daily sync job) or `custom` (an admin's direct upload).
 _Avoid_: Firmware type, firmware source
+
+**Sensor**:
+A Device's current reading for one Qwiic sensor add-on kind — `carbon_dioxide`, `humidity`, `pressure`, or `temperature` — parsed from the `SENSORS` header official OG firmware sends on every `/display` poll. At most one Sensor per Device per kind: each poll's header is the authoritative full snapshot, so a kind missing from a poll is deleted rather than left stale, and a kind present is upserted with its `value`/`unit`. Exposed to Plugin Liquid templates as an implicit `sensors` object keyed by kind (e.g. `sensors.temperature.value`), present only when the Device currently has that reading — no Plugin opt-in required. Device-attached only; a physically separate concept from server-attached (Raspberry Pi) sensors, which Kuroshiro does not support.
+_Avoid_: Telemetry (too broad), Extension, Exchange (Terminus's terms — not adopted here)

--- a/docs/adr/0018-device-sensor-latest-value-snapshot-per-poll.md
+++ b/docs/adr/0018-device-sensor-latest-value-snapshot-per-poll.md
@@ -1,0 +1,15 @@
+# Device sensor readings are a latest-value snapshot, one row per kind
+
+TRMNL OG firmware reports Qwiic sensor add-on data on every `/display` poll via a `SENSORS` header — a comma-delimited list of `make=...;model=...;kind=...;value=...;unit=...;created_at=...` records, one per attached sensor. Kuroshiro parses this into a new `DeviceSensor` entity: at most one row per `(Device, kind)`, `kind` one of `carbon_dioxide`/`humidity`/`pressure`/`temperature`, holding just `value` and `unit`.
+
+Each poll's header is treated as the complete, authoritative snapshot of what's currently attached — not a delta. On every poll, any `DeviceSensor` row whose kind is absent from that poll's header is deleted, and every kind present is upserted with its latest `value`/`unit`. This means a sensor physically unplugged from its Qwiic bus disappears from Kuroshiro on the very next poll, rather than leaving a stale reading behind indefinitely — no separate staleness window or expiry job is needed.
+
+The header's `make`/`model` (sensor hardware identity, e.g. `Sensirion`/`SCD41`) and per-reading `created_at` are read but not persisted. `model` here would collide with Kuroshiro's existing "Device Model" concept (the TRMNL panel's own hardware class) if stored under that name, and neither field is needed: hardware identity isn't used by any decision or template, and `created_at` freshness is already implied by the snapshot-clearing behaviour above.
+
+Sensor values are exposed to Plugin Liquid templates as an implicit `sensors` object, keyed by kind (e.g. `sensors.temperature.value`, `sensors.temperature.unit`), present whenever the Device has current readings and absent otherwise — no Plugin opt-in or declaration required. `unit` is kept as its own field rather than folded into a formatted string, since it's device-reported and not a constant Kuroshiro controls.
+
+## Consequences
+
+- No time-series/history table exists for sensor readings — only ever "what does this Device currently report." A future trends feature would need new storage, not an extension of `DeviceSensor`.
+- Template authors must guard for absence (`{% if sensors.temperature %}`) since any kind can vanish between polls.
+- Hardware identity (`make`/`model`) is additive to bring back later — it wasn't discarded because it's wrong, just because nothing needs it yet.

--- a/docs/adr/0019-sensor-ingestion-v1-scope-cuts.md
+++ b/docs/adr/0019-sensor-ingestion-v1-scope-cuts.md
@@ -1,0 +1,13 @@
+# Sensor ingestion v1 scope cuts
+
+Grilling issue #782 deliberately cut the following from v1:
+
+- **Device-attached only, no server-attached sensors.** Terminus also supports sensors wired to a self-hosted Raspberry Pi, synced independently on their own schedule. That needs a new sync job, a pairing story, and a `source` concept Kuroshiro doesn't have yet — a much bigger, self-hosting-specific undertaking than parsing a header TRMNL OG devices already send on every poll. Deferred to a future issue if there's demonstrated demand.
+- **No history/time-series storage.** Only the latest reading per kind is kept (see ADR-0018) — no per-reading history table, matching every other piece of Device telemetry Kuroshiro already stores (`batteryVoltage`, `rssi`, etc., all single overwritten columns).
+- **No Device Model gating.** Nothing enforces that only OG Devices can have sensor data — the `SENSORS` header simply won't appear on other models' polls, so the constraint self-resolves without any enforcement code. No Device Model capability-gating mechanism exists elsewhere in the codebase to reuse anyway.
+- **No admin UI.** `DeviceInformationCard.vue` already surfaces battery voltage and RSSI, but sensor readings aren't added to it in v1 — backend parsing plus Liquid template exposure is the whole v1 surface. A read endpoint and UI card are a separable follow-up.
+
+## Consequences
+
+- A future server-attached sensor feature is additive — it needs its own sync mechanism and a `source` discriminator on `DeviceSensor`, but doesn't require reshaping the device-attached path from ADR-0018.
+- A future admin UI card is a pure read — it needs a new endpoint over the existing `DeviceSensor` table, nothing about ingestion changes to support it.

--- a/packages/api/src/app.module.ts
+++ b/packages/api/src/app.module.ts
@@ -9,6 +9,7 @@ import config from './config/config'
 import { DeviceModelsModule } from './device-models/device-models.module'
 import { DeviceModel } from './device-models/entities/device-model.entity'
 import { Palette } from './device-models/entities/palette.entity'
+import { DeviceSensor } from './device-sensors/entities/device-sensor.entity'
 import { Device } from './devices/devices.entity'
 import { DevicesModule } from './devices/devices.module'
 import { Firmware } from './firmware/entities/firmware.entity'
@@ -51,7 +52,7 @@ const conf = config()
       username: conf.database.user,
       password: conf.database.password,
       database: conf.database.database,
-      entities: [Device, DeviceModel, Palette, Screen, LogEntry, Plugin, DevicePlugin, PluginDataSource, PluginTemplate, PluginField, PluginFieldValue, PluginVariable, MashupConfiguration, MashupSlot, Schedule, Firmware],
+      entities: [Device, DeviceModel, Palette, DeviceSensor, Screen, LogEntry, Plugin, DevicePlugin, PluginDataSource, PluginTemplate, PluginField, PluginFieldValue, PluginVariable, MashupConfiguration, MashupSlot, Schedule, Firmware],
       migrations: (() => {
         const dir = path.join(process.cwd(), 'dist', 'src', 'migrations')
         if (!fs.existsSync(dir))

--- a/packages/api/src/config/typeorm.config.ts
+++ b/packages/api/src/config/typeorm.config.ts
@@ -2,6 +2,7 @@ import process from 'node:process'
 import { DataSource } from 'typeorm'
 import { DeviceModel } from '../device-models/entities/device-model.entity'
 import { Palette } from '../device-models/entities/palette.entity'
+import { DeviceSensor } from '../device-sensors/entities/device-sensor.entity'
 import { Device } from '../devices/devices.entity'
 import { Firmware } from '../firmware/entities/firmware.entity'
 import { LogEntry } from '../logs/logs.entity'
@@ -24,7 +25,7 @@ const AppDataSource = new DataSource({
   username: process.env.KUROSHIRO_DB_USER || 'root',
   password: process.env.KUROSHIRO_DB_PASSWORD || 'root',
   database: process.env.KUROSHIRO_DB_DB || 'test',
-  entities: [Device, DeviceModel, Palette, Screen, LogEntry, Plugin, DevicePlugin, PluginDataSource, PluginTemplate, PluginField, PluginFieldValue, PluginVariable, MashupConfiguration, MashupSlot, Schedule, Firmware],
+  entities: [Device, DeviceModel, Palette, DeviceSensor, Screen, LogEntry, Plugin, DevicePlugin, PluginDataSource, PluginTemplate, PluginField, PluginFieldValue, PluginVariable, MashupConfiguration, MashupSlot, Schedule, Firmware],
   migrations: ['dist/src/migrations/*.js'],
   migrationsTableName: 'migrations',
   synchronize: false,

--- a/packages/api/src/device-sensors/__test__/device-sensors.service.spec.ts
+++ b/packages/api/src/device-sensors/__test__/device-sensors.service.spec.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { DeviceSensorsService } from '../device-sensors.service'
+
+function createMockRepo() {
+  return {
+    find: vi.fn(),
+    save: vi.fn(),
+    remove: vi.fn(),
+    create: vi.fn((attrs: any) => attrs),
+  }
+}
+
+describe('deviceSensorsService', () => {
+  let service: DeviceSensorsService
+  let sensorRepo: ReturnType<typeof createMockRepo>
+
+  const device = { id: 'device-1' } as any
+
+  beforeEach(() => {
+    sensorRepo = createMockRepo()
+    sensorRepo.find.mockResolvedValue([])
+    sensorRepo.save.mockImplementation(async (row: any) => row)
+    sensorRepo.remove.mockResolvedValue(undefined)
+    service = new DeviceSensorsService(sensorRepo as any)
+  })
+
+  describe('syncFromHeader', () => {
+    it('upserts every kind in a full valid header for a device with no prior rows', async () => {
+      const header = 'make=Sensirion;model=SCD41;kind=temperature;value=21.5;unit=C;created_at=2026-08-22T00:00:00Z,make=Sensirion;model=SCD41;kind=humidity;value=45;unit=%;created_at=2026-08-22T00:00:00Z'
+
+      await service.syncFromHeader(device, header)
+
+      expect(sensorRepo.remove).not.toHaveBeenCalled()
+      expect(sensorRepo.save).toHaveBeenCalledWith(expect.objectContaining({ device, kind: 'temperature', value: 21.5, unit: 'C' }))
+      expect(sensorRepo.save).toHaveBeenCalledWith(expect.objectContaining({ device, kind: 'humidity', value: 45, unit: '%' }))
+      expect(sensorRepo.save).toHaveBeenCalledTimes(2)
+    })
+
+    it('updates value/unit in place for a kind that already has a row', async () => {
+      const existingRow = { id: 'row-1', kind: 'temperature', value: 20, unit: 'C' }
+      sensorRepo.find.mockResolvedValue([existingRow])
+
+      await service.syncFromHeader(device, 'kind=temperature;value=22.1;unit=C')
+
+      expect(sensorRepo.create).not.toHaveBeenCalled()
+      expect(sensorRepo.save).toHaveBeenCalledWith(expect.objectContaining({ id: 'row-1', kind: 'temperature', value: 22.1, unit: 'C' }))
+    })
+
+    it('clears only the kinds missing from this poll, leaving present kinds untouched', async () => {
+      const temperatureRow = { id: 'row-1', kind: 'temperature', value: 20, unit: 'C' }
+      const humidityRow = { id: 'row-2', kind: 'humidity', value: 40, unit: '%' }
+      sensorRepo.find.mockResolvedValue([temperatureRow, humidityRow])
+
+      await service.syncFromHeader(device, 'kind=temperature;value=21;unit=C')
+
+      expect(sensorRepo.remove).toHaveBeenCalledWith([humidityRow])
+      expect(sensorRepo.save).toHaveBeenCalledWith(expect.objectContaining({ id: 'row-1', value: 21 }))
+      expect(sensorRepo.save).toHaveBeenCalledTimes(1)
+    })
+
+    it('drops a record missing a required field instead of erroring', async () => {
+      const header = 'kind=temperature;value=21;unit=C,kind=humidity;value=oops;unit=%,kind=pressure;unit=hPa,make=x;model=y'
+
+      await service.syncFromHeader(device, header)
+
+      expect(sensorRepo.save).toHaveBeenCalledTimes(1)
+      expect(sensorRepo.save).toHaveBeenCalledWith(expect.objectContaining({ kind: 'temperature', value: 21, unit: 'C' }))
+    })
+
+    it('collapses a kind repeated within one header to its last occurrence, avoiding a duplicate insert', async () => {
+      const header = 'kind=temperature;value=20;unit=C,kind=temperature;value=22.5;unit=C'
+
+      await service.syncFromHeader(device, header)
+
+      expect(sensorRepo.save).toHaveBeenCalledTimes(1)
+      expect(sensorRepo.save).toHaveBeenCalledWith(expect.objectContaining({ kind: 'temperature', value: 22.5, unit: 'C' }))
+    })
+
+    it('drops a record with an unrecognised kind', async () => {
+      await service.syncFromHeader(device, 'kind=light;value=100;unit=lux')
+
+      expect(sensorRepo.save).not.toHaveBeenCalled()
+    })
+
+    it('clears every existing row when the header is absent', async () => {
+      const temperatureRow = { id: 'row-1', kind: 'temperature', value: 20, unit: 'C' }
+      sensorRepo.find.mockResolvedValue([temperatureRow])
+
+      await service.syncFromHeader(device, undefined)
+
+      expect(sensorRepo.remove).toHaveBeenCalledWith([temperatureRow])
+      expect(sensorRepo.save).not.toHaveBeenCalled()
+    })
+
+    it('clears every existing row when the header is blank', async () => {
+      const temperatureRow = { id: 'row-1', kind: 'temperature', value: 20, unit: 'C' }
+      sensorRepo.find.mockResolvedValue([temperatureRow])
+
+      await service.syncFromHeader(device, '')
+
+      expect(sensorRepo.remove).toHaveBeenCalledWith([temperatureRow])
+    })
+
+    it('does nothing when the header is absent and there were no prior rows', async () => {
+      await service.syncFromHeader(device, undefined)
+
+      expect(sensorRepo.remove).not.toHaveBeenCalled()
+      expect(sensorRepo.save).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('findForDevice', () => {
+    it('queries rows scoped to the given device', async () => {
+      const rows = [{ id: 'row-1', kind: 'temperature', value: 21, unit: 'C' }]
+      sensorRepo.find.mockResolvedValue(rows)
+
+      await expect(service.findForDevice('device-1')).resolves.toBe(rows)
+      expect(sensorRepo.find).toHaveBeenCalledWith({ where: { device: { id: 'device-1' } } })
+    })
+  })
+})

--- a/packages/api/src/device-sensors/__test__/mockDeviceSensorsService.ts
+++ b/packages/api/src/device-sensors/__test__/mockDeviceSensorsService.ts
@@ -1,0 +1,16 @@
+import { vi } from 'vitest'
+
+export function createMockDeviceSensorsService() {
+  return {
+    findForDevice: vi.fn(),
+    syncFromHeader: vi.fn(),
+  }
+}
+
+export type MockDeviceSensorsService = ReturnType<typeof createMockDeviceSensorsService>
+
+/** Default behaviour after `vi.resetAllMocks()`: no readings, sync resolves without doing anything observable. */
+export function primeMockDeviceSensorsService(mock: MockDeviceSensorsService) {
+  mock.findForDevice.mockResolvedValue([])
+  mock.syncFromHeader.mockResolvedValue(undefined)
+}

--- a/packages/api/src/device-sensors/device-sensors.module.ts
+++ b/packages/api/src/device-sensors/device-sensors.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common'
+import { TypeOrmModule } from '@nestjs/typeorm'
+import { DeviceSensorsService } from './device-sensors.service'
+import { DeviceSensor } from './entities/device-sensor.entity'
+
+@Module({
+  imports: [TypeOrmModule.forFeature([DeviceSensor])],
+  providers: [DeviceSensorsService],
+  exports: [DeviceSensorsService],
+})
+export class DeviceSensorsModule {}

--- a/packages/api/src/device-sensors/device-sensors.service.ts
+++ b/packages/api/src/device-sensors/device-sensors.service.ts
@@ -1,0 +1,101 @@
+import type { Device } from '../devices/devices.entity'
+import { Injectable, Logger } from '@nestjs/common'
+import { InjectRepository } from '@nestjs/typeorm'
+import { Repository } from 'typeorm'
+import { DEVICE_SENSOR_KINDS, DeviceSensor, DeviceSensorKind } from './entities/device-sensor.entity'
+
+interface ParsedSensorRecord {
+  kind: DeviceSensorKind
+  value: number
+  unit: string
+}
+
+function isDeviceSensorKind(value: string): value is DeviceSensorKind {
+  return (DEVICE_SENSOR_KINDS as readonly string[]).includes(value)
+}
+
+/**
+ * Parses one `make=...;model=...;kind=...;value=...;unit=...;created_at=...`
+ * record. `make`/`model`/`created_at` are read but discarded (ADR-0018). A
+ * record missing `kind`/`value`/`unit`, with an unrecognised `kind`, or a
+ * non-numeric `value` is dropped rather than raising, matching the wire
+ * protocol's own reference parser behaviour.
+ */
+function parseSensorRecord(record: string): ParsedSensorRecord | null {
+  const fields = new Map<string, string>()
+  for (const field of record.split(';')) {
+    const separatorIndex = field.indexOf('=')
+    if (separatorIndex === -1)
+      continue
+    fields.set(field.slice(0, separatorIndex).trim(), field.slice(separatorIndex + 1).trim())
+  }
+
+  const kind = fields.get('kind')
+  const unit = fields.get('unit')
+  const value = Number.parseFloat(fields.get('value') ?? '')
+
+  if (!kind || !unit || !isDeviceSensorKind(kind) || Number.isNaN(value))
+    return null
+
+  return { kind, value, unit }
+}
+
+/**
+ * A kind repeated within one header collapses to its last occurrence, so the
+ * upsert step below never has two records racing to write the same
+ * `(device, kind)` row.
+ */
+function parseSensorsHeader(rawHeaderValue?: string | null): ParsedSensorRecord[] {
+  if (!rawHeaderValue)
+    return []
+  const byKind = new Map<DeviceSensorKind, ParsedSensorRecord>()
+  for (const record of rawHeaderValue.split(',')) {
+    const parsed = parseSensorRecord(record)
+    if (parsed)
+      byKind.set(parsed.kind, parsed)
+  }
+  return [...byKind.values()]
+}
+
+@Injectable()
+export class DeviceSensorsService {
+  private readonly logger = new Logger(DeviceSensorsService.name)
+
+  constructor(
+    @InjectRepository(DeviceSensor)
+    private readonly sensorRepository: Repository<DeviceSensor>,
+  ) {}
+
+  findForDevice(deviceId: string): Promise<DeviceSensor[]> {
+    return this.sensorRepository.find({ where: { device: { id: deviceId } } })
+  }
+
+  /**
+   * Treats the poll's header as the complete, authoritative snapshot of what
+   * the Device currently has attached (ADR-0018): every existing row for a
+   * kind missing from this poll is deleted, and every kind present is
+   * upserted with its latest value/unit.
+   */
+  async syncFromHeader(device: Device, rawHeaderValue?: string | null): Promise<void> {
+    const records = parseSensorsHeader(rawHeaderValue)
+    const presentKinds = new Set(records.map(record => record.kind))
+
+    const existing = await this.sensorRepository.find({ where: { device: { id: device.id } } })
+
+    const toDelete = existing.filter(row => !presentKinds.has(row.kind))
+    if (toDelete.length > 0) {
+      this.logger.debug(`Clearing sensor kinds no longer reported for device ${device.id}: ${toDelete.map(row => row.kind).join(', ')}`)
+      await this.sensorRepository.remove(toDelete)
+    }
+
+    await Promise.all(records.map((record) => {
+      const existingRow = existing.find(row => row.kind === record.kind)
+      if (existingRow) {
+        existingRow.value = record.value
+        existingRow.unit = record.unit
+        return this.sensorRepository.save(existingRow)
+      }
+      return this.sensorRepository.save(this.sensorRepository.create({ device, kind: record.kind, value: record.value, unit: record.unit }))
+    }))
+  }
+}

--- a/packages/api/src/device-sensors/entities/device-sensor.entity.ts
+++ b/packages/api/src/device-sensors/entities/device-sensor.entity.ts
@@ -1,0 +1,23 @@
+import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm'
+import { Device } from '../../devices/devices.entity'
+
+export const DEVICE_SENSOR_KINDS = ['carbon_dioxide', 'humidity', 'pressure', 'temperature'] as const
+export type DeviceSensorKind = typeof DEVICE_SENSOR_KINDS[number]
+
+@Entity()
+export class DeviceSensor {
+  @PrimaryGeneratedColumn('uuid')
+  id: string
+
+  @Column('text')
+  kind: DeviceSensorKind
+
+  @Column('float')
+  value: number
+
+  @Column('text')
+  unit: string
+
+  @ManyToOne(() => Device, { onDelete: 'CASCADE' })
+  device: Device
+}

--- a/packages/api/src/devices/__test__/display.service.spec.ts
+++ b/packages/api/src/devices/__test__/display.service.spec.ts
@@ -1,8 +1,11 @@
 import type { MockDeviceModelsService, MockFallbackScreensService } from '../../device-models/__test__/mockDeviceModelsService'
+import type { MockDeviceSensorsService } from '../../device-sensors/__test__/mockDeviceSensorsService'
 import { promises as fs } from 'node:fs'
 import { NotFoundException, UnauthorizedException } from '@nestjs/common'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createMockDeviceModelsService, createMockFallbackScreensService, GRAY_4, GRAY_16, OG_PLUS, primeMockDeviceModelsService, primeMockFallbackScreensService, V2 } from '../../device-models/__test__/mockDeviceModelsService'
+import { createMockDeviceSensorsService, primeMockDeviceSensorsService } from '../../device-sensors/__test__/mockDeviceSensorsService'
+import { PluginTemplateContextService } from '../../plugins/services/plugin-template-context.service'
 import { Display } from '../display'
 import { DeviceDisplayService } from '../display.service'
 import { DisplayScreen } from '../displayScreen'
@@ -66,6 +69,7 @@ describe('deviceDisplayService', () => {
   let deviceModels: MockDeviceModelsService
   let fallbackScreens: MockFallbackScreensService
   let firmwareService: { verifyChecksum: ReturnType<typeof vi.fn>, fileUrl: ReturnType<typeof vi.fn> }
+  let deviceSensors: MockDeviceSensorsService
 
   beforeEach(() => {
     deviceRepo = createMockRepo()
@@ -74,6 +78,7 @@ describe('deviceDisplayService', () => {
     deviceModels = createMockDeviceModelsService()
     fallbackScreens = createMockFallbackScreensService()
     firmwareService = { verifyChecksum: vi.fn(), fileUrl: vi.fn() }
+    deviceSensors = createMockDeviceSensorsService()
     service = new DeviceDisplayService(
       deviceRepo as any,
       screenRepo as any,
@@ -84,10 +89,13 @@ describe('deviceDisplayService', () => {
       {} as any,
       {} as any,
       {} as any,
+      deviceSensors as any,
+      new PluginTemplateContextService(),
     )
     vi.resetAllMocks()
     primeMockDeviceModelsService(deviceModels)
     primeMockFallbackScreensService(fallbackScreens)
+    primeMockDeviceSensorsService(deviceSensors)
     primePuppeteer()
   })
 
@@ -150,6 +158,31 @@ describe('deviceDisplayService', () => {
       deviceRepo.findOneBy.mockResolvedValue(device)
       await service.getCurrentImage({ ...headers, model: 'x' } as any)
       expect(deviceModels.assignResolvedModel).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('sensor ingestion', () => {
+    beforeEach(() => {
+      screenRepo.find.mockResolvedValue([])
+      configService.get.mockReturnValue('http://api')
+    })
+
+    it('syncs sensor readings from the resolved device and the raw sensors header', async () => {
+      const device = { ...baseDevice, deviceModel: OG_PLUS }
+      deviceRepo.findOneBy.mockResolvedValue(device)
+
+      await service.getCurrentImage({ ...headers, sensors: 'kind=temperature;value=21.5;unit=C' } as any)
+
+      expect(deviceSensors.syncFromHeader).toHaveBeenCalledWith(device, 'kind=temperature;value=21.5;unit=C')
+    })
+
+    it('syncs even when the sensors header is absent, clearing any stale readings', async () => {
+      const device = { ...baseDevice, deviceModel: OG_PLUS }
+      deviceRepo.findOneBy.mockResolvedValue(device)
+
+      await service.getCurrentImage(headers as any)
+
+      expect(deviceSensors.syncFromHeader).toHaveBeenCalledWith(device, undefined)
     })
   })
 

--- a/packages/api/src/devices/devices.module.ts
+++ b/packages/api/src/devices/devices.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common'
 import { ConfigModule } from '@nestjs/config'
 import { TypeOrmModule } from '@nestjs/typeorm'
 import { DeviceModelsModule } from '../device-models/device-models.module'
+import { DeviceSensorsModule } from '../device-sensors/device-sensors.module'
 import { FirmwareModule } from '../firmware/firmware.module'
 import { LogEntry } from '../logs/logs.entity'
 import { PluginsModule } from '../plugins/plugins.module'
@@ -16,7 +17,7 @@ import { SetupController } from './setup.controller'
 import { DeviceSetupService } from './setup.service'
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Device, Screen, LogEntry]), ConfigModule, PluginsModule, DeviceModelsModule, FirmwareModule, ScreensModule],
+  imports: [TypeOrmModule.forFeature([Device, Screen, LogEntry]), ConfigModule, PluginsModule, DeviceModelsModule, DeviceSensorsModule, FirmwareModule, ScreensModule],
   controllers: [DevicesController, DisplayController, SetupController],
   providers: [DevicesService, DeviceDisplayService, DeviceSetupService],
   exports: [DevicesService],

--- a/packages/api/src/devices/display.service.ts
+++ b/packages/api/src/devices/display.service.ts
@@ -11,9 +11,11 @@ import { DeviceModelsService } from '../device-models/device-models.service'
 import { FallbackScreensService } from '../device-models/fallback-screens.service'
 import { renderHtmlToPng } from '../device-models/render-html-to-png'
 import { viewFull, wrapInScreenShell } from '../device-models/screen-shell'
+import { DeviceSensorsService } from '../device-sensors/device-sensors.service'
 import { FirmwareService } from '../firmware/firmware.service'
 import { PluginDataFetcherService } from '../plugins/services/plugin-data-fetcher.service'
 import { PluginRendererService } from '../plugins/services/plugin-renderer.service'
+import { PluginTemplateContextService } from '../plugins/services/plugin-template-context.service'
 import { PluginTransformService } from '../plugins/services/plugin-transform.service'
 import { isScheduleEligible } from '../schedule/schedule-eligibility'
 import { Screen } from '../screens/screens.entity'
@@ -54,6 +56,8 @@ export class DeviceDisplayService {
     private pluginDataFetcher: PluginDataFetcherService,
     private pluginRenderer: PluginRendererService,
     private pluginTransformer: PluginTransformService,
+    private deviceSensors: DeviceSensorsService,
+    private pluginTemplateContext: PluginTemplateContextService,
   ) {
     // Lazy injection to avoid circular dependency
     setTimeout(async () => {
@@ -65,6 +69,8 @@ export class DeviceDisplayService {
           this.pluginRenderer,
           this.pluginTransformer,
           this.configService,
+          this.deviceSensors,
+          this.pluginTemplateContext,
         )
       }
       catch {
@@ -95,6 +101,7 @@ export class DeviceDisplayService {
     device.reportedModel = headers.model ?? device.reportedModel
     if (!device.deviceModel)
       await this.deviceModels.assignResolvedModel(device)
+    await this.deviceSensors.syncFromHeader(device, headers.sensors)
     // Handling reset
     const resetDevice = device.resetDevice
     device.resetDevice = false
@@ -394,7 +401,7 @@ export class DeviceDisplayService {
         // Fallback: fetch and render on-demand
         else if (plugin.dataSources && plugin.dataSources.length > 0 && plugin.templates && plugin.templates.length > 0) {
           try {
-            const renderedHtml = await this.renderPluginHtml(plugin, screen)
+            const renderedHtml = await this.renderPluginHtml(plugin, screen, device)
             if (renderedHtml)
               imgUrl = await this.renderBodyToScreenPng(viewFull(renderedHtml), screen, device)
           }
@@ -445,29 +452,11 @@ export class DeviceDisplayService {
       : await this.fallbackImageUrl('error', device)
   }
 
-  private async renderPluginHtml(plugin: Plugin, screen: Screen): Promise<string | null> {
+  private async renderPluginHtml(plugin: Plugin, screen: Screen, device: Device): Promise<string | null> {
     this.logger.log(`No cache, rendering plugin ${plugin.id} on-demand for screen ${screen.id}`)
 
-    // Build template context with trmnl system variables
-    const templateContext: any = {
-      trmnl: {
-        system: {
-          timestamp_utc: Math.floor(Date.now() / 1000),
-        },
-        plugin_settings: {
-          instance_name: plugin.name,
-          strategy: 'polling',
-          dark_mode: 'no',
-          no_screen_padding: 'no',
-        },
-        user: {
-          id: 'kuroshiro-user',
-          locale: 'en',
-        },
-      },
-    }
-
-    // TODO: Add plugin field values to context when we have device-specific values
+    const sensors = await this.deviceSensors.findForDevice(device.id)
+    const templateContext: any = this.pluginTemplateContext.build(plugin, sensors)
 
     // Fetch all of the plugin's data sources in parallel; a source that fails
     // gets an error marker instead of aborting the whole render (ADR-0005)

--- a/packages/api/src/devices/dto/display-request-headers.dto.ts
+++ b/packages/api/src/devices/dto/display-request-headers.dto.ts
@@ -38,4 +38,8 @@ export class DisplayRequestHeadersDto {
   @IsOptional()
   @IsString()
   model?: string
+
+  @IsOptional()
+  @IsString()
+  sensors?: string
 }

--- a/packages/api/src/mashup/__test__/mashup-renderer.service.spec.ts
+++ b/packages/api/src/mashup/__test__/mashup-renderer.service.spec.ts
@@ -1,4 +1,5 @@
 import type { ConfigService } from '@nestjs/config'
+import type { MockDeviceSensorsService } from '../../device-sensors/__test__/mockDeviceSensorsService'
 import type { Device } from '../../devices/devices.entity'
 import type { Plugin } from '../../plugins/entities/plugin.entity'
 import type { PluginDataFetcherService } from '../../plugins/services/plugin-data-fetcher.service'
@@ -7,6 +8,8 @@ import type { PluginTransformService } from '../../plugins/services/plugin-trans
 import type { MashupConfiguration } from '../entities/mashup-configuration.entity'
 import type { MashupSlot } from '../entities/mashup-slot.entity'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createMockDeviceSensorsService, primeMockDeviceSensorsService } from '../../device-sensors/__test__/mockDeviceSensorsService'
+import { PluginTemplateContextService } from '../../plugins/services/plugin-template-context.service'
 import { MashupRendererService } from '../services/mashup-renderer.service'
 
 describe('mashupRendererService', () => {
@@ -15,6 +18,7 @@ describe('mashupRendererService', () => {
   let pluginRenderer: PluginRendererService
   let pluginTransformer: PluginTransformService
   let configService: ConfigService
+  let deviceSensors: MockDeviceSensorsService
 
   beforeEach(() => {
     pluginDataFetcher = {
@@ -33,14 +37,20 @@ describe('mashupRendererService', () => {
       get: vi.fn().mockReturnValue('http://api'),
     } as any
 
+    deviceSensors = createMockDeviceSensorsService()
+    primeMockDeviceSensorsService(deviceSensors)
+
     service = new MashupRendererService(
       pluginDataFetcher,
       pluginRenderer,
       pluginTransformer,
       configService,
+      deviceSensors as any,
+      new PluginTemplateContextService(),
     )
 
     vi.resetAllMocks()
+    primeMockDeviceSensorsService(deviceSensors)
   })
 
   it('should render mashup with all plugins successful', async () => {

--- a/packages/api/src/mashup/mashup.module.ts
+++ b/packages/api/src/mashup/mashup.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common'
 import { ConfigModule } from '@nestjs/config'
 import { TypeOrmModule } from '@nestjs/typeorm'
+import { DeviceSensorsModule } from '../device-sensors/device-sensors.module'
 import { Device } from '../devices/devices.entity'
 import { Plugin } from '../plugins/entities/plugin.entity'
 import { PluginsModule } from '../plugins/plugins.module'
@@ -21,6 +22,7 @@ import { MashupRendererService } from './services/mashup-renderer.service'
       Plugin,
     ]),
     PluginsModule,
+    DeviceSensorsModule,
     ConfigModule,
   ],
   controllers: [MashupController],

--- a/packages/api/src/mashup/services/mashup-renderer.service.ts
+++ b/packages/api/src/mashup/services/mashup-renderer.service.ts
@@ -1,10 +1,13 @@
+import type { DeviceSensor } from '../../device-sensors/entities/device-sensor.entity'
 import type { Device } from '../../devices/devices.entity'
 import type { MashupConfiguration } from '../entities/mashup-configuration.entity'
 import type { MashupSlot } from '../entities/mashup-slot.entity'
 import { Injectable, Logger } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
+import { DeviceSensorsService } from '../../device-sensors/device-sensors.service'
 import { PluginDataFetcherService } from '../../plugins/services/plugin-data-fetcher.service'
 import { PluginRendererService } from '../../plugins/services/plugin-renderer.service'
+import { PluginTemplateContextService } from '../../plugins/services/plugin-template-context.service'
 import { PluginTransformService } from '../../plugins/services/plugin-transform.service'
 import { getErrorMessage } from '../../utils/getErrorMessage'
 
@@ -17,17 +20,20 @@ export class MashupRendererService {
     private readonly pluginRenderer: PluginRendererService,
     private readonly pluginTransformer: PluginTransformService,
     private readonly configService: ConfigService,
+    private readonly deviceSensors: DeviceSensorsService,
+    private readonly pluginTemplateContext: PluginTemplateContextService,
   ) {}
 
   async renderMashup(mashupConfig: MashupConfiguration, device: Device): Promise<string> {
     this.logger.log(`Rendering mashup ${mashupConfig.id} for device ${device.id}`)
 
     const slotHtmls: Array<{ slot: MashupSlot, html: string }> = []
+    const sensors = await this.deviceSensors.findForDevice(device.id)
 
     // Render each slot (with error handling for partial renders)
     for (const slot of mashupConfig.slots) {
       try {
-        const html = await this.renderSlot(slot, device)
+        const html = await this.renderSlot(slot, sensors)
         slotHtmls.push({ slot, html })
       }
       catch (err) {
@@ -44,31 +50,14 @@ export class MashupRendererService {
     return this.buildMashupHtml(mashupConfig.layout, slotHtmls)
   }
 
-  private async renderSlot(slot: MashupSlot, _device: Device): Promise<string> {
+  private async renderSlot(slot: MashupSlot, sensors: DeviceSensor[]): Promise<string> {
     const plugin = slot.plugin
 
     if (!plugin.dataSources || plugin.dataSources.length === 0 || !plugin.templates || plugin.templates.length === 0) {
       throw new Error('Plugin missing data sources or templates')
     }
 
-    // Build template context
-    const templateContext: any = {
-      trmnl: {
-        system: {
-          timestamp_utc: Math.floor(Date.now() / 1000),
-        },
-        plugin_settings: {
-          instance_name: plugin.name,
-          strategy: 'polling',
-          dark_mode: 'no',
-          no_screen_padding: 'no',
-        },
-        user: {
-          id: 'kuroshiro-user',
-          locale: 'en',
-        },
-      },
-    }
+    const templateContext: any = this.pluginTemplateContext.build(plugin, sensors)
 
     // Fetch all of the plugin's data sources in parallel; a source that fails
     // gets an error marker instead of aborting the whole render (ADR-0005)

--- a/packages/api/src/migrations/1787130000000-AddDeviceSensors.ts
+++ b/packages/api/src/migrations/1787130000000-AddDeviceSensors.ts
@@ -1,0 +1,25 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddDeviceSensors1787130000000 implements MigrationInterface {
+  name = 'AddDeviceSensors1787130000000'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "device_sensor" (
+        "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+        "kind" text NOT NULL,
+        "value" double precision NOT NULL,
+        "unit" text NOT NULL,
+        "deviceId" uuid NOT NULL,
+        CONSTRAINT "CHK_device_sensor_kind" CHECK ("kind" IN ('carbon_dioxide', 'humidity', 'pressure', 'temperature')),
+        CONSTRAINT "UQ_device_sensor_device_kind" UNIQUE ("deviceId", "kind"),
+        CONSTRAINT "FK_device_sensor_device"
+          FOREIGN KEY ("deviceId") REFERENCES "device"("id") ON DELETE CASCADE
+      )
+    `)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "device_sensor"`)
+  }
+}

--- a/packages/api/src/plugins/__test__/plugin-scheduler.service.spec.ts
+++ b/packages/api/src/plugins/__test__/plugin-scheduler.service.spec.ts
@@ -3,6 +3,7 @@ import type { PluginDataFetcherService } from '../services/plugin-data-fetcher.s
 import type { PluginRenderCacheService } from '../services/plugin-render-cache.service'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { PluginSchedulerService } from '../services/plugin-scheduler.service'
+import { PluginTemplateContextService } from '../services/plugin-template-context.service'
 
 let capturedCallback: (() => Promise<void>) | undefined
 
@@ -34,7 +35,7 @@ describe('pluginSchedulerService', () => {
       renderAndCache: vi.fn(),
     } as any
 
-    service = new PluginSchedulerService(mockDataFetcher, mockRenderCache)
+    service = new PluginSchedulerService(mockDataFetcher, mockRenderCache, new PluginTemplateContextService())
   })
 
   it('schedules a plugin with refresh interval', () => {

--- a/packages/api/src/plugins/__test__/plugin-template-context.service.spec.ts
+++ b/packages/api/src/plugins/__test__/plugin-template-context.service.spec.ts
@@ -1,0 +1,51 @@
+import type { DeviceSensor } from '../../device-sensors/entities/device-sensor.entity'
+import type { Plugin } from '../entities/plugin.entity'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { PluginTemplateContextService } from '../services/plugin-template-context.service'
+
+describe('pluginTemplateContextService', () => {
+  let service: PluginTemplateContextService
+
+  const plugin = { name: 'Weather' } as Plugin
+
+  beforeEach(() => {
+    service = new PluginTemplateContextService()
+  })
+
+  it('includes the trmnl system object keyed by the plugin name', () => {
+    const context = service.build(plugin, [])
+
+    expect(context.trmnl.plugin_settings.instance_name).toBe('Weather')
+    expect(context.trmnl.user).toEqual({ id: 'kuroshiro-user', locale: 'en' })
+    expect(typeof context.trmnl.system.timestamp_utc).toBe('number')
+  })
+
+  it('shapes a sensors object keyed by kind for a device with readings across multiple kinds', () => {
+    const sensors = [
+      { kind: 'temperature', value: 21.5, unit: 'C' },
+      { kind: 'humidity', value: 45, unit: '%' },
+    ] as DeviceSensor[]
+
+    const context = service.build(plugin, sensors)
+
+    expect(context.sensors).toEqual({
+      temperature: { value: 21.5, unit: 'C' },
+      humidity: { value: 45, unit: '%' },
+    })
+  })
+
+  it('produces an empty sensors object for a device with none', () => {
+    const context = service.build(plugin, [])
+
+    expect(context.sensors).toEqual({})
+  })
+
+  it('omits kinds the device has no current reading for', () => {
+    const sensors = [{ kind: 'pressure', value: 1013, unit: 'hPa' }] as DeviceSensor[]
+
+    const context = service.build(plugin, sensors)
+
+    expect(context.sensors).toEqual({ pressure: { value: 1013, unit: 'hPa' } })
+    expect(context.sensors.temperature).toBeUndefined()
+  })
+})

--- a/packages/api/src/plugins/plugins.module.ts
+++ b/packages/api/src/plugins/plugins.module.ts
@@ -17,6 +17,7 @@ import { PluginImporterService } from './services/plugin-importer.service'
 import { PluginRenderCacheService } from './services/plugin-render-cache.service'
 import { PluginRendererService } from './services/plugin-renderer.service'
 import { PluginSchedulerService } from './services/plugin-scheduler.service'
+import { PluginTemplateContextService } from './services/plugin-template-context.service'
 import { PluginTransformService } from './services/plugin-transform.service'
 import { WebhookIngestService } from './services/webhook-ingest.service'
 import { WebhookIngestController } from './webhook-ingest.controller'
@@ -44,9 +45,10 @@ import { WebhookIngestController } from './webhook-ingest.controller'
     PluginExporterService,
     PluginTransformService,
     PluginRenderCacheService,
+    PluginTemplateContextService,
     WebhookIngestService,
     WebhookPluginGuard,
   ],
-  exports: [PluginsService, PluginSchedulerService, PluginDataFetcherService, PluginRendererService, PluginTransformService, PluginRenderCacheService],
+  exports: [PluginsService, PluginSchedulerService, PluginDataFetcherService, PluginRendererService, PluginTransformService, PluginRenderCacheService, PluginTemplateContextService],
 })
 export class PluginsModule {}

--- a/packages/api/src/plugins/services/plugin-scheduler.service.ts
+++ b/packages/api/src/plugins/services/plugin-scheduler.service.ts
@@ -4,6 +4,7 @@ import { Injectable, Logger } from '@nestjs/common'
 import cron from 'node-cron'
 import { PluginDataFetcherService } from './plugin-data-fetcher.service'
 import { PluginRenderCacheService } from './plugin-render-cache.service'
+import { PluginTemplateContextService } from './plugin-template-context.service'
 
 @Injectable()
 export class PluginSchedulerService {
@@ -13,6 +14,7 @@ export class PluginSchedulerService {
   constructor(
     private readonly dataFetcher: PluginDataFetcherService,
     private readonly renderCache: PluginRenderCacheService,
+    private readonly pluginTemplateContext: PluginTemplateContextService,
   ) {}
 
   schedulePlugin(plugin: Plugin): void {
@@ -28,26 +30,10 @@ export class PluginSchedulerService {
 
     const task = cron.schedule(cronExpression, async () => {
       try {
-        // Build template context with trmnl system variables
-        const templateContext: any = {
-          trmnl: {
-            system: {
-              timestamp_utc: Math.floor(Date.now() / 1000),
-            },
-            plugin_settings: {
-              instance_name: plugin.name,
-              strategy: 'polling',
-              dark_mode: 'no',
-              no_screen_padding: 'no',
-            },
-            user: {
-              id: 'kuroshiro-user',
-              locale: 'en',
-            },
-          },
-        }
-
-        // TODO: Add plugin field values to context when we have device-specific values
+        // This cache entry is shared across every Screen/Device the Plugin is
+        // assigned to (renderAndCache below writes it to all of them), so
+        // there is no single Device to scope sensors to here.
+        const templateContext: any = this.pluginTemplateContext.build(plugin, [])
 
         // Fetch all of the plugin's data sources in parallel; a source that fails
         // gets an error marker instead of aborting the whole render (ADR-0005)

--- a/packages/api/src/plugins/services/plugin-template-context.service.ts
+++ b/packages/api/src/plugins/services/plugin-template-context.service.ts
@@ -1,0 +1,33 @@
+import type { DeviceSensor } from '../../device-sensors/entities/device-sensor.entity'
+import type { Plugin } from '../entities/plugin.entity'
+import { Injectable } from '@nestjs/common'
+
+/**
+ * Base Liquid template context: the `trmnl` system object plus an implicit
+ * `sensors` object keyed by kind (ADR-0018) for whichever kinds the rendering
+ * Device currently has a reading for. Callers merge a Plugin's fetched Data
+ * Source `data` on top of this at the render call.
+ */
+@Injectable()
+export class PluginTemplateContextService {
+  build(plugin: Plugin, sensors: DeviceSensor[]): Record<string, any> {
+    return {
+      trmnl: {
+        system: {
+          timestamp_utc: Math.floor(Date.now() / 1000),
+        },
+        plugin_settings: {
+          instance_name: plugin.name,
+          strategy: 'polling',
+          dark_mode: 'no',
+          no_screen_padding: 'no',
+        },
+        user: {
+          id: 'kuroshiro-user',
+          locale: 'en',
+        },
+      },
+      sensors: Object.fromEntries(sensors.map(sensor => [sensor.kind, { value: sensor.value, unit: sensor.unit }])),
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Parses the `SENSORS` header TRMNL OG firmware sends on every `/display` poll into a new `DeviceSensor` entity — one row per `(Device, kind)`, latest value only, each poll treated as the authoritative full snapshot (kinds missing from a poll are deleted, kinds present are upserted).
- Exposes current readings to Plugin Liquid templates as an implicit `sensors` object (`sensors.temperature.value`, `sensors.temperature.unit`) via a new shared `PluginTemplateContextService`, now the single seam used by the direct-render path, the Mashup-render path, and the scheduled/cached Poll-plugin render path (previously three separate duplicated `templateContext` literals).
- Records the architecture/scope decisions from the `/grilling` session on #782 as ADR-0018 and ADR-0019 (renumbered from the source branch's 0012/0013, which collided with the already-merged Sleep Mode ADRs), plus a `Sensor` glossary entry in `CONTEXT.md`.
- Out of scope per ADR-0019: server-attached (Raspberry Pi) sensors, reading history, Device Model gating, and any admin UI/read endpoint.

## Test plan
- [x] `pnpm type-check` (API + UI)
- [x] `pnpm lint`
- [x] `pnpm --filter ./packages/api test` — 700 passed, 5 skipped (pre-existing skips)
- [x] New unit tests: `DeviceSensorsService` (header parsing, snapshot upsert/delete semantics, malformed/duplicate-kind records) and `PluginTemplateContextService` (sensors shape across multiple/no/partial kinds)
- [x] Extended `display.service.spec.ts` to assert `syncFromHeader` is called with the resolved Device and raw header value, unconditionally of mirror status

Closes #801

https://claude.ai/code/session_01FGX7XAJs6vssxKjZae5AdQ