### PR TITLE
fix(types): remove any/unsafe casts, enforce ts/no-explicit-any

### DIFF
--- a/packages/api/eslint.config.mjs
+++ b/packages/api/eslint.config.mjs
@@ -13,4 +13,15 @@ export default antfu(
       'ts/consistent-type-imports': 'off',
     },
   },
+  {
+    rules: {
+      'ts/no-explicit-any': 'error',
+    },
+  },
+  {
+    files: ['**/__test__/**', '**/__tests__/**', '**/*.spec.ts'],
+    rules: {
+      'ts/no-explicit-any': 'warn',
+    },
+  },
 )

--- a/packages/api/src/device-models/custom-palettes.service.ts
+++ b/packages/api/src/device-models/custom-palettes.service.ts
@@ -45,7 +45,7 @@ export class CustomPalettesService {
   private assertValid(dto: CreateCustomPaletteDto): void {
     if (!dto.name?.trim())
       throw new BadRequestException('name is required')
-    if (!CUSTOM_PALETTE_FRAMEWORK_CLASSES.includes(dto.frameworkClass as any))
+    if (!CUSTOM_PALETTE_FRAMEWORK_CLASSES.includes(dto.frameworkClass))
       throw new BadRequestException(`frameworkClass must be one of: ${CUSTOM_PALETTE_FRAMEWORK_CLASSES.join(', ')}`)
     if (!Array.isArray(dto.colors) || dto.colors.length === 0 || dto.colors.some(c => !HEX_COLOR_PATTERN.test(c)))
       throw new BadRequestException('colors must be a non-empty array of #RRGGBB hex values')

--- a/packages/api/src/devices/display.service.ts
+++ b/packages/api/src/devices/display.service.ts
@@ -368,12 +368,15 @@ export class DeviceDisplayService {
   }
 
   private async fetchAndStoreMirrorImage(device: Device, proxyHeaders?: DisplayRequestHeadersDto): Promise<{ response: TrmnlScreenResponse, localImageUrl: string }> {
+    if (!device.mirrorMac || !device.mirrorApikey) {
+      throw new Error(`Device ${device.id} has mirroring enabled but is missing a mirror MAC or API key`)
+    }
     const mirrorHeaders = proxyHeaders
       ? { ...proxyHeaders, 'ID': device.mirrorMac, 'access-token': device.mirrorApikey }
       : { 'access-token': device.mirrorApikey, 'ID': device.mirrorMac }
     this.logger.debug(`Sending headers: ${JSON.stringify(mirrorHeaders)}`)
     const res = await fetch(`https://usetrmnl.com/api/${proxyHeaders ? 'display' : 'current_screen'}`, {
-      headers: mirrorHeaders as Record<string, string>,
+      headers: mirrorHeaders,
     })
     const response: TrmnlScreenResponse = await res.json()
     this.logger.debug(`Got this from TRMNL ${JSON.stringify(response)}`)
@@ -515,7 +518,7 @@ export class DeviceDisplayService {
     this.logger.log(`No cache, rendering plugin ${plugin.id} on-demand for screen ${screen.id}`)
 
     const sensors = await this.deviceSensors.findForDevice(device.id)
-    const templateContext: any = this.pluginTemplateContext.build(plugin, sensors)
+    const templateContext = this.pluginTemplateContext.build(plugin, sensors)
 
     // Fetch all of the plugin's data sources in parallel; a source that fails
     // gets an error marker instead of aborting the whole render (ADR-0005)
@@ -530,7 +533,7 @@ export class DeviceDisplayService {
       }),
     )
 
-    const data: Record<string, any> = {}
+    const data: Record<string, unknown> = {}
     results.forEach((result, index) => {
       const name = plugin.dataSources[index].name
       if (result.status === 'fulfilled') {

--- a/packages/api/src/logs/dto/create-log.dto.ts
+++ b/packages/api/src/logs/dto/create-log.dto.ts
@@ -1,3 +1,4 @@
+import type { JsonObject } from '../../utils/json'
 import { IsObject } from 'class-validator'
 
 export class CreateLogDto {
@@ -5,6 +6,6 @@ export class CreateLogDto {
   log: {
     logs_array: Array<{
       log_id: number
-    } & Record<string, any>>
+    } & JsonObject>
   }
 }

--- a/packages/api/src/mashup/services/mashup-renderer.service.ts
+++ b/packages/api/src/mashup/services/mashup-renderer.service.ts
@@ -57,7 +57,7 @@ export class MashupRendererService {
       throw new Error('Plugin missing data sources or templates')
     }
 
-    const templateContext: any = this.pluginTemplateContext.build(plugin, sensors)
+    const templateContext = this.pluginTemplateContext.build(plugin, sensors)
 
     // Fetch all of the plugin's data sources in parallel; a source that fails
     // gets an error marker instead of aborting the whole render (ADR-0005)
@@ -71,7 +71,7 @@ export class MashupRendererService {
       }),
     )
 
-    const data: Record<string, any> = {}
+    const data: Record<string, unknown> = {}
     results.forEach((result, index) => {
       const name = plugin.dataSources[index].name
       data[name] = result.status === 'fulfilled'

--- a/packages/api/src/plugins/__test__/plugin-importer.service.spec.ts
+++ b/packages/api/src/plugins/__test__/plugin-importer.service.spec.ts
@@ -204,6 +204,48 @@ describe('pluginImporterService', () => {
       fs.unlinkSync(tmpPath)
     })
 
+    it('rejects a manifest.yml that is a YAML scalar instead of an object', async () => {
+      const zip = new AdmZip()
+      zip.addFile('.trmnlp.yml', Buffer.from('just a plain string', 'utf8'))
+      zip.addFile('src/settings.yml', Buffer.from(yaml.dump({ endpoint: 'https://api.example.com' }), 'utf8'))
+      zip.addFile('src/full.liquid', Buffer.from('test', 'utf8'))
+
+      const tmpPath = path.join(__dirname, 'test-scalar-manifest.zip')
+      zip.writeZip(tmpPath)
+
+      await expect(service.importFromFile(tmpPath)).rejects.toThrow('Invalid manifest.yml')
+
+      fs.unlinkSync(tmpPath)
+    })
+
+    it('rejects a manifest.yml that is a YAML array instead of an object', async () => {
+      const zip = new AdmZip()
+      zip.addFile('.trmnlp.yml', Buffer.from(yaml.dump(['not', 'an', 'object']), 'utf8'))
+      zip.addFile('src/settings.yml', Buffer.from(yaml.dump({ endpoint: 'https://api.example.com' }), 'utf8'))
+      zip.addFile('src/full.liquid', Buffer.from('test', 'utf8'))
+
+      const tmpPath = path.join(__dirname, 'test-array-manifest.zip')
+      zip.writeZip(tmpPath)
+
+      await expect(service.importFromFile(tmpPath)).rejects.toThrow('Invalid manifest.yml')
+
+      fs.unlinkSync(tmpPath)
+    })
+
+    it('rejects a settings.yml that is a YAML array instead of an object', async () => {
+      const zip = new AdmZip()
+      zip.addFile('.trmnlp.yml', Buffer.from(yaml.dump({ name: 'Test Plugin' }), 'utf8'))
+      zip.addFile('src/settings.yml', Buffer.from(yaml.dump(['not', 'an', 'object']), 'utf8'))
+      zip.addFile('src/full.liquid', Buffer.from('test', 'utf8'))
+
+      const tmpPath = path.join(__dirname, 'test-array-settings.zip')
+      zip.writeZip(tmpPath)
+
+      await expect(service.importFromFile(tmpPath)).rejects.toThrow('Invalid settings.yml')
+
+      fs.unlinkSync(tmpPath)
+    })
+
     it('parses plugin with Terminus-style settings', async () => {
       const zip = new AdmZip()
 

--- a/packages/api/src/plugins/__test__/plugin-transform.service.spec.ts
+++ b/packages/api/src/plugins/__test__/plugin-transform.service.spec.ts
@@ -15,7 +15,7 @@ describe('pluginTransformService', () => {
       };
     `
     const rawData = { value: 42 }
-    const result = service.transform(transformJs, rawData)
+    const result = service.transform(transformJs, rawData) as Record<string, any>
 
     expect(result.transformed).toBe(true)
     expect(result.original).toEqual({ value: 42 })
@@ -28,7 +28,7 @@ describe('pluginTransformService', () => {
       }
     `
     const rawData = { value: 10 }
-    const result = service.transform(transformJs, rawData)
+    const result = service.transform(transformJs, rawData) as Record<string, any>
 
     expect(result.doubled).toBe(20)
   })
@@ -55,7 +55,7 @@ describe('pluginTransformService', () => {
       };
     `
     const rawData = { items: [{ id: 1 }, { id: 2 }] }
-    const result = service.transform(transformJs, rawData)
+    const result = service.transform(transformJs, rawData) as Record<string, any>
 
     expect(result.items).toHaveLength(2)
     expect(result.items[0].processed).toBe(true)
@@ -95,7 +95,7 @@ describe('pluginTransformService', () => {
       };
     `
     const rawData = { value: 42 }
-    const result = service.transform(transformJs, rawData)
+    const result = service.transform(transformJs, rawData) as Record<string, any>
 
     expect(result.logged).toBe(true)
   })

--- a/packages/api/src/plugins/__test__/plugin-variable-resolver.service.spec.ts
+++ b/packages/api/src/plugins/__test__/plugin-variable-resolver.service.spec.ts
@@ -117,6 +117,23 @@ describe('pluginVariableResolverService', () => {
       expect(result.data).toBe(null)
     })
 
+    it('resolves variables inside array values without mangling the array into an object', () => {
+      const obj = {
+        tags: ['{{ API_KEY }}', 'static', 5],
+      }
+      const result = service.resolveInObject(obj, variables)
+      expect(Array.isArray(result.tags)).toBe(true)
+      expect(result.tags).toEqual(['secret-key-123', 'static', 5])
+    })
+
+    it('resolves variables inside objects nested within arrays', () => {
+      const obj = {
+        headers: [{ token: '{{ API_KEY }}' }],
+      }
+      const result = service.resolveInObject(obj, variables)
+      expect(result.headers).toEqual([{ token: 'secret-key-123' }])
+    })
+
     it('handles mixed types in object', () => {
       const obj = {
         // eslint-disable-next-line no-template-curly-in-string

--- a/packages/api/src/plugins/dto/__test__/create-plugin.dto.spec.ts
+++ b/packages/api/src/plugins/dto/__test__/create-plugin.dto.spec.ts
@@ -1,11 +1,19 @@
+import type { ValidationError } from 'class-validator'
 import { plainToInstance } from 'class-transformer'
 import { validate } from 'class-validator'
 import { describe, expect, it } from 'vitest'
 import { CreatePluginDto } from '../create-plugin.dto'
 
+function flattenConstraints(errors: ValidationError[]): string[] {
+  return errors.flatMap(error => [
+    ...Object.values(error.constraints ?? {}),
+    ...flattenConstraints(error.children ?? []),
+  ])
+}
+
 async function violations(payload: Record<string, any>): Promise<string[]> {
   const errors = await validate(plainToInstance(CreatePluginDto, payload))
-  return errors.flatMap(error => Object.values(error.constraints ?? {}))
+  return flattenConstraints(errors)
 }
 
 describe('create-plugin dto', () => {
@@ -55,6 +63,24 @@ describe('create-plugin dto', () => {
 
     expect(dto.fields).toHaveLength(1)
     expect(dto.fields?.[0].keyname).toBe('api_key')
+  })
+
+  describe('nested dataSources validation', () => {
+    it('rejects a data source with a non-string url', async () => {
+      const payload = { name: 'Weather Plugin', dataSources: [{ name: 'weather', url: 123, method: 'GET' }] }
+
+      const errors = await violations(payload)
+
+      expect(errors.some(message => message.includes('url must be a string'))).toBe(true)
+    })
+
+    it('rejects a data source missing a name', async () => {
+      const payload = { name: 'Weather Plugin', dataSources: [{ url: 'https://api.example.com', method: 'GET' }] }
+
+      const errors = await violations(payload)
+
+      expect(errors.some(message => message.includes('name must be a string'))).toBe(true)
+    })
   })
 
   describe('plugin kind', () => {

--- a/packages/api/src/plugins/dto/__test__/update-device-assignment.dto.spec.ts
+++ b/packages/api/src/plugins/dto/__test__/update-device-assignment.dto.spec.ts
@@ -1,0 +1,32 @@
+import { plainToInstance } from 'class-transformer'
+import { validate } from 'class-validator'
+import { describe, expect, it } from 'vitest'
+import { UpdateDeviceAssignmentDto } from '../update-device-assignment.dto'
+
+async function violations(payload: Record<string, unknown>): Promise<string[]> {
+  const errors = await validate(plainToInstance(UpdateDeviceAssignmentDto, payload), {
+    whitelist: true,
+    forbidNonWhitelisted: true,
+  })
+  return errors.flatMap(error => Object.values(error.constraints ?? {}))
+}
+
+describe('update-device-assignment dto', () => {
+  it('accepts isActive and order alone', async () => {
+    expect(await violations({ isActive: false })).toEqual([])
+    expect(await violations({ order: 3 })).toEqual([])
+    expect(await violations({ isActive: true, order: 0 })).toEqual([])
+  })
+
+  it('rejects a body carrying fields outside isActive/order, matching the mass-assignment guard on the route', async () => {
+    const errors = await violations({ id: 'other-device-plugin', order: 3 })
+
+    expect(errors.some(message => message.includes('should not exist'))).toBe(true)
+  })
+
+  it('rejects an attempt to smuggle a plugin/device relation through the update', async () => {
+    const errors = await violations({ plugin: { id: 'other-plugin' } })
+
+    expect(errors.some(message => message.includes('should not exist'))).toBe(true)
+  })
+})

--- a/packages/api/src/plugins/dto/__test__/update-plugin.dto.spec.ts
+++ b/packages/api/src/plugins/dto/__test__/update-plugin.dto.spec.ts
@@ -1,11 +1,19 @@
+import type { ValidationError } from 'class-validator'
 import { plainToInstance } from 'class-transformer'
 import { validate } from 'class-validator'
 import { describe, expect, it } from 'vitest'
 import { UpdatePluginDto } from '../update-plugin.dto'
 
+function flattenConstraints(errors: ValidationError[]): string[] {
+  return errors.flatMap(error => [
+    ...Object.values(error.constraints ?? {}),
+    ...flattenConstraints(error.children ?? []),
+  ])
+}
+
 async function violations(payload: Record<string, any>): Promise<string[]> {
   const errors = await validate(plainToInstance(UpdatePluginDto, payload))
-  return errors.flatMap(error => Object.values(error.constraints ?? {}))
+  return flattenConstraints(errors)
 }
 
 describe('update-plugin dto', () => {
@@ -53,6 +61,14 @@ describe('update-plugin dto', () => {
 
     expect(dto.fields).toHaveLength(1)
     expect(dto.fields?.[0].keyname).toBe('new_field')
+  })
+
+  describe('nested dataSources validation', () => {
+    it('rejects a data source with a non-string url', async () => {
+      const errors = await violations({ dataSources: [{ name: 'weather', url: 123, method: 'GET' }] })
+
+      expect(errors.some(message => message.includes('url must be a string'))).toBe(true)
+    })
   })
 
   describe('webhook fields', () => {

--- a/packages/api/src/plugins/dto/create-plugin.dto.ts
+++ b/packages/api/src/plugins/dto/create-plugin.dto.ts
@@ -1,8 +1,12 @@
 import type { ValidationArguments, ValidationOptions, ValidatorConstraintInterface } from 'class-validator'
 import type { MergeStrategy, PluginKind } from '../entities/plugin.entity'
-import { IsBoolean, IsIn, IsInt, IsOptional, IsString, Min, registerDecorator, ValidatorConstraint } from 'class-validator'
+import { Type } from 'class-transformer'
+import { IsArray, IsBoolean, IsIn, IsInt, IsOptional, IsString, Min, registerDecorator, ValidateNested, ValidatorConstraint } from 'class-validator'
 import { MERGE_STRATEGIES, PLUGIN_KINDS } from '../entities/plugin.entity'
 import { pluginKindFieldViolation } from '../plugin-kind-fields'
+import { PluginDataSourceDto } from './plugin-data-source.dto'
+import { PluginFieldDto } from './plugin-field.dto'
+import { PluginTemplateDto } from './plugin-template.dto'
 
 @ValidatorConstraint({ name: 'pluginKindFields' })
 class PluginKindFieldsConstraint implements ValidatorConstraintInterface {
@@ -79,11 +83,20 @@ export class CreatePluginDto {
   sourceRecipeId?: string
 
   @IsOptional()
-  dataSources?: any[]
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => PluginDataSourceDto)
+  dataSources?: PluginDataSourceDto[]
 
   @IsOptional()
-  templates?: any[]
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => PluginTemplateDto)
+  templates?: PluginTemplateDto[]
 
   @IsOptional()
-  fields?: any[]
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => PluginFieldDto)
+  fields?: PluginFieldDto[]
 }

--- a/packages/api/src/plugins/dto/plugin-data-source.dto.ts
+++ b/packages/api/src/plugins/dto/plugin-data-source.dto.ts
@@ -1,0 +1,30 @@
+import type { JsonObject } from '../../utils/json'
+import { IsInt, IsObject, IsOptional, IsString } from 'class-validator'
+
+export class PluginDataSourceDto {
+  @IsString()
+  name: string
+
+  @IsOptional()
+  @IsString()
+  method?: string
+
+  @IsString()
+  url: string
+
+  @IsOptional()
+  @IsObject()
+  headers?: Record<string, string>
+
+  @IsOptional()
+  @IsObject()
+  body?: JsonObject
+
+  @IsOptional()
+  @IsString()
+  transformJs?: string | null
+
+  @IsOptional()
+  @IsInt()
+  order?: number
+}

--- a/packages/api/src/plugins/dto/plugin-field.dto.ts
+++ b/packages/api/src/plugins/dto/plugin-field.dto.ts
@@ -1,0 +1,29 @@
+import { IsBoolean, IsInt, IsOptional, IsString } from 'class-validator'
+
+export class PluginFieldDto {
+  @IsString()
+  keyname: string
+
+  @IsOptional()
+  @IsString()
+  fieldType?: string
+
+  @IsString()
+  name: string
+
+  @IsOptional()
+  @IsString()
+  description?: string
+
+  @IsOptional()
+  @IsString()
+  defaultValue?: string
+
+  @IsOptional()
+  @IsBoolean()
+  required?: boolean
+
+  @IsOptional()
+  @IsInt()
+  order?: number
+}

--- a/packages/api/src/plugins/dto/plugin-template.dto.ts
+++ b/packages/api/src/plugins/dto/plugin-template.dto.ts
@@ -1,0 +1,10 @@
+import { IsOptional, IsString } from 'class-validator'
+
+export class PluginTemplateDto {
+  @IsOptional()
+  @IsString()
+  layout?: string
+
+  @IsString()
+  liquidMarkup: string
+}

--- a/packages/api/src/plugins/dto/preview-plugin.dto.ts
+++ b/packages/api/src/plugins/dto/preview-plugin.dto.ts
@@ -1,0 +1,41 @@
+import type { JsonObject } from '../../utils/json'
+import { Type } from 'class-transformer'
+import { IsArray, IsObject, IsOptional, IsString, ValidateNested } from 'class-validator'
+
+export class PreviewSourceDto {
+  @IsString()
+  name: string
+
+  @IsString()
+  url: string
+
+  @IsString()
+  method: string
+
+  @IsOptional()
+  @IsObject()
+  headers?: Record<string, string>
+
+  @IsOptional()
+  @IsObject()
+  body?: JsonObject
+
+  @IsOptional()
+  @IsString()
+  transformJs?: string
+}
+
+export class PreviewPluginDto {
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => PreviewSourceDto)
+  sources: PreviewSourceDto[]
+
+  @IsOptional()
+  @IsString()
+  template?: string
+
+  @IsOptional()
+  @IsObject()
+  fieldValues?: Record<string, string>
+}

--- a/packages/api/src/plugins/dto/update-device-assignment.dto.ts
+++ b/packages/api/src/plugins/dto/update-device-assignment.dto.ts
@@ -1,0 +1,12 @@
+import { IsBoolean, IsInt, IsOptional, Min } from 'class-validator'
+
+export class UpdateDeviceAssignmentDto {
+  @IsOptional()
+  @IsBoolean()
+  isActive?: boolean
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  order?: number
+}

--- a/packages/api/src/plugins/dto/update-plugin.dto.ts
+++ b/packages/api/src/plugins/dto/update-plugin.dto.ts
@@ -1,6 +1,10 @@
 import type { MergeStrategy, PluginKind } from '../entities/plugin.entity'
-import { IsBoolean, IsIn, IsInt, IsOptional, IsString, Min } from 'class-validator'
+import { Type } from 'class-transformer'
+import { IsArray, IsBoolean, IsIn, IsInt, IsOptional, IsString, Min, ValidateNested } from 'class-validator'
 import { MERGE_STRATEGIES, PLUGIN_KINDS } from '../entities/plugin.entity'
+import { PluginDataSourceDto } from './plugin-data-source.dto'
+import { PluginFieldDto } from './plugin-field.dto'
+import { PluginTemplateDto } from './plugin-template.dto'
 
 export class UpdatePluginDto {
   @IsOptional()
@@ -41,11 +45,20 @@ export class UpdatePluginDto {
   streamLimit?: number
 
   @IsOptional()
-  dataSources?: any[]
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => PluginDataSourceDto)
+  dataSources?: PluginDataSourceDto[]
 
   @IsOptional()
-  templates?: any[]
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => PluginTemplateDto)
+  templates?: PluginTemplateDto[]
 
   @IsOptional()
-  fields?: any[]
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => PluginFieldDto)
+  fields?: PluginFieldDto[]
 }

--- a/packages/api/src/plugins/entities/plugin-data-source.entity.ts
+++ b/packages/api/src/plugins/entities/plugin-data-source.entity.ts
@@ -1,3 +1,4 @@
+import type { JsonObject } from '../../utils/json'
 import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm'
 import { Plugin } from './plugin.entity'
 
@@ -19,10 +20,10 @@ export class PluginDataSource {
   headers?: Record<string, string>
 
   @Column('jsonb', { nullable: true })
-  body?: Record<string, any>
+  body?: JsonObject
 
   @Column('text', { nullable: true })
-  transformJs?: string
+  transformJs?: string | null
 
   @Column('int', { default: 0 })
   order: number = 0

--- a/packages/api/src/plugins/entities/plugin.entity.ts
+++ b/packages/api/src/plugins/entities/plugin.entity.ts
@@ -11,7 +11,10 @@ export type PluginKind = typeof PLUGIN_KINDS[number]
 export const MERGE_STRATEGIES = ['standard', 'deep_merge', 'stream'] as const
 export type MergeStrategy = typeof MERGE_STRATEGIES[number]
 
-export type WebhookPayload = Record<string, any> | any[] | null
+// A plain object, array, or null — modeled shallowly (rather than as a fully
+// recursive JSON type) because TypeORM's DeepPartial mapping over a
+// self-referential union here blows past TS's recursion limit (TS2589).
+export type WebhookPayload = Record<string, unknown> | unknown[] | null
 
 @Entity()
 export class Plugin {
@@ -69,4 +72,10 @@ export class Plugin {
 
   @OneToMany('PluginVariable', 'plugin')
   variables: PluginVariable[]
+}
+
+export type DevicePluginView = Plugin & {
+  _devicePluginId: string
+  _isActive: boolean
+  _order: number
 }

--- a/packages/api/src/plugins/guards/webhook-plugin.guard.ts
+++ b/packages/api/src/plugins/guards/webhook-plugin.guard.ts
@@ -6,7 +6,7 @@ import { Injectable, UnauthorizedException } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
 import { Plugin as PluginEntity } from '../entities/plugin.entity'
 
-export interface WebhookRequest extends Request {
+export interface WebhookRequest extends Request<{ token: string }> {
   plugin: Plugin
 }
 
@@ -19,7 +19,7 @@ export class WebhookPluginGuard implements CanActivate {
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest<WebhookRequest>()
-    const token = request.params?.token as string | undefined
+    const token = request.params?.token
 
     if (!token) {
       throw new UnauthorizedException('Invalid webhook token')

--- a/packages/api/src/plugins/plugins.controller.ts
+++ b/packages/api/src/plugins/plugins.controller.ts
@@ -4,6 +4,8 @@ import { FileInterceptor } from '@nestjs/platform-express'
 import { diskStorage } from 'multer'
 import { AssignPluginToDeviceDto } from './dto/assign-plugin-to-device.dto'
 import { CreatePluginDto } from './dto/create-plugin.dto'
+import { PreviewPluginDto } from './dto/preview-plugin.dto'
+import { UpdateDeviceAssignmentDto } from './dto/update-device-assignment.dto'
 import { UpdatePluginDto } from './dto/update-plugin.dto'
 import { PluginsService } from './plugins.service'
 import { PluginExporterService } from './services/plugin-exporter.service'
@@ -18,7 +20,8 @@ export class PluginsController {
   ) {}
 
   @Post('preview')
-  async preview(@Body() previewData: { sources: Array<{ name: string, url: string, method: string, headers?: Record<string, string>, body?: any, transformJs?: string }>, template: string, fieldValues?: Record<string, string> }) {
+  @UsePipes(new ValidationPipe({ transform: true }))
+  async preview(@Body() previewData: PreviewPluginDto) {
     return this.pluginsService.preview(previewData.sources, previewData.template, previewData.fieldValues)
   }
 
@@ -38,13 +41,13 @@ export class PluginsController {
   }
 
   @Post()
-  @UsePipes(new ValidationPipe({ transform: true }))
+  @UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
   async create(@Body() createPluginDto: CreatePluginDto) {
     return this.pluginsService.create(createPluginDto)
   }
 
   @Patch(':id')
-  @UsePipes(new ValidationPipe({ transform: true }))
+  @UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
   async update(@Param('id') id: string, @Body() updatePluginDto: UpdatePluginDto) {
     return this.pluginsService.update(id, updatePluginDto)
   }
@@ -153,7 +156,8 @@ export class PluginsController {
   }
 
   @Patch('device-assignment/:devicePluginId')
-  async updateDeviceAssignment(@Param('devicePluginId') devicePluginId: string, @Body() updates: any) {
+  @UsePipes(new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true }))
+  async updateDeviceAssignment(@Param('devicePluginId') devicePluginId: string, @Body() updates: UpdateDeviceAssignmentDto) {
     return this.pluginsService.updateDeviceAssignment(devicePluginId, updates)
   }
 }

--- a/packages/api/src/plugins/plugins.service.ts
+++ b/packages/api/src/plugins/plugins.service.ts
@@ -1,11 +1,17 @@
 import type { MashupSlot } from '../mashup/entities/mashup-slot.entity'
 import type { AssignPluginToDeviceDto } from './dto/assign-plugin-to-device.dto'
+import type { CreatePluginDto } from './dto/create-plugin.dto'
+import type { PreviewSourceDto } from './dto/preview-plugin.dto'
+import type { UpdateDeviceAssignmentDto } from './dto/update-device-assignment.dto'
+import type { UpdatePluginDto } from './dto/update-plugin.dto'
+import type { DevicePluginView } from './entities/plugin.entity'
 import type { PluginKindFields } from './plugin-kind-fields'
 import { BadRequestException, Injectable, Logger, NotFoundException, OnModuleInit } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
 import { Repository } from 'typeorm'
 import { Screen } from '../screens/screens.entity'
 import generateApikey from '../utils/generateApikey'
+import { getErrorMessage } from '../utils/getErrorMessage'
 import { DevicePlugin } from './entities/device-plugin.entity'
 import { PluginDataSource } from './entities/plugin-data-source.entity'
 import { PluginField } from './entities/plugin-field.entity'
@@ -84,7 +90,7 @@ export class PluginsService implements OnModuleInit {
     })
   }
 
-  async findByDevice(deviceId: string): Promise<Plugin[]> {
+  async findByDevice(deviceId: string): Promise<DevicePluginView[]> {
     const devicePlugins = await this.devicePluginRepository.find({
       where: { device: { id: deviceId } },
       relations: { plugin: { dataSources: true, templates: true, fields: true } },
@@ -96,13 +102,13 @@ export class PluginsService implements OnModuleInit {
       _devicePluginId: dp.id,
       _isActive: dp.isActive,
       _order: dp.order,
-    })) as any
+    }))
   }
 
   async assignToDevice(pluginId: string, assignData: AssignPluginToDeviceDto): Promise<DevicePlugin> {
     const devicePlugin = this.devicePluginRepository.create({
-      plugin: { id: pluginId } as Plugin,
-      device: { id: assignData.deviceId } as any,
+      plugin: { id: pluginId },
+      device: { id: assignData.deviceId },
       isActive: assignData.isActive ?? true,
       order: assignData.order ?? 0,
     })
@@ -112,8 +118,8 @@ export class PluginsService implements OnModuleInit {
     const maxOrder = await this.screenRepository.maximum('order', { device: { id: assignData.deviceId } }) || 0
     const screen = this.screenRepository.create({
       type: 'plugin',
-      device: { id: assignData.deviceId } as any,
-      plugin: { id: pluginId } as Plugin,
+      device: { id: assignData.deviceId },
+      plugin: { id: pluginId },
       devicePluginId: saved.id,
       isActive: assignData.isActive ?? true,
       order: maxOrder + 1,
@@ -139,7 +145,7 @@ export class PluginsService implements OnModuleInit {
     return true
   }
 
-  async updateDeviceAssignment(devicePluginId: string, updates: Partial<DevicePlugin>): Promise<DevicePlugin | null> {
+  async updateDeviceAssignment(devicePluginId: string, updates: UpdateDeviceAssignmentDto): Promise<DevicePlugin | null> {
     const devicePlugin = await this.devicePluginRepository.findOneBy({ id: devicePluginId })
     if (!devicePlugin)
       return null
@@ -157,8 +163,8 @@ export class PluginsService implements OnModuleInit {
     return saved
   }
 
-  async create(pluginData: Partial<Plugin>): Promise<Plugin> {
-    const { dataSources, templates, fields, ...basicFields } = pluginData as any
+  async create(pluginData: CreatePluginDto): Promise<Plugin> {
+    const { dataSources, templates, fields, ...basicFields } = pluginData
 
     this.logger.debug(`Creating plugin with data: ${JSON.stringify({ dataSources, templates, fields, basicFields })}`)
 
@@ -260,7 +266,7 @@ export class PluginsService implements OnModuleInit {
     return created
   }
 
-  async update(id: string, pluginData: Partial<Plugin>): Promise<Plugin | null> {
+  async update(id: string, pluginData: UpdatePluginDto): Promise<Plugin | null> {
     const plugin = await this.pluginRepository.findOne({
       where: { id },
       relations: { dataSources: true, templates: true, fields: true },
@@ -268,7 +274,7 @@ export class PluginsService implements OnModuleInit {
     if (!plugin)
       return null
 
-    const { dataSources, templates, fields, webhookToken, webhookPayload, ...basicFields } = pluginData as any
+    const { dataSources, templates, fields, webhookToken, ...basicFields } = pluginData
 
     if ('kind' in basicFields && basicFields.kind !== plugin.kind) {
       throw new BadRequestException(`A Plugin's Kind is fixed at creation and cannot be changed`)
@@ -291,12 +297,7 @@ export class PluginsService implements OnModuleInit {
       streamLimit,
     })
 
-    if (plugin.kind === 'Webhook') {
-      basicFields.mergeStrategy = mergeStrategy
-      basicFields.streamLimit = streamLimit ?? null
-    }
-
-    Object.assign(plugin, basicFields)
+    Object.assign(plugin, basicFields, plugin.kind === 'Webhook' ? { mergeStrategy, streamLimit: streamLimit ?? null } : {})
 
     if (dataSources !== undefined) {
       if (plugin.dataSources && plugin.dataSources.length > 0) {
@@ -479,9 +480,9 @@ export class PluginsService implements OnModuleInit {
     return true
   }
 
-  async preview(sources: Array<{ name: string, url: string, method: string, headers?: Record<string, string>, body?: any, transformJs?: string }>, template?: string, fieldValues?: Record<string, string>): Promise<{ html: string, data: Record<string, any> }> {
+  async preview(sources: PreviewSourceDto[], template?: string, fieldValues?: Record<string, string>): Promise<{ html: string, data: Record<string, unknown> }> {
     // Build template context with trmnl system variables and plugin field values
-    const templateContext: any = {
+    const templateContext: Record<string, unknown> = {
       trmnl: {
         system: {
           timestamp_utc: Math.floor(Date.now() / 1000),
@@ -515,19 +516,20 @@ export class PluginsService implements OnModuleInit {
       }),
     )
 
-    const data: Record<string, any> = {}
+    const data: Record<string, unknown> = {}
     results.forEach((result, index) => {
       const name = sources[index].name
       if (result.status === 'fulfilled') {
         data[name] = result.value
       }
       else {
-        this.logger.warn(`Data source "${name}" failed during preview: ${result.reason?.message || result.reason}`)
-        data[name] = { error: true, message: result.reason?.message || String(result.reason) }
+        const message = getErrorMessage(result.reason)
+        this.logger.warn(`Data source "${name}" failed during preview: ${message}`)
+        data[name] = { error: true, message }
       }
     })
 
-    const templateData: any = { ...templateContext, ...data }
+    const templateData: Record<string, unknown> = { ...templateContext, ...data }
 
     const html = template ? await this.renderer.render(template, templateData) : ''
     return { html, data }

--- a/packages/api/src/plugins/services/plugin-data-fetcher.service.ts
+++ b/packages/api/src/plugins/services/plugin-data-fetcher.service.ts
@@ -1,3 +1,4 @@
+import type { JsonObject } from '../../utils/json'
 import { Injectable, Logger } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import { assertPublicUrl } from '../../utils/ssrfGuard'
@@ -16,9 +17,9 @@ export class PluginDataFetcherService {
     method: string,
     url: string,
     headers: Record<string, string> = {},
-    body?: Record<string, any>,
-    templateContext?: Record<string, any>,
-  ): Promise<any> {
+    body?: JsonObject,
+    templateContext?: object,
+  ): Promise<unknown> {
     let resolvedUrl = url
 
     // If URL contains Liquid template syntax, render it first

--- a/packages/api/src/plugins/services/plugin-importer.service.ts
+++ b/packages/api/src/plugins/services/plugin-importer.service.ts
@@ -1,17 +1,27 @@
+import type { JsonObject } from '../../utils/json'
 import type { PluginKind } from '../entities/plugin.entity'
 import { Buffer } from 'node:buffer'
 import * as fs from 'node:fs'
 import * as path from 'node:path'
-import { Injectable, Logger } from '@nestjs/common'
+import { BadRequestException, Injectable, Logger } from '@nestjs/common'
 import AdmZip from 'adm-zip'
 import * as yaml from 'js-yaml'
+import { isPlainObject } from '../../utils/json'
 import { resolveAppPath } from '../../utils/pathHelper'
 
+function parseYamlObject<T>(content: string, invalidMessage: string): T {
+  const parsed: unknown = yaml.load(content)
+  if (!isPlainObject(parsed)) {
+    throw new BadRequestException(invalidMessage)
+  }
+  return parsed as T
+}
+
 interface TerminusManifest {
-  name: string
+  name?: string
   description?: string
   custom_fields?: CustomField[]
-  variables?: Record<string, any>
+  variables?: JsonObject
 }
 
 interface CustomField {
@@ -28,7 +38,7 @@ interface DataSourceEntry {
   endpoint?: string
   method?: string
   headers?: Record<string, string>
-  body?: Record<string, any>
+  body?: JsonObject
   transform_js?: string
 }
 
@@ -36,7 +46,7 @@ interface TerminusSettings {
   // Standard fields
   name?: string
   refresh_interval?: number
-  custom_fields?: CustomField[] | Record<string, any>
+  custom_fields?: CustomField[] | JsonObject
 
   // Kuroshiro's own multi-source round-trip format (issue #776)
   data_sources?: DataSourceEntry[]
@@ -47,7 +57,7 @@ interface TerminusSettings {
   endpoint?: string
   method?: string
   headers?: Record<string, string>
-  body?: Record<string, any>
+  body?: JsonObject
 
   // Actual Terminus format
   polling_url?: string
@@ -69,7 +79,7 @@ interface ParsedDataSource {
   method: string
   url: string
   headers?: Record<string, string>
-  body?: Record<string, any>
+  body?: JsonObject
   transformJs?: string | null
 }
 
@@ -209,8 +219,8 @@ export class PluginImporterService {
     const manifestContent = manifestEntry.getData().toString('utf8')
     const settingsContent = settingsEntry.getData().toString('utf8')
 
-    const manifest = yaml.load(manifestContent) as TerminusManifest
-    const settings = yaml.load(settingsContent) as TerminusSettings
+    const manifest = parseYamlObject<TerminusManifest>(manifestContent, 'Invalid manifest.yml')
+    const settings = parseYamlObject<TerminusSettings>(settingsContent, 'Invalid settings.yml')
 
     // Extract transform.js if it exists (used to process API data)
     const transformEntry = zipEntries.find(entry =>
@@ -306,7 +316,7 @@ export class PluginImporterService {
     }
 
     const settingsContent = settingsEntry.getData().toString('utf8')
-    const recipeSettings = yaml.load(settingsContent) as RecipeSettings
+    const recipeSettings = parseYamlObject<RecipeSettings>(settingsContent, 'Invalid settings.yml')
 
     if (recipeSettings.oauth_enabled) {
       throw new Error('OAuth recipes aren\'t supported yet')
@@ -356,7 +366,7 @@ export class PluginImporterService {
 
   private async importFromYaml(yamlPath: string, fallbackName: string): Promise<ParsedPlugin> {
     const content = await fs.promises.readFile(yamlPath, 'utf8')
-    const manifest = yaml.load(content) as TerminusManifest
+    const manifest = parseYamlObject<TerminusManifest>(content, 'Invalid manifest.yml')
 
     const dirName = path.dirname(yamlPath)
     const settingsPath = path.join(dirName, 'src', 'settings.yml')
@@ -366,7 +376,7 @@ export class PluginImporterService {
     }
 
     const settingsContent = await fs.promises.readFile(settingsPath, 'utf8')
-    const settings = yaml.load(settingsContent) as TerminusSettings
+    const settings = parseYamlObject<TerminusSettings>(settingsContent, 'Invalid settings.yml')
 
     const srcDir = path.join(dirName, 'src')
     const templates: Array<{ layout: string, liquidMarkup: string }> = []

--- a/packages/api/src/plugins/services/plugin-render-cache.service.ts
+++ b/packages/api/src/plugins/services/plugin-render-cache.service.ts
@@ -28,12 +28,12 @@ export class PluginRenderCacheService {
     }, 0)
   }
 
-  async renderAndCache(plugin: Plugin, data: any): Promise<void> {
+  async renderAndCache(plugin: Plugin, data: object | null): Promise<void> {
     if (!plugin.templates || plugin.templates.length === 0) {
       return
     }
 
-    const rendered = await this.renderer.render(plugin.templates[0].liquidMarkup, data)
+    const rendered = await this.renderer.render(plugin.templates[0].liquidMarkup, data ?? {})
 
     await this.screenRepository.update(
       { plugin: { id: plugin.id } },

--- a/packages/api/src/plugins/services/plugin-renderer.service.ts
+++ b/packages/api/src/plugins/services/plugin-renderer.service.ts
@@ -12,27 +12,27 @@ export class PluginRendererService {
 
   private registerCustomFilters() {
     // Date formatting filters
-    this.liquid.registerFilter('date_short', (date: any) => {
-      const d = new Date(date)
+    this.liquid.registerFilter('date_short', (date: unknown) => {
+      const d = new Date(date as string | number | Date)
       return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
     })
 
-    this.liquid.registerFilter('date_long', (date: any) => {
-      const d = new Date(date)
+    this.liquid.registerFilter('date_long', (date: unknown) => {
+      const d = new Date(date as string | number | Date)
       return d.toLocaleDateString('en-US', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' })
     })
 
-    this.liquid.registerFilter('time_short', (date: any) => {
-      const d = new Date(date)
+    this.liquid.registerFilter('time_short', (date: unknown) => {
+      const d = new Date(date as string | number | Date)
       return d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })
     })
 
     // Number formatting
-    this.liquid.registerFilter('number_with_delimiter', (num: any) => {
+    this.liquid.registerFilter('number_with_delimiter', (num: unknown) => {
       return Number(num).toLocaleString('en-US')
     })
 
-    this.liquid.registerFilter('round', (num: any, precision = 0) => {
+    this.liquid.registerFilter('round', (num: unknown, precision = 0) => {
       return Number(num).toFixed(precision)
     })
 
@@ -51,7 +51,7 @@ export class PluginRendererService {
     })
 
     // Array helpers
-    this.liquid.registerFilter('shuffle', (arr: any[]) => {
+    this.liquid.registerFilter('shuffle', (arr: unknown[]) => {
       const shuffled = [...arr]
       for (let i = shuffled.length - 1; i > 0; i--) {
         const j = Math.floor(Math.random() * (i + 1));
@@ -60,32 +60,32 @@ export class PluginRendererService {
       return shuffled
     })
 
-    this.liquid.registerFilter('sample', (arr: any[], count = 1) => {
+    this.liquid.registerFilter('sample', (arr: unknown[], count = 1) => {
       const shuffled = [...arr].sort(() => Math.random() - 0.5)
       return count === 1 ? shuffled[0] : shuffled.slice(0, count)
     })
 
     // Boolean helpers
-    this.liquid.registerFilter('yesno', (value: any, yes = 'Yes', no = 'No') => {
+    this.liquid.registerFilter('yesno', (value: unknown, yes = 'Yes', no = 'No') => {
       return value ? yes : no
     })
 
     // JSON serialization (used by TRMNL plugins)
-    this.liquid.registerFilter('json', (value: any) => {
+    this.liquid.registerFilter('json', (value: unknown) => {
       return JSON.stringify(value)
     })
 
     // URL encoding
-    this.liquid.registerFilter('url_encode', (value: any) => {
+    this.liquid.registerFilter('url_encode', (value: unknown) => {
       return encodeURIComponent(String(value))
     })
 
-    this.liquid.registerFilter('url_decode', (value: any) => {
+    this.liquid.registerFilter('url_decode', (value: unknown) => {
       return decodeURIComponent(String(value))
     })
   }
 
-  async render(template: string, data: Record<string, any>): Promise<string> {
+  async render(template: string, data: object): Promise<string> {
     return this.liquid.parseAndRender(template, data)
   }
 }

--- a/packages/api/src/plugins/services/plugin-scheduler.service.ts
+++ b/packages/api/src/plugins/services/plugin-scheduler.service.ts
@@ -33,7 +33,7 @@ export class PluginSchedulerService {
         // This cache entry is shared across every Screen/Device the Plugin is
         // assigned to (renderAndCache below writes it to all of them), so
         // there is no single Device to scope sensors to here.
-        const templateContext: any = this.pluginTemplateContext.build(plugin, [])
+        const templateContext = this.pluginTemplateContext.build(plugin, [])
 
         // Fetch all of the plugin's data sources in parallel; a source that fails
         // gets an error marker instead of aborting the whole render (ADR-0005)
@@ -43,7 +43,7 @@ export class PluginSchedulerService {
           ),
         )
 
-        const sourceData: Record<string, any> = {}
+        const sourceData: Record<string, unknown> = {}
         results.forEach((result, index) => {
           const name = plugin.dataSources[index].name
           if (result.status === 'fulfilled') {

--- a/packages/api/src/plugins/services/plugin-template-context.service.ts
+++ b/packages/api/src/plugins/services/plugin-template-context.service.ts
@@ -2,6 +2,15 @@ import type { DeviceSensor } from '../../device-sensors/entities/device-sensor.e
 import type { Plugin } from '../entities/plugin.entity'
 import { Injectable } from '@nestjs/common'
 
+export interface PluginTemplateContext {
+  trmnl: {
+    system: { timestamp_utc: number }
+    plugin_settings: { instance_name: string, strategy: 'polling', dark_mode: 'no' | 'yes', no_screen_padding: 'no' | 'yes' }
+    user: { id: string, locale: string }
+  }
+  sensors: Record<string, { value: number, unit: string }>
+}
+
 /**
  * Base Liquid template context: the `trmnl` system object plus an implicit
  * `sensors` object keyed by kind (ADR-0018) for whichever kinds the rendering
@@ -10,7 +19,7 @@ import { Injectable } from '@nestjs/common'
  */
 @Injectable()
 export class PluginTemplateContextService {
-  build(plugin: Plugin, sensors: DeviceSensor[]): Record<string, any> {
+  build(plugin: Plugin, sensors: DeviceSensor[]): PluginTemplateContext {
     return {
       trmnl: {
         system: {

--- a/packages/api/src/plugins/services/plugin-transform.service.ts
+++ b/packages/api/src/plugins/services/plugin-transform.service.ts
@@ -10,7 +10,7 @@ export class PluginTransformService {
    * Execute transform.js on fetched data
    * Runs in a sandboxed VM to prevent malicious code execution
    */
-  transform(transformJs: string, rawData: any): any {
+  transform(transformJs: string, rawData: unknown): unknown {
     try {
       // Provide module and exports objects for Terminus compatibility
       const moduleObj = { exports: {} }
@@ -23,7 +23,7 @@ export class PluginTransformService {
           module: moduleObj,
           exports: moduleObj.exports,
           console: {
-            log: (...args: any[]) => this.logger.debug(`[Transform] ${args.join(' ')}`),
+            log: (...args: unknown[]) => this.logger.debug(`[Transform] ${args.join(' ')}`),
           },
         },
       })

--- a/packages/api/src/plugins/services/plugin-variable-resolver.service.ts
+++ b/packages/api/src/plugins/services/plugin-variable-resolver.service.ts
@@ -1,6 +1,7 @@
 import type { PluginVariable } from '../entities/plugin-variable.entity'
 import process from 'node:process'
 import { Injectable, Logger } from '@nestjs/common'
+import { isPlainObject } from '../../utils/json'
 
 @Injectable()
 export class PluginVariableResolverService {
@@ -37,21 +38,26 @@ export class PluginVariableResolverService {
     return resolved
   }
 
-  resolveInObject(obj: Record<string, any>, variables: PluginVariable[]): Record<string, any> {
-    const resolved: Record<string, any> = {}
+  resolveInObject<T extends Record<string, unknown>>(obj: T, variables: PluginVariable[]): T {
+    const resolved: Record<string, unknown> = {}
 
     for (const [key, value] of Object.entries(obj)) {
-      if (typeof value === 'string') {
-        resolved[key] = this.resolveVariables(value, variables)
-      }
-      else if (typeof value === 'object' && value !== null) {
-        resolved[key] = this.resolveInObject(value, variables)
-      }
-      else {
-        resolved[key] = value
-      }
+      resolved[key] = this.resolveValue(value, variables)
     }
 
-    return resolved
+    return resolved as T
+  }
+
+  private resolveValue(value: unknown, variables: PluginVariable[]): unknown {
+    if (typeof value === 'string') {
+      return this.resolveVariables(value, variables)
+    }
+    if (Array.isArray(value)) {
+      return value.map(item => this.resolveValue(item, variables))
+    }
+    if (isPlainObject(value)) {
+      return this.resolveInObject(value, variables)
+    }
+    return value
   }
 }

--- a/packages/api/src/plugins/services/webhook-ingest.service.ts
+++ b/packages/api/src/plugins/services/webhook-ingest.service.ts
@@ -2,21 +2,23 @@ import type { WebhookPayload } from '../entities/plugin.entity'
 import { Injectable, Logger, UnprocessableEntityException } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
 import { Repository } from 'typeorm'
+import { isPlainObject } from '../../utils/json'
 import { Plugin } from '../entities/plugin.entity'
 import { PluginRenderCacheService } from './plugin-render-cache.service'
 
-type JsonObject = Record<string, any>
-
-function isPlainObject(value: unknown): value is JsonObject {
-  return typeof value === 'object' && value !== null && !Array.isArray(value)
+function isWebhookPayload(value: unknown): value is WebhookPayload {
+  return value === null || Array.isArray(value) || isPlainObject(value)
 }
 
+// `incoming`/`value` are only ever reached here once `isWebhookPayload` has
+// confirmed the root body is JSON-object/array/null shaped, so recursing
+// through it with `unknown` and handing leaf values back as-is is safe.
 function deepMerge(stored: unknown, incoming: unknown): unknown {
   if (!isPlainObject(stored) || !isPlainObject(incoming)) {
     return incoming
   }
 
-  return Object.entries(incoming).reduce<JsonObject>(
+  return Object.entries(incoming).reduce<Record<string, unknown>>(
     (merged, [key, value]) => ({
       ...merged,
       [key]: isPlainObject(value) && isPlainObject(stored[key]) ? deepMerge(stored[key], value) : value,
@@ -30,9 +32,9 @@ function appendStream(stored: unknown, incoming: unknown, streamLimit: number): 
     return incoming
   }
 
-  const base: JsonObject = isPlainObject(stored) ? { ...stored } : {}
+  const base: Record<string, unknown> = isPlainObject(stored) ? { ...stored } : {}
 
-  return Object.entries(incoming).reduce<JsonObject>((merged, [key, value]) => {
+  return Object.entries(incoming).reduce<Record<string, unknown>>((merged, [key, value]) => {
     if (!Array.isArray(value)) {
       return { ...merged, [key]: value }
     }
@@ -59,9 +61,16 @@ export class WebhookIngestService {
       throw new UnprocessableEntityException(`Plugin "${plugin.name}" has no template configured`)
     }
 
+    if (!isWebhookPayload(body)) {
+      throw new UnprocessableEntityException('Webhook body must be a JSON object or array')
+    }
+
     const merged = this.merge(plugin, body)
 
-    await this.pluginRepository.update(plugin.id, { webhookPayload: merged })
+    // TypeORM's QueryDeepPartialEntity can't distribute over the WebhookPayload
+    // union against a union-typed value, even though `merged`'s type already
+    // matches the column exactly — hence the assertion rather than a real gap.
+    await this.pluginRepository.update(plugin.id, { webhookPayload: merged } as Parameters<typeof this.pluginRepository.update>[1])
     await this.renderCache.renderAndCache(plugin, merged)
 
     this.logger.debug(`Ingested webhook payload for plugin ${plugin.id} using ${plugin.mergeStrategy} merge strategy`)
@@ -73,7 +82,7 @@ export class WebhookIngestService {
     return plugin.webhookPayload ?? null
   }
 
-  private merge(plugin: Plugin, body: unknown): WebhookPayload {
+  private merge(plugin: Plugin, body: WebhookPayload): WebhookPayload {
     switch (plugin.mergeStrategy) {
       case 'deep_merge':
         return deepMerge(plugin.webhookPayload, body) as WebhookPayload
@@ -83,7 +92,7 @@ export class WebhookIngestService {
         }
         return appendStream(plugin.webhookPayload, body, plugin.streamLimit) as WebhookPayload
       default:
-        return body as WebhookPayload
+        return body
     }
   }
 }

--- a/packages/api/src/screens/__test__/screens.controller.spec.ts
+++ b/packages/api/src/screens/__test__/screens.controller.spec.ts
@@ -37,7 +37,7 @@ describe('screensController (unit)', () => {
 
   it('add creates a screen', async () => {
     const dto: CreateScreenDto = { filename: 'file', deviceId: 'dev', fetchManual: false }
-    const file = { buffer: buffer.Buffer.from('data') }
+    const file = { buffer: buffer.Buffer.from('data') } as Express.Multer.File
     const screen = { id: '1', filename: 'file' } as Screen
     service.add.mockResolvedValue(screen)
     configService.get.mockReturnValue(false)

--- a/packages/api/src/screens/__test__/screens.service.spec.ts
+++ b/packages/api/src/screens/__test__/screens.service.spec.ts
@@ -68,7 +68,7 @@ describe('screensService', () => {
 
   it('add throws if both file and externalLink are provided', async () => {
     const dto: CreateScreenDto = { filename: 'file', deviceId: 'dev', externalLink: 'url', fetchManual: false, html: '' }
-    await expect(service.add(dto, { buffer: buffer.Buffer.from('data') })).rejects.toThrow()
+    await expect(service.add(dto, { buffer: buffer.Buffer.from('data') } as Express.Multer.File)).rejects.toThrow()
   })
 
   it('add throws if neither file nor externalLink is provided', async () => {
@@ -83,7 +83,7 @@ describe('screensService', () => {
     screensRepo.create.mockReturnValue(screen)
     screensRepo.save.mockResolvedValue(screen)
     screensRepo.update.mockResolvedValue(undefined)
-    const file = { buffer: buffer.Buffer.from('data') }
+    const file = { buffer: buffer.Buffer.from('data') } as Express.Multer.File
     const writeFileMock = vi.spyOn(fs.promises, 'writeFile').mockResolvedValue(undefined)
     vi.spyOn(fs.promises, 'mkdir').mockResolvedValue(undefined)
     const result = await service.add({ filename: 'file', deviceId: 'dev', fetchManual: false, html: '' }, file)

--- a/packages/api/src/screens/screens.controller.ts
+++ b/packages/api/src/screens/screens.controller.ts
@@ -31,7 +31,7 @@ export class ScreensController {
   @Post()
   @UsePipes(new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true }))
   @UseInterceptors(FileInterceptor('file'))
-  async add(@Body() body: CreateScreenDto, @UploadedFile() file?: any): Promise<Screen> {
+  async add(@Body() body: CreateScreenDto, @UploadedFile() file?: Express.Multer.File): Promise<Screen> {
     if (file && this.configService.get<string>('demo_mode'))
       throw new MethodNotAllowedException('Not available in demo mode')
     return this.screensService.add(body, file)

--- a/packages/api/src/screens/screens.service.ts
+++ b/packages/api/src/screens/screens.service.ts
@@ -31,7 +31,7 @@ export class ScreensService {
     return this.screensRepository.find()
   }
 
-  async add(body: CreateScreenDto, file?: any): Promise<Screen> {
+  async add(body: CreateScreenDto, file?: Express.Multer.File): Promise<Screen> {
     this.logger.log(`Adding screen to device ${body.deviceId}`)
     if (body.externalLink && file)
       throw new BadRequestException('Can\'t upload a file to an external image')

--- a/packages/api/src/utils/json.ts
+++ b/packages/api/src/utils/json.ts
@@ -1,0 +1,7 @@
+export type JsonPrimitive = string | number | boolean | null
+export type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue }
+export interface JsonObject { [key: string]: JsonValue }
+
+export function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}

--- a/packages/ui/eslint.config.ts
+++ b/packages/ui/eslint.config.ts
@@ -1,3 +1,16 @@
 import antfu from '@antfu/eslint-config'
 
-export default antfu()
+export default antfu(
+  {},
+  {
+    rules: {
+      'ts/no-explicit-any': 'error',
+    },
+  },
+  {
+    files: ['**/__test__/**', '**/__tests__/**', '**/*.spec.ts'],
+    rules: {
+      'ts/no-explicit-any': 'warn',
+    },
+  },
+)

--- a/packages/ui/src/components/AddMashupCard.vue
+++ b/packages/ui/src/components/AddMashupCard.vue
@@ -5,6 +5,7 @@ import { useMashupStore } from '@/stores/mashup'
 import { usePluginsStore } from '@/stores/plugins'
 import { useScreensStore } from '@/stores/screens'
 import { MASHUP_LAYOUTS } from '@/types/mashup'
+import { errorMessage } from '@/utils/errorMessage'
 
 const props = defineProps<{ deviceId: string }>()
 
@@ -64,8 +65,8 @@ async function createMashup() {
     selectedLayout.value = ''
     selectedPlugins.value = []
   }
-  catch (err: any) {
-    error.value = err.message || 'Failed to create mashup'
+  catch (err) {
+    error.value = errorMessage(err, 'Failed to create mashup')
   }
   finally {
     loading.value = false

--- a/packages/ui/src/components/PluginDataSourcesEditor.vue
+++ b/packages/ui/src/components/PluginDataSourcesEditor.vue
@@ -3,7 +3,7 @@ import type { PluginDataSource } from '@/types/plugin'
 import { mdiDelete, mdiPlus } from '@mdi/js'
 import { VAlert, VBtn, VExpansionPanel, VExpansionPanels, VExpansionPanelText, VExpansionPanelTitle, VSelect, VTextarea, VTextField } from 'vuetify/components'
 
-type EditableDataSource = Partial<PluginDataSource> & { headersJson?: string }
+export type EditableDataSource = Partial<PluginDataSource> & { headersJson?: string }
 
 const dataSources = defineModel<EditableDataSource[]>({ required: true })
 

--- a/packages/ui/src/components/PluginImportDialog.vue
+++ b/packages/ui/src/components/PluginImportDialog.vue
@@ -3,6 +3,7 @@ import { mdiUpload } from '@mdi/js'
 import { ref } from 'vue'
 import { VAlert, VBtn, VCard, VCardActions, VCardText, VCardTitle, VDialog, VDivider, VFileInput, VSelect, VTab, VTabs, VTextField, VWindow, VWindowItem } from 'vuetify/components'
 import { useDeviceStore } from '../stores/device'
+import { errorMessage } from '../utils/errorMessage'
 
 defineProps<{
   modelValue: boolean
@@ -105,8 +106,8 @@ async function importPlugin() {
     emit('imported')
     close()
   }
-  catch (err: any) {
-    error.value = err.message || 'Failed to import plugin'
+  catch (err) {
+    error.value = errorMessage(err, 'Failed to import plugin')
   }
   finally {
     loading.value = false

--- a/packages/ui/src/router/index.ts
+++ b/packages/ui/src/router/index.ts
@@ -1,6 +1,7 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import { useDeviceStore } from '../stores/device'
 import { usePluginsStore } from '../stores/plugins'
+import { routeParam } from '../utils/routeParam'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -22,7 +23,7 @@ const router = createRouter({
       beforeEnter: async (to) => {
         const store = useDeviceStore()
         await store.fetchDevices()
-        if (!store.getById(to.params.id as string))
+        if (!store.getById(routeParam(to.params.id)))
           return { name: 'overview' }
       },
     },
@@ -62,10 +63,11 @@ const router = createRouter({
       beforeEnter: async (to) => {
         const deviceStore = useDeviceStore()
         const pluginsStore = usePluginsStore()
+        const deviceId = routeParam(to.params.deviceId)
         await deviceStore.fetchDevices()
-        if (!deviceStore.getById(to.params.deviceId as string))
+        if (!deviceId || !deviceStore.getById(deviceId))
           return { name: 'overview' }
-        await pluginsStore.fetchPluginsForDevice(to.params.deviceId as string)
+        await pluginsStore.fetchPluginsForDevice(deviceId)
       },
     },
     {

--- a/packages/ui/src/stores/device.ts
+++ b/packages/ui/src/stores/device.ts
@@ -24,7 +24,7 @@ export const useDeviceStore = defineStore('device', () => {
     }
   }
 
-  function getById(id: string) {
+  function getById(id: string | undefined) {
     return devices.value.find(device => device.id === id)
   }
 

--- a/packages/ui/src/stores/logs.ts
+++ b/packages/ui/src/stores/logs.ts
@@ -5,7 +5,7 @@ import { ref } from 'vue'
 function createLogStore(deviceId: string) {
   return () => {
     const error = ref('')
-    const logEntries = ref([] as LogEntry[])
+    const logEntries = ref<LogEntry[]>([])
     const loading = ref(true)
 
     const clearLogs = async () => {

--- a/packages/ui/src/stores/mashup.ts
+++ b/packages/ui/src/stores/mashup.ts
@@ -3,7 +3,7 @@ import { defineStore } from 'pinia'
 import { ref } from 'vue'
 
 export const useMashupStore = defineStore('mashup', () => {
-  const layouts = ref<any | null>(null)
+  const layouts = ref<Record<string, unknown> | null>(null)
 
   async function fetchLayouts() {
     const res = await fetch('/api/mashup/layouts')

--- a/packages/ui/src/stores/plugins.ts
+++ b/packages/ui/src/stores/plugins.ts
@@ -1,4 +1,4 @@
-import type { Plugin } from '@/types/plugin'
+import type { CreatePluginPayload, Plugin } from '@/types/plugin'
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 
@@ -12,7 +12,7 @@ export const usePluginsStore = defineStore('plugins', () => {
     plugins.value = await res.json()
   }
 
-  const createPlugin = async (pluginData: Partial<Plugin>) => {
+  const createPlugin = async (pluginData: CreatePluginPayload) => {
     const res = await fetch('/api/plugins', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -29,7 +29,7 @@ export const usePluginsStore = defineStore('plugins', () => {
     return newPlugin
   }
 
-  const updatePlugin = async (id: string, pluginData: Partial<Plugin>) => {
+  const updatePlugin = async (id: string, pluginData: Partial<CreatePluginPayload>) => {
     const res = await fetch(`/api/plugins/${id}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },

--- a/packages/ui/src/types/plugin.ts
+++ b/packages/ui/src/types/plugin.ts
@@ -32,7 +32,7 @@ export interface PluginDataSource {
   method: string
   url: string
   headers?: Record<string, string>
-  body?: Record<string, any>
+  body?: Record<string, unknown>
   transformJs?: string
   order: number
 }
@@ -60,4 +60,44 @@ export interface PluginFieldValue {
   id: string
   value: string
   deviceId?: string
+}
+
+export interface CreatePluginDataSourcePayload {
+  name: string
+  method?: string
+  url: string
+  headers?: Record<string, string>
+  body?: Record<string, unknown>
+  transformJs?: string
+  order?: number
+}
+
+export interface CreatePluginTemplatePayload {
+  layout?: string
+  liquidMarkup: string
+}
+
+export interface CreatePluginFieldPayload {
+  keyname: string
+  fieldType?: string
+  name: string
+  description?: string
+  defaultValue?: string
+  required?: boolean
+  order?: number
+}
+
+export interface CreatePluginPayload {
+  name: string
+  description?: string
+  kind?: string
+  refreshInterval?: number
+  isActive?: boolean
+  order?: number
+  mergeStrategy?: string
+  streamLimit?: number
+  sourceRecipeId?: string
+  dataSources?: CreatePluginDataSourcePayload[]
+  templates?: CreatePluginTemplatePayload[]
+  fields?: CreatePluginFieldPayload[]
 }

--- a/packages/ui/src/utils/__test__/errorMessage.spec.ts
+++ b/packages/ui/src/utils/__test__/errorMessage.spec.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { errorMessage } from '../errorMessage'
+
+describe('errorMessage', () => {
+  it('reads the message off an Error', () => {
+    expect(errorMessage(new Error('Failed to fetch'), 'fallback')).toBe('Failed to fetch')
+  })
+
+  it('falls back for a non-Error thrown value', () => {
+    expect(errorMessage('a plain string', 'fallback')).toBe('fallback')
+    expect(errorMessage(undefined, 'fallback')).toBe('fallback')
+  })
+
+  it('falls back for an Error with an empty message', () => {
+    const emptyError = new Error('placeholder')
+    emptyError.message = ''
+    expect(errorMessage(emptyError, 'fallback')).toBe('fallback')
+  })
+})

--- a/packages/ui/src/utils/__test__/routeParam.spec.ts
+++ b/packages/ui/src/utils/__test__/routeParam.spec.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { routeParam } from '../routeParam'
+
+describe('routeParam', () => {
+  it('passes a single string param through', () => {
+    expect(routeParam('device-1')).toBe('device-1')
+  })
+
+  it('takes the first value of a repeated param', () => {
+    expect(routeParam(['device-1', 'device-2'])).toBe('device-1')
+  })
+
+  it('passes undefined through', () => {
+    expect(routeParam(undefined)).toBeUndefined()
+  })
+})

--- a/packages/ui/src/utils/errorMessage.ts
+++ b/packages/ui/src/utils/errorMessage.ts
@@ -1,0 +1,3 @@
+export function errorMessage(err: unknown, fallback: string): string {
+  return err instanceof Error && err.message ? err.message : fallback
+}

--- a/packages/ui/src/utils/routeParam.ts
+++ b/packages/ui/src/utils/routeParam.ts
@@ -1,0 +1,6 @@
+type RouteParamLike = string | null | undefined | Array<string | null>
+
+export function routeParam(value: RouteParamLike): string | undefined {
+  const first = Array.isArray(value) ? value[0] : value
+  return first ?? undefined
+}

--- a/packages/ui/src/views/PluginCreateView.vue
+++ b/packages/ui/src/views/PluginCreateView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { Plugin } from '../types/plugin'
+import type { CreatePluginPayload, Plugin } from '../types/plugin'
 import type { RenderTarget } from '@/utils/screenShell'
 import { mdiArrowLeft, mdiArrowRight, mdiCheck, mdiEye } from '@mdi/js'
 import { computed, ref } from 'vue'
@@ -8,7 +8,9 @@ import { VAlert, VBtn, VCard, VCardActions, VCardText, VCardTitle, VCol, VContai
 import PluginDataSourcesEditor from '@/components/PluginDataSourcesEditor.vue'
 import RenderTargetPicker from '@/components/RenderTargetPicker.vue'
 import ScreenFrame from '@/components/ScreenFrame.vue'
+import { errorMessage } from '@/utils/errorMessage'
 import { DEFAULT_MODEL, DEFAULT_PALETTE } from '@/utils/renderTarget'
+import { routeParam } from '@/utils/routeParam'
 import { viewFull } from '@/utils/screenShell'
 import { usePluginsStore } from '../stores/plugins'
 
@@ -19,7 +21,7 @@ const pluginsStore = usePluginsStore()
 const step = ref(1)
 const formRef = ref<null | typeof VForm>(null)
 
-const deviceId = computed(() => route.query.deviceId as string | undefined)
+const deviceId = computed(() => routeParam(route.query.deviceId))
 
 const pluginData = ref<Partial<Plugin>>({
   name: '',
@@ -105,7 +107,7 @@ const saveError = ref('')
 const previewLoading = ref(false)
 const previewHtml = ref('')
 const previewTarget = ref<RenderTarget>({ model: DEFAULT_MODEL, palette: DEFAULT_PALETTE })
-const previewData = ref<any>(null)
+const previewData = ref<Record<string, unknown> | null>(null)
 const previewError = ref('')
 const showPreview = ref(false)
 const previewTab = ref('rendered')
@@ -157,9 +159,9 @@ async function previewPlugin() {
     previewError.value = ''
     showPreview.value = true
   }
-  catch (err: any) {
+  catch (err) {
     console.error('Preview error:', err)
-    previewError.value = err.message || 'Failed to generate preview. Check console for details.'
+    previewError.value = errorMessage(err, 'Failed to generate preview. Check console for details.')
   }
   finally {
     previewLoading.value = false
@@ -173,10 +175,10 @@ async function createPlugin() {
     const sources = pluginData.value.dataSources || []
     const template = pluginData.value.templates?.[0]
 
-    const payload: any = {
-      name: pluginData.value.name,
+    const payload: CreatePluginPayload = {
+      name: pluginData.value.name ?? '',
       description: pluginData.value.description,
-      kind: pluginData.value.kind,
+      kind: pluginData.value.kind ?? 'Poll',
       refreshInterval: pluginData.value.refreshInterval,
       dataSources: sources.map((source, index) => ({
         name: source.name,
@@ -204,8 +206,8 @@ async function createPlugin() {
       router.push({ name: 'pluginsOverview' })
     }
   }
-  catch (err: any) {
-    saveError.value = err.message || 'Failed to create plugin. Check console for details.'
+  catch (err) {
+    saveError.value = errorMessage(err, 'Failed to create plugin. Check console for details.')
   }
   finally {
     loading.value = false

--- a/packages/ui/src/views/PluginEditView.vue
+++ b/packages/ui/src/views/PluginEditView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import type { Plugin } from '../types/plugin'
+import type { CreatePluginDataSourcePayload, Plugin } from '../types/plugin'
+import type { EditableDataSource } from '@/components/PluginDataSourcesEditor.vue'
 import type { RenderTarget } from '@/utils/screenShell'
 import { mdiArrowLeft, mdiContentSave, mdiEye } from '@mdi/js'
 import { computed, onMounted, ref } from 'vue'
@@ -8,6 +9,7 @@ import { VAlert, VBtn, VCard, VCardActions, VCardText, VCardTitle, VCol, VContai
 import PluginDataSourcesEditor from '@/components/PluginDataSourcesEditor.vue'
 import RenderTargetPicker from '@/components/RenderTargetPicker.vue'
 import ScreenFrame from '@/components/ScreenFrame.vue'
+import { errorMessage } from '@/utils/errorMessage'
 import { DEFAULT_MODEL, DEFAULT_PALETTE } from '@/utils/renderTarget'
 import { viewFull } from '@/utils/screenShell'
 import { usePluginsStore } from '../stores/plugins'
@@ -19,7 +21,9 @@ const props = defineProps<{
 const router = useRouter()
 const pluginsStore = usePluginsStore()
 
-const plugin = ref<Plugin | null>(null)
+type EditablePlugin = Omit<Plugin, 'dataSources'> & { dataSources?: EditableDataSource[] }
+
+const plugin = ref<EditablePlugin | null>(null)
 const formRef = ref<null | typeof VForm>(null)
 
 const nameRules = [
@@ -64,12 +68,12 @@ onMounted(async () => {
     if (!res.ok)
       throw new Error('Failed to fetch plugin')
     plugin.value = await res.json()
-    if (plugin.value && !plugin.value.dataSources) {
-      plugin.value.dataSources = []
+    if (plugin.value) {
+      plugin.value.dataSources = (plugin.value.dataSources ?? []).map(source => ({
+        ...source,
+        headersJson: source.headers ? JSON.stringify(source.headers, null, 2) : '',
+      }))
     }
-    plugin.value?.dataSources?.forEach((source: any) => {
-      source.headersJson = source.headers ? JSON.stringify(source.headers, null, 2) : ''
-    })
     // Initialize field values from plugin fields
     if (plugin.value?.fields) {
       plugin.value.fields.forEach((field) => {
@@ -88,7 +92,7 @@ const saveError = ref('')
 const previewLoading = ref(false)
 const previewHtml = ref('')
 const previewTarget = ref<RenderTarget>({ model: DEFAULT_MODEL, palette: DEFAULT_PALETTE })
-const previewData = ref<any>(null)
+const previewData = ref<Record<string, unknown> | null>(null)
 const previewError = ref('')
 const showPreview = ref(false)
 const previewTab = ref('rendered')
@@ -104,16 +108,21 @@ async function savePlugin() {
     // in the editor may carry stale or colliding order values.
     const payload = {
       ...plugin.value,
-      dataSources: (plugin.value.dataSources || []).map((source, index) => ({
-        ...source,
+      dataSources: (plugin.value.dataSources || []).map((source, index): CreatePluginDataSourcePayload => ({
+        name: source.name ?? '',
+        method: source.method,
+        url: source.url ?? '',
+        headers: source.headers,
+        body: source.body,
+        transformJs: source.transformJs,
         order: index,
       })),
     }
     await pluginsStore.updatePlugin(props.id, payload)
     router.push({ name: 'pluginsOverview' })
   }
-  catch (err: any) {
-    saveError.value = err.message || 'Failed to save plugin. Check console for details.'
+  catch (err) {
+    saveError.value = errorMessage(err, 'Failed to save plugin. Check console for details.')
   }
   finally {
     loading.value = false
@@ -168,9 +177,9 @@ async function previewPlugin() {
     previewError.value = ''
     showPreview.value = true
   }
-  catch (err: any) {
+  catch (err) {
     console.error('Preview error:', err)
-    previewError.value = err.message || 'Failed to generate preview. Check console for details.'
+    previewError.value = errorMessage(err, 'Failed to generate preview. Check console for details.')
   }
   finally {
     previewLoading.value = false

--- a/packages/ui/src/views/VirtualDeviceView.vue
+++ b/packages/ui/src/views/VirtualDeviceView.vue
@@ -5,12 +5,14 @@ import { useRoute } from 'vue-router'
 import { VAlert, VAutocomplete, VBtn, VCard, VCardText, VCardTitle, VCol, VContainer, VDivider, VExpansionPanel, VExpansionPanels, VExpansionPanelText, VExpansionPanelTitle, VForm, VImg, VRow, VTab, VTabs, VTextField, VWindow, VWindowItem } from 'vuetify/components'
 import { useDeviceStore } from '@/stores/device'
 import { deviceRenderSize } from '@/utils/deviceRenderSize'
+import { errorMessage } from '@/utils/errorMessage'
 import { getRandomMac, isValidMac } from '@/utils/getRandomMac'
+import { routeParam } from '@/utils/routeParam'
 
 const mac = ref('')
 const apiKey = ref<string | null>(null)
 const friendlyId = ref('')
-const displayResponse = ref<any>(null)
+const displayResponse = ref<Record<string, unknown> | null>(null)
 const displayImageUrl = ref('')
 const customHeaders = ref({
   'battery-voltage': '4.2V',
@@ -39,8 +41,8 @@ async function callSetup() {
     apiKey.value = data.api_key
     friendlyId.value = data.friendly_id
   }
-  catch (e: any) {
-    error.value = e.message
+  catch (e) {
+    error.value = errorMessage(e, 'Setup failed')
   }
   finally {
     loadingSetup.value = false
@@ -73,8 +75,8 @@ async function callDisplay() {
     displayResponse.value = data
     displayImageUrl.value = data.image_url
   }
-  catch (e: any) {
-    error.value = e.message
+  catch (e) {
+    error.value = errorMessage(e, 'Display failed')
   }
   finally {
     loadingDisplay.value = false
@@ -95,7 +97,7 @@ const route = useRoute()
 const currentMac = computed(() => {
   if (route.name !== 'device')
     return null
-  return deviceStore.getById(route.params?.id as string)?.mac || null
+  return deviceStore.getById(routeParam(route.params?.id))?.mac || null
 })
 
 function takeCurrentMac() {


### PR DESCRIPTION
## Summary
- Closes two real validation gaps: `PATCH /plugins/device-assignment/:id` no longer mass-assigns an unvalidated body onto the `DevicePlugin` entity, and plugin ZIP imports validate `manifest.yml`/`settings.yml` are actual objects before use (both reject with 400 instead of silently accepting bad input).
- Removes ~69 production `any` usages and the unsafe `as X` casts flagged in #816 across the Plugins pipeline (data fetcher, transformer, renderer, render cache, variable resolver, template context), the webhook ingest merge path, the plugin importer, and several UI views/stores — replaced with `unknown`/`object`/a small shared `JsonObject` type, or removed outright where the cast was unnecessary.
- `CreatePluginDto`/`UpdatePluginDto` now validate their nested `dataSources`/`templates`/`fields` arrays via `class-validator`/`class-transformer` instead of accepting `any[]`.
- Adds `errorMessage`/`routeParam` UI utilities to replace `catch (err: any)` and `route.params.x as string` patterns.
- Enables `ts/no-explicit-any: error` for production code (`warn` for tests) in both packages' ESLint configs.
- Fixes a real regression caught during review: the `isPlainObject` guard swap in `PluginVariableResolverService.resolveInObject` would have stopped recursing into array values — added proper array handling with new test coverage.

## Test plan
- [x] `pnpm run type-check` passes (both packages)
- [x] `pnpm run lint` passes (0 errors; only expected `warn`-level `any` in test files)
- [x] `pnpm run test` passes — 737 API tests, 164 UI tests
- [x] New tests: manifest/settings shape validation on plugin import, device-assignment mass-assignment rejection, nested `dataSources` validation on create/update, array handling in variable resolution, `errorMessage`/`routeParam` utils
- [x] `grep -rnE '\bany\b' packages/*/src` (excluding tests) returns zero real `any` type usages
- [x] Ran `/code-review --level high`; the one finding it surfaced (array-handling regression) was fixed and covered by a test

https://claude.ai/code/session_01YZJtzp8MYGjhSmXH3ZDsPj