### PR TITLE
fix(devices): forward resetDevice on the cycling and mirror paths

### DIFF
--- a/packages/api/src/devices/__test__/display.service.spec.ts
+++ b/packages/api/src/devices/__test__/display.service.spec.ts
@@ -503,6 +503,89 @@ describe('deviceDisplayService', () => {
     })
   })
 
+  describe('reset device delivery', () => {
+    function primeNoScreen(device: Record<string, unknown>) {
+      deviceRepo.findOneBy.mockResolvedValue(device)
+      screenRepo.find.mockResolvedValue([])
+      configService.get.mockReturnValue('http://api')
+    }
+
+    function primeCycling(device: Record<string, unknown>) {
+      const activeScreen = { id: 'screen1', order: 1, device, isActive: true, fetchManual: false, externalLink: null, filename: 'file.png', generatedAt: new Date() }
+      deviceRepo.findOneBy.mockResolvedValue(device)
+      screenRepo.find.mockResolvedValue([activeScreen, { ...activeScreen, id: 'screen2', order: 2, isActive: false }])
+      configService.get.mockReturnValue('http://api')
+      fileExists.mockResolvedValue(true)
+    }
+
+    function primeMirror(device: Record<string, unknown>, response: Record<string, unknown>) {
+      deviceRepo.findOneBy.mockResolvedValue(device)
+      configService.get.mockReturnValue('http://api')
+      mockFetch.mockResolvedValueOnce({ json: () => Promise.resolve(response) })
+    }
+
+    function mirroredDevice(mirrorMac: string, resetDevice: boolean) {
+      return { ...baseDevice, deviceModel: OG_PLUS, mirrorEnabled: true, mirrorMac, mirrorApikey: 'mirror-token', resetDevice }
+    }
+
+    it('delivers a pending reset and clears the flag when the device has no screen', async () => {
+      primeNoScreen({ ...baseDevice, deviceModel: OG_PLUS, resetDevice: true })
+
+      const result = await service.getCurrentImage(headers as any)
+
+      expect(result.reset_firmware).toBe(true)
+      expect(deviceRepo.save).toHaveBeenCalledWith(expect.objectContaining({ resetDevice: false }))
+    })
+
+    it('delivers a pending reset while cycling screens', async () => {
+      primeCycling({ ...baseDevice, deviceModel: OG_PLUS, resetDevice: true })
+
+      const result = await service.getCurrentImage(headers as any)
+
+      expect(result.reset_firmware).toBe(true)
+    })
+
+    it('does not report a reset while cycling screens when none is pending', async () => {
+      primeCycling({ ...baseDevice, deviceModel: OG_PLUS, resetDevice: false })
+
+      const result = await service.getCurrentImage(headers as any)
+
+      expect(result.reset_firmware).toBe(false)
+    })
+
+    it('lets the upstream response own reset_firmware when proxying', async () => {
+      primeMirror(mirroredDevice('mac', true), { filename: 'mirror.png', image_url: 'http://example.com/image.jpg', reset_firmware: false })
+
+      const result = await service.getCurrentImage(headers as any)
+
+      expect(result.reset_firmware).toBe(false)
+    })
+
+    it('falls back to the locally pending reset when a proxied response omits it', async () => {
+      primeMirror(mirroredDevice('mac', true), { filename: 'mirror.png', image_url: 'http://example.com/image.jpg' })
+
+      const result = await service.getCurrentImage(headers as any)
+
+      expect(result.reset_firmware).toBe(true)
+    })
+
+    it('delivers a pending reset on a non-proxy mirrored device', async () => {
+      primeMirror(mirroredDevice('different-mac', true), { filename: 'mirror.png', image_url: 'http://example.com/image.jpg' })
+
+      const result = await service.getCurrentImage(headers as any)
+
+      expect(result.reset_firmware).toBe(true)
+    })
+
+    it('does not report a reset on a non-proxy mirrored device when none is pending', async () => {
+      primeMirror(mirroredDevice('different-mac', false), { filename: 'mirror.png', image_url: 'http://example.com/image.jpg' })
+
+      const result = await service.getCurrentImage(headers as any)
+
+      expect(result.reset_firmware).toBe(false)
+    })
+  })
+
   describe('firmware push', () => {
     const targetFirmware = { id: 'fw-1', version: '1.5.6', checksum: 'abc123' }
 

--- a/packages/api/src/devices/display.service.ts
+++ b/packages/api/src/devices/display.service.ts
@@ -154,7 +154,7 @@ export class DeviceDisplayService {
         firmware_url: pushedFirmwareUrl,
         image_url: imgUrl,
         refresh_rate: device.refreshRate,
-        reset_firmware: false,
+        reset_firmware: resetDevice,
         special_function: specialFunction,
         temperature_profile: 'default',
         update_firmware: pushedUpdateFirmware,
@@ -174,7 +174,7 @@ export class DeviceDisplayService {
       let filename = 'error.png'
       let localImageUrl = await this.fallbackImageUrl('error', device)
       let firmwareUrl: string | null = null
-      let resetFirmware = false
+      let resetFirmware = resetDevice
       let mirrorSpecialFunction = specialFunction
       let mirrorAction = specialFunction
       let updateFirmware = false


### PR DESCRIPTION
## Summary
- `resetDevice` was read and cleared on every `/display` poll, but `reset_firmware` was only ever delivered on the no-active-Screen path. The cycling path hardcoded `false`, and the non-proxy mirror path (`current_screen`, different MAC) never assigned it from the local flag at all — so flipping **Reset device** on any Device actually in use silently did nothing.
- Forwards `resetDevice` on the cycling path.
- Initializes the mirror path's `resetFirmware` from the local `resetDevice` flag (mirroring how `mirrorSpecialFunction`/`mirrorAction` already default to the local values), so a non-proxy mirrored Device is resettable too — proxying still lets TRMNL's own `reset_firmware` value win when present, since TRMNL owns it for that MAC.
- Adds a `reset device delivery` test block pinning `reset_firmware` across all four response paths (no-screen, cycling, proxy, non-proxy mirror).

Fixes #806.

## Test plan
- [x] `pnpm test` (API) — 733 passed, 5 skipped
- [x] `pnpm run type-check` (API + UI) — clean
- [x] `pnpm run lint` (API) — clean
- [x] New tests in `display.service.spec.ts` cover reset delivery/non-delivery on all four paths

https://claude.ai/code/session_012y2mf776ugMfHon8ceJHJo