### PR TITLE
feat(plugins): literal Data Source mode + static Recipe import (#821)

### DIFF
--- a/packages/api/src/devices/__test__/display.service.spec.ts
+++ b/packages/api/src/devices/__test__/display.service.spec.ts
@@ -231,7 +231,10 @@ describe('deviceDisplayService', () => {
       const device = { ...baseDevice, deviceModel: OG_PLUS }
       const plugin = { id: 'p1', name: 'P', dataSources: [{ name: 'source', method: 'GET', url: 'http://x' }], templates: [{ layout: 'full', liquidMarkup: '{{ v }}' }] }
       primeRotation({ id: 'screen2', type: 'plugin', order: 2, device, plugin, filename: 'x', generatedAt: new Date() }, device)
-      ;(service as any).pluginDataFetcher = { fetchData: vi.fn().mockResolvedValue({ v: 1 }) } as any
+      ;(service as any).pluginDataFetcher = {
+        fetchData: vi.fn().mockResolvedValue({ v: 1 }),
+        fetchOrLiteral: vi.fn().mockResolvedValue({ v: 1 }),
+      } as any
       ;(service as any).pluginRenderer = { render: vi.fn().mockResolvedValue('<b>1</b>') } as any
 
       await service.getCurrentImage(headers as any)
@@ -830,7 +833,7 @@ describe('deviceDisplayService', () => {
   describe('mashup screen rendering', () => {
     beforeEach(() => {
       // Inject services needed for mashup
-      ;(service as any).pluginDataFetcher = { fetchData: vi.fn() } as any
+      ;(service as any).pluginDataFetcher = { fetchData: vi.fn(), fetchOrLiteral: vi.fn() } as any
       ;(service as any).pluginRenderer = { render: vi.fn() } as any
       ;(service as any).pluginTransformer = { transform: vi.fn() } as any
     })

--- a/packages/api/src/devices/display.service.ts
+++ b/packages/api/src/devices/display.service.ts
@@ -521,10 +521,12 @@ export class DeviceDisplayService {
     const templateContext = this.pluginTemplateContext.build(plugin, sensors)
 
     // Fetch all of the plugin's data sources in parallel; a source that fails
-    // gets an error marker instead of aborting the whole render (ADR-0005)
+    // gets an error marker instead of aborting the whole render (ADR-0005).
+    // A literal-mode source has no fetch to make — it contributes its stored
+    // value directly, with no call to the data fetcher at all.
     const results = await Promise.allSettled(
       plugin.dataSources.map(async (source) => {
-        let rawData = await this.pluginDataFetcher.fetchData(source.method, source.url, source.headers, source.body, templateContext)
+        let rawData = await this.pluginDataFetcher.fetchOrLiteral(source, templateContext)
         if (source.transformJs) {
           this.logger.debug(`Applying transform.js to data source: ${source.name}`)
           rawData = this.pluginTransformer.transform(source.transformJs, rawData)

--- a/packages/api/src/mashup/__test__/mashup-renderer.service.spec.ts
+++ b/packages/api/src/mashup/__test__/mashup-renderer.service.spec.ts
@@ -23,6 +23,11 @@ describe('mashupRendererService', () => {
   beforeEach(() => {
     pluginDataFetcher = {
       fetchData: vi.fn(),
+      fetchOrLiteral: vi.fn((source: any, ctx: any) =>
+        source.mode === 'literal'
+          ? Promise.resolve(source.literalValue ?? null)
+          : pluginDataFetcher.fetchData(source.method, source.url ?? '', source.headers, source.body, ctx),
+      ),
     } as any
 
     pluginRenderer = {

--- a/packages/api/src/mashup/services/mashup-renderer.service.ts
+++ b/packages/api/src/mashup/services/mashup-renderer.service.ts
@@ -60,10 +60,12 @@ export class MashupRendererService {
     const templateContext = this.pluginTemplateContext.build(plugin, sensors)
 
     // Fetch all of the plugin's data sources in parallel; a source that fails
-    // gets an error marker instead of aborting the whole render (ADR-0005)
+    // gets an error marker instead of aborting the whole render (ADR-0005).
+    // A literal-mode source has no fetch to make — it contributes its stored
+    // value directly, with no call to the data fetcher at all.
     const results = await Promise.allSettled(
       plugin.dataSources.map(async (source) => {
-        let rawData = await this.pluginDataFetcher.fetchData(source.method, source.url, source.headers, source.body, templateContext)
+        let rawData = await this.pluginDataFetcher.fetchOrLiteral(source, templateContext)
         if (source.transformJs) {
           rawData = this.pluginTransformer.transform(source.transformJs, rawData)
         }

--- a/packages/api/src/migrations/1787140000000-AddDataSourceMode.ts
+++ b/packages/api/src/migrations/1787140000000-AddDataSourceMode.ts
@@ -1,0 +1,32 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddDataSourceMode1787140000000 implements MigrationInterface {
+  name = 'AddDataSourceMode1787140000000'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "plugin_data_source"
+        ADD "mode" text NOT NULL DEFAULT 'fetch',
+        ADD "literalValue" jsonb,
+        ALTER COLUMN "url" DROP NOT NULL
+    `)
+
+    await queryRunner.query(`
+      ALTER TABLE "plugin_data_source"
+        ADD CONSTRAINT "CHK_plugin_data_source_mode" CHECK ("mode" IN ('fetch', 'literal'))
+    `)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "plugin_data_source" DROP CONSTRAINT "CHK_plugin_data_source_mode"`)
+    // A literal-mode row has no url — back-fill a placeholder so the
+    // restored NOT NULL constraint doesn't fail on existing data.
+    await queryRunner.query(`UPDATE "plugin_data_source" SET "url" = '' WHERE "url" IS NULL`)
+    await queryRunner.query(`
+      ALTER TABLE "plugin_data_source"
+        ALTER COLUMN "url" SET NOT NULL,
+        DROP COLUMN "literalValue",
+        DROP COLUMN "mode"
+    `)
+  }
+}

--- a/packages/api/src/plugins/__test__/plugin-data-source-mode.spec.ts
+++ b/packages/api/src/plugins/__test__/plugin-data-source-mode.spec.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+import { dataSourceModeViolation } from '../plugin-data-source-mode'
+
+describe('dataSourceModeViolation', () => {
+  describe('literal mode', () => {
+    it('passes with only a literalValue', () => {
+      expect(dataSourceModeViolation({ mode: 'literal', literalValue: { title: 'Hello' } })).toBeNull()
+    })
+
+    it('accepts a scalar literalValue', () => {
+      expect(dataSourceModeViolation({ mode: 'literal', literalValue: 'a plain string' })).toBeNull()
+      expect(dataSourceModeViolation({ mode: 'literal', literalValue: 42 })).toBeNull()
+      expect(dataSourceModeViolation({ mode: 'literal', literalValue: false })).toBeNull()
+    })
+
+    it('rejects a non-default Method', () => {
+      expect(dataSourceModeViolation({ mode: 'literal', literalValue: {}, method: 'POST' })).toBe(
+        'A literal-mode Data Source cannot have a Method',
+      )
+    })
+
+    it('tolerates a Method of "GET", since that is the entity column\'s non-nullable default rather than something a caller actually set', () => {
+      expect(dataSourceModeViolation({ mode: 'literal', literalValue: {}, method: 'GET' })).toBeNull()
+    })
+
+    it('rejects a URL', () => {
+      expect(dataSourceModeViolation({ mode: 'literal', literalValue: {}, url: 'https://api.example.com' })).toBe(
+        'A literal-mode Data Source cannot have a URL',
+      )
+    })
+
+    it('rejects Headers', () => {
+      expect(dataSourceModeViolation({ mode: 'literal', literalValue: {}, headers: { Authorization: 'x' } })).toBe(
+        'A literal-mode Data Source cannot have Headers',
+      )
+    })
+
+    it('rejects a Body', () => {
+      expect(dataSourceModeViolation({ mode: 'literal', literalValue: {}, body: { a: 1 } })).toBe(
+        'A literal-mode Data Source cannot have a Body',
+      )
+    })
+
+    it('rejects a Transform', () => {
+      expect(dataSourceModeViolation({ mode: 'literal', literalValue: {}, transformJs: 'module.exports = d => d' })).toBe(
+        'A literal-mode Data Source cannot have a Transform',
+      )
+    })
+
+    it('requires a literalValue', () => {
+      expect(dataSourceModeViolation({ mode: 'literal' })).toBe(
+        'A literal-mode Data Source requires a Value',
+      )
+    })
+
+    it('rejects a null literalValue as missing', () => {
+      expect(dataSourceModeViolation({ mode: 'literal', literalValue: null })).toBe(
+        'A literal-mode Data Source requires a Value',
+      )
+    })
+  })
+
+  describe('fetch mode', () => {
+    it('passes with only a URL', () => {
+      expect(dataSourceModeViolation({ mode: 'fetch', url: 'https://api.example.com' })).toBeNull()
+    })
+
+    it('defaults to fetch mode when mode is omitted', () => {
+      expect(dataSourceModeViolation({ url: 'https://api.example.com' })).toBeNull()
+      expect(dataSourceModeViolation({})).toBe('A fetch-mode Data Source requires a URL')
+    })
+
+    it('requires a URL', () => {
+      expect(dataSourceModeViolation({ mode: 'fetch' })).toBe('A fetch-mode Data Source requires a URL')
+    })
+
+    it('rejects a literalValue', () => {
+      expect(dataSourceModeViolation({ mode: 'fetch', url: 'https://api.example.com', literalValue: { a: 1 } })).toBe(
+        'A fetch-mode Data Source cannot have a Value',
+      )
+    })
+  })
+})

--- a/packages/api/src/plugins/__test__/plugin-data-source.entity.spec.ts
+++ b/packages/api/src/plugins/__test__/plugin-data-source.entity.spec.ts
@@ -97,4 +97,28 @@ describe('pluginDataSource entity', () => {
     const dataSource = new PluginDataSource()
     expect(dataSource.method).toBe('GET')
   })
+
+  it('defaults mode to fetch', () => {
+    const dataSource = new PluginDataSource()
+    expect(dataSource.mode).toBe('fetch')
+  })
+
+  it('stores a literal-mode value of any JSON shape', () => {
+    const dataSource = new PluginDataSource()
+    dataSource.mode = 'literal'
+    dataSource.literalValue = { title: 'Hello', count: 3 }
+
+    expect(dataSource.mode).toBe('literal')
+    expect(dataSource.literalValue).toEqual({ title: 'Hello', count: 3 })
+  })
+
+  it('accepts a scalar or array literalValue', () => {
+    const dataSource = new PluginDataSource()
+    dataSource.mode = 'literal'
+    dataSource.literalValue = 'a plain string'
+    expect(dataSource.literalValue).toBe('a plain string')
+
+    dataSource.literalValue = [1, 2, 3]
+    expect(dataSource.literalValue).toEqual([1, 2, 3])
+  })
 })

--- a/packages/api/src/plugins/__test__/plugin-exporter.service.spec.ts
+++ b/packages/api/src/plugins/__test__/plugin-exporter.service.spec.ts
@@ -141,6 +141,33 @@ describe('pluginExporterService', () => {
     expect(settings.data_sources[1].name).toBe('air_quality')
   })
 
+  it('exports a literal-mode data source as a mode/literal_value entry, not a broken endpoint', async () => {
+    const plugin = {
+      name: 'Mixed',
+      refreshInterval: 15,
+      dataSources: [
+        { name: 'weather', mode: 'fetch', url: 'https://api.example.com/weather', method: 'GET', order: 0 },
+        { name: 'title', mode: 'literal', literalValue: { text: 'Hello' }, order: 1 },
+      ],
+      templates: [{ layout: 'full', liquidMarkup: 'Test' }],
+      fields: [],
+    } as unknown as Plugin
+
+    const buffer = await service.exportToZip(plugin)
+    const zip = new AdmZip(buffer)
+    const settings = yaml.load(zip.getEntry('src/settings.yml')!.getData().toString('utf8')) as any
+
+    expect(settings.data_sources).toHaveLength(2)
+    const literalEntry = settings.data_sources.find((s: any) => s.name === 'title')
+    expect(literalEntry.mode).toBe('literal')
+    expect(literalEntry.literal_value).toEqual({ text: 'Hello' })
+    expect(literalEntry.endpoint).toBeUndefined()
+
+    const fetchEntry = settings.data_sources.find((s: any) => s.name === 'weather')
+    expect(fetchEntry.endpoint).toBe('https://api.example.com/weather')
+    expect(fetchEntry.mode).toBeUndefined()
+  })
+
   it('exports multiple templates with different layouts', async () => {
     const plugin = {
       name: 'Multi Layout',

--- a/packages/api/src/plugins/__test__/plugin-importer.service.spec.ts
+++ b/packages/api/src/plugins/__test__/plugin-importer.service.spec.ts
@@ -393,6 +393,32 @@ describe('pluginImporterService', () => {
       expect(result.dataSources[1]).toMatchObject({ name: 'air_quality', url: 'https://api.example.com/air', method: 'GET', transformJs: 'module.exports = (d) => d' })
     })
 
+    it('round-trips a "mode: literal" entry in a "data_sources" array into a literal-mode Data Source', async () => {
+      const zip = new AdmZip()
+
+      const manifest = { name: 'Literal Source Plugin' }
+      const settings = {
+        data_sources: [
+          { name: 'title', mode: 'literal', literal_value: { text: 'Hello' } },
+        ],
+      }
+
+      zip.addFile('.trmnlp.yml', Buffer.from(yaml.dump(manifest), 'utf8'))
+      zip.addFile('src/settings.yml', Buffer.from(yaml.dump(settings), 'utf8'))
+      zip.addFile('src/full.liquid', Buffer.from('{{ title.text }}', 'utf8'))
+
+      const tmpPath = path.join(__dirname, 'test-literal-source.zip')
+      zip.writeZip(tmpPath)
+
+      const result = await service.importFromFile(tmpPath)
+
+      fs.unlinkSync(tmpPath)
+
+      expect(result.dataSources).toHaveLength(1)
+      expect(result.dataSources[0]).toMatchObject({ name: 'title', mode: 'literal', literalValue: { text: 'Hello' } })
+      expect(result.dataSources[0].url).toBeUndefined()
+    })
+
     it('defaults an unnamed entry in a "data_sources" array to source_N', async () => {
       const zip = new AdmZip()
 

--- a/packages/api/src/plugins/__test__/plugin-recipe-import.spec.ts
+++ b/packages/api/src/plugins/__test__/plugin-recipe-import.spec.ts
@@ -145,12 +145,53 @@ describe('pluginImporterService recipe import', () => {
       await expect(service.importFromRecipeArchive(archive, '1')).rejects.toThrow('OAuth')
     })
 
-    it('rejects a "static" strategy recipe with a clear "not supported yet" error', async () => {
+    it('imports a "static" strategy recipe as a Poll plugin with one literal-mode Data Source named "source"', async () => {
+      const settings = { name: 'Static Recipe', strategy: 'static', static_data: { title: 'Hello', count: 3 } }
+      const archive = buildFlatRecipeArchive(settings)
+
+      const service = new PluginImporterService()
+      const result = await service.importFromRecipeArchive(archive, '1')
+
+      expect(result.kind).toBe('Poll')
+      expect(result.dataSources).toHaveLength(1)
+      expect(result.dataSources[0]).toMatchObject({
+        name: 'source',
+        mode: 'literal',
+        literalValue: { title: 'Hello', count: 3 },
+      })
+      expect(result.dataSources[0].url).toBeUndefined()
+      expect(result.sourceRecipeId).toBe('1')
+    })
+
+    it('imports a "static" strategy recipe with missing static_data as an empty literal value', async () => {
       const settings = { name: 'Static Recipe', strategy: 'static' }
       const archive = buildFlatRecipeArchive(settings)
 
       const service = new PluginImporterService()
-      await expect(service.importFromRecipeArchive(archive, '1')).rejects.toThrow(/static.*not supported/i)
+      const result = await service.importFromRecipeArchive(archive, '1')
+
+      expect(result.dataSources[0].literalValue).toEqual({})
+    })
+
+    it('imports a "static" strategy recipe with a null static_data as an empty literal value', async () => {
+      const settings = { name: 'Static Recipe', strategy: 'static', static_data: null }
+      const archive = buildFlatRecipeArchive(settings)
+
+      const service = new PluginImporterService()
+      const result = await service.importFromRecipeArchive(archive, '1')
+
+      expect(result.dataSources[0].literalValue).toEqual({})
+    })
+
+    it('rejects a "static" strategy recipe that also carries a transform.js', async () => {
+      const settings = { name: 'Static Recipe', strategy: 'static', static_data: { title: 'Hello' } }
+      const archive = buildFlatRecipeArchive(settings, {
+        'full.liquid': '<div>{{ source.title }}</div>',
+        'transform.js': 'module.exports = (data) => data',
+      })
+
+      const service = new PluginImporterService()
+      await expect(service.importFromRecipeArchive(archive, '1')).rejects.toThrow(/transform\.js/i)
     })
 
     it('rejects a recipe with a missing/unrecognized strategy, naming the value', async () => {

--- a/packages/api/src/plugins/__test__/plugin-scheduler.service.spec.ts
+++ b/packages/api/src/plugins/__test__/plugin-scheduler.service.spec.ts
@@ -29,6 +29,11 @@ describe('pluginSchedulerService', () => {
 
     mockDataFetcher = {
       fetchData: vi.fn(),
+      fetchOrLiteral: vi.fn((source: any, ctx: any) =>
+        source.mode === 'literal'
+          ? Promise.resolve(source.literalValue ?? null)
+          : mockDataFetcher.fetchData(source.method, source.url ?? '', source.headers, source.body, ctx),
+      ),
     } as any
 
     mockRenderCache = {
@@ -224,6 +229,86 @@ describe('pluginSchedulerService', () => {
       expect(mockRenderCache.renderAndCache).toHaveBeenCalledWith(
         plugin,
         expect.objectContaining({ weather: { temp: 25 }, air_quality: { aqi: 42 } }),
+      )
+    })
+
+    it('schedules a plugin with only literal-mode data sources and renders its stored value without calling the data fetcher', async () => {
+      const plugin = {
+        id: 'plugin-1',
+        name: 'Literal Only',
+        refreshInterval: 15,
+        isActive: true,
+        dataSources: [
+          { name: 'source', mode: 'literal', literalValue: { title: 'Hello' } },
+        ],
+        templates: [{ layout: 'full', liquidMarkup: '{{ source.title }}' }],
+      } as unknown as Plugin
+
+      mockRenderCache.renderAndCache = vi.fn().mockResolvedValue(undefined)
+
+      service.schedulePlugin(plugin)
+      expect(service.hasScheduledJob('plugin-1')).toBe(true)
+
+      await capturedCallback!()
+
+      expect(mockDataFetcher.fetchData).not.toHaveBeenCalled()
+      expect(mockRenderCache.renderAndCache).toHaveBeenCalledWith(
+        plugin,
+        expect.objectContaining({ source: { title: 'Hello' } }),
+      )
+    })
+
+    it('renders a mixed plugin with one fetch and one literal source, without fetching the literal one', async () => {
+      const plugin = {
+        id: 'plugin-1',
+        name: 'Mixed',
+        refreshInterval: 15,
+        isActive: true,
+        dataSources: [
+          { name: 'weather', mode: 'fetch', url: 'https://api.example.com/weather', method: 'GET' },
+          { name: 'title', mode: 'literal', literalValue: 'Static Title' },
+        ],
+        templates: [{ layout: 'full', liquidMarkup: '{{ title }} {{ weather.temp }}' }],
+      } as unknown as Plugin
+
+      mockDataFetcher.fetchData = vi.fn().mockResolvedValue({ temp: 25 })
+      mockRenderCache.renderAndCache = vi.fn().mockResolvedValue(undefined)
+
+      service.schedulePlugin(plugin)
+      await capturedCallback!()
+
+      expect(mockDataFetcher.fetchData).toHaveBeenCalledTimes(1)
+      expect(mockRenderCache.renderAndCache).toHaveBeenCalledWith(
+        plugin,
+        expect.objectContaining({ weather: { temp: 25 }, title: 'Static Title' }),
+      )
+    })
+
+    it('gives a failing fetch-mode source an error marker while a literal-mode source alongside it still renders normally', async () => {
+      const plugin = {
+        id: 'plugin-1',
+        name: 'Mixed Partial Failure',
+        refreshInterval: 15,
+        isActive: true,
+        dataSources: [
+          { name: 'weather', mode: 'fetch', url: 'https://api.example.com/weather', method: 'GET' },
+          { name: 'title', mode: 'literal', literalValue: 'Static Title' },
+        ],
+        templates: [{ layout: 'full', liquidMarkup: '{{ title }}' }],
+      } as unknown as Plugin
+
+      mockDataFetcher.fetchData = vi.fn().mockRejectedValue(new Error('API timeout'))
+      mockRenderCache.renderAndCache = vi.fn().mockResolvedValue(undefined)
+
+      service.schedulePlugin(plugin)
+      await capturedCallback!()
+
+      expect(mockRenderCache.renderAndCache).toHaveBeenCalledWith(
+        plugin,
+        expect.objectContaining({
+          weather: { error: true, message: 'API timeout' },
+          title: 'Static Title',
+        }),
       )
     })
 

--- a/packages/api/src/plugins/__test__/plugins.service.spec.ts
+++ b/packages/api/src/plugins/__test__/plugins.service.spec.ts
@@ -54,7 +54,14 @@ describe('pluginsService', () => {
     templateRepo = createMockRepository()
     fieldRepo = createMockRepository()
 
-    mockDataFetcher = { fetchData: vi.fn() } as any
+    mockDataFetcher = {
+      fetchData: vi.fn(),
+      fetchOrLiteral: vi.fn((source: any, ctx: any) =>
+        source.mode === 'literal'
+          ? Promise.resolve(source.literalValue ?? null)
+          : mockDataFetcher.fetchData(source.method || 'GET', source.url || '', source.headers, source.body, ctx),
+      ),
+    } as any
     mockRenderer = { render: vi.fn() } as any
     mockScheduler = {
       schedulePlugin: vi.fn(),
@@ -305,6 +312,59 @@ describe('pluginsService', () => {
     expect(fieldRepo.create).toHaveBeenCalled()
     expect(fieldRepo.save).toHaveBeenCalled()
     expect(result).toBe(savedPlugin)
+  })
+
+  it('create builds a literal-mode data source with its literalValue and no fetch fields', async () => {
+    const pluginData = {
+      name: 'Static Plugin',
+      dataSources: [
+        { name: 'title', mode: 'literal', literalValue: { text: 'Hello' } },
+      ],
+    }
+
+    const savedPlugin = { ...basePlugin, id: '2' } as Plugin
+    pluginRepo.save.mockResolvedValue(savedPlugin)
+    dataSourceRepo.create.mockReturnValue({})
+    dataSourceRepo.save.mockResolvedValue({})
+    pluginRepo.findOne.mockResolvedValue(savedPlugin)
+
+    await service.create(pluginData as any)
+
+    expect(dataSourceRepo.create).toHaveBeenCalledWith(expect.objectContaining({
+      name: 'title',
+      mode: 'literal',
+      literalValue: { text: 'Hello' },
+    }))
+    expect(dataSourceRepo.create).not.toHaveBeenCalledWith(expect.objectContaining({ url: expect.anything() }))
+  })
+
+  it('create tolerates a literal-mode data source carrying method "GET", the entity column\'s non-nullable default rather than a real fetch field', async () => {
+    const pluginData = {
+      name: 'Round-tripped Static Plugin',
+      dataSources: [
+        { name: 'title', mode: 'literal', literalValue: { text: 'Hello' }, method: 'GET' },
+      ],
+    }
+
+    const savedPlugin = { ...basePlugin, id: '2' } as Plugin
+    pluginRepo.save.mockResolvedValue(savedPlugin)
+    dataSourceRepo.create.mockReturnValue({})
+    dataSourceRepo.save.mockResolvedValue({})
+    pluginRepo.findOne.mockResolvedValue(savedPlugin)
+
+    await expect(service.create(pluginData as any)).resolves.toBe(savedPlugin)
+  })
+
+  it('create rejects a literal-mode data source that also carries a URL', async () => {
+    const pluginData = {
+      name: 'Bad Static Plugin',
+      dataSources: [
+        { name: 'title', mode: 'literal', literalValue: { text: 'Hello' }, url: 'https://api.example.com' },
+      ],
+    }
+
+    await expect(service.create(pluginData as any)).rejects.toThrow('A literal-mode Data Source cannot have a URL')
+    expect(pluginRepo.save).not.toHaveBeenCalled()
   })
 
   it('assignToDevice creates device plugin and screen', async () => {

--- a/packages/api/src/plugins/dto/__test__/create-plugin.dto.spec.ts
+++ b/packages/api/src/plugins/dto/__test__/create-plugin.dto.spec.ts
@@ -33,6 +33,7 @@ describe('create-plugin dto', () => {
     dto.dataSources = [
       {
         name: 'weather',
+        mode: 'fetch',
         url: 'https://api.example.com',
         method: 'GET',
         headers: {},
@@ -80,6 +81,40 @@ describe('create-plugin dto', () => {
       const errors = await violations(payload)
 
       expect(errors.some(message => message.includes('name must be a string'))).toBe(true)
+    })
+  })
+
+  describe('data source mode', () => {
+    it('accepts a literal-mode data source with only a literalValue', async () => {
+      const payload = { name: 'Plugin', dataSources: [{ name: 'source', mode: 'literal', literalValue: { title: 'Hello' } }] }
+
+      await expect(violations(payload)).resolves.toEqual([])
+    })
+
+    it('defaults to fetch mode and requires a URL when mode is omitted', async () => {
+      const payload = { name: 'Plugin', dataSources: [{ name: 'source' }] }
+
+      await expect(violations(payload)).resolves.toContain('A fetch-mode Data Source requires a URL')
+    })
+
+    it('rejects a literal-mode data source carrying a URL', async () => {
+      const payload = { name: 'Plugin', dataSources: [{ name: 'source', mode: 'literal', literalValue: {}, url: 'https://api.example.com' }] }
+
+      await expect(violations(payload)).resolves.toContain('A literal-mode Data Source cannot have a URL')
+    })
+
+    it('rejects a literal-mode data source missing a literalValue', async () => {
+      const payload = { name: 'Plugin', dataSources: [{ name: 'source', mode: 'literal' }] }
+
+      await expect(violations(payload)).resolves.toContain('A literal-mode Data Source requires a Value')
+    })
+
+    it('rejects an unknown mode', async () => {
+      const payload = { name: 'Plugin', dataSources: [{ name: 'source', mode: 'weird', url: 'https://api.example.com' }] }
+
+      const errors = await violations(payload)
+
+      expect(errors.some(message => message.includes('mode must be one of the following values: fetch, literal'))).toBe(true)
     })
   })
 

--- a/packages/api/src/plugins/dto/__test__/update-plugin.dto.spec.ts
+++ b/packages/api/src/plugins/dto/__test__/update-plugin.dto.spec.ts
@@ -31,6 +31,7 @@ describe('update-plugin dto', () => {
     dto.dataSources = [
       {
         name: 'weather',
+        mode: 'fetch',
         url: 'https://new-api.example.com',
         method: 'POST',
         headers: { Authorization: 'Bearer token' },

--- a/packages/api/src/plugins/dto/plugin-data-source.dto.ts
+++ b/packages/api/src/plugins/dto/plugin-data-source.dto.ts
@@ -1,16 +1,60 @@
+import type { ValidationArguments, ValidationOptions, ValidatorConstraintInterface } from 'class-validator'
 import type { JsonObject } from '../../utils/json'
-import { IsInt, IsObject, IsOptional, IsString } from 'class-validator'
+import type { DataSourceLiteralValue, DataSourceMode } from '../entities/plugin-data-source.entity'
+import { IsIn, IsInt, IsObject, IsOptional, IsString, registerDecorator, ValidatorConstraint } from 'class-validator'
+import { DATA_SOURCE_MODES } from '../entities/plugin-data-source.entity'
+import { dataSourceModeViolation } from '../plugin-data-source-mode'
+
+@ValidatorConstraint({ name: 'dataSourceModeFields' })
+class DataSourceModeFieldsConstraint implements ValidatorConstraintInterface {
+  validate(_value: unknown, args: ValidationArguments): boolean {
+    return dataSourceModeViolation(this.fieldsOf(args)) === null
+  }
+
+  defaultMessage(args: ValidationArguments): string {
+    return dataSourceModeViolation(this.fieldsOf(args)) ?? ''
+  }
+
+  private fieldsOf(args: ValidationArguments) {
+    const dto = args.object as PluginDataSourceDto
+    return {
+      mode: dto.mode,
+      method: dto.method,
+      url: dto.url,
+      headers: dto.headers,
+      body: dto.body,
+      transformJs: dto.transformJs,
+      literalValue: dto.literalValue,
+    }
+  }
+}
+
+function MatchesDataSourceMode(validationOptions?: ValidationOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      validator: DataSourceModeFieldsConstraint,
+    })
+  }
+}
 
 export class PluginDataSourceDto {
   @IsString()
   name: string
 
+  @IsIn(DATA_SOURCE_MODES)
+  @MatchesDataSourceMode()
+  mode: DataSourceMode = 'fetch'
+
   @IsOptional()
   @IsString()
   method?: string
 
+  @IsOptional()
   @IsString()
-  url: string
+  url?: string
 
   @IsOptional()
   @IsObject()
@@ -23,6 +67,9 @@ export class PluginDataSourceDto {
   @IsOptional()
   @IsString()
   transformJs?: string | null
+
+  @IsOptional()
+  literalValue?: DataSourceLiteralValue
 
   @IsOptional()
   @IsInt()

--- a/packages/api/src/plugins/dto/preview-plugin.dto.ts
+++ b/packages/api/src/plugins/dto/preview-plugin.dto.ts
@@ -1,16 +1,24 @@
 import type { JsonObject } from '../../utils/json'
+import type { DataSourceLiteralValue, DataSourceMode } from '../entities/plugin-data-source.entity'
 import { Type } from 'class-transformer'
-import { IsArray, IsObject, IsOptional, IsString, ValidateNested } from 'class-validator'
+import { IsArray, IsIn, IsObject, IsOptional, IsString, ValidateNested } from 'class-validator'
+import { DATA_SOURCE_MODES } from '../entities/plugin-data-source.entity'
 
 export class PreviewSourceDto {
   @IsString()
   name: string
 
-  @IsString()
-  url: string
+  @IsOptional()
+  @IsIn(DATA_SOURCE_MODES)
+  mode?: DataSourceMode
 
+  @IsOptional()
   @IsString()
-  method: string
+  url?: string
+
+  @IsOptional()
+  @IsString()
+  method?: string
 
   @IsOptional()
   @IsObject()
@@ -23,6 +31,9 @@ export class PreviewSourceDto {
   @IsOptional()
   @IsString()
   transformJs?: string
+
+  @IsOptional()
+  literalValue?: DataSourceLiteralValue
 }
 
 export class PreviewPluginDto {

--- a/packages/api/src/plugins/entities/plugin-data-source.entity.ts
+++ b/packages/api/src/plugins/entities/plugin-data-source.entity.ts
@@ -2,6 +2,14 @@ import type { JsonObject } from '../../utils/json'
 import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm'
 import { Plugin } from './plugin.entity'
 
+export const DATA_SOURCE_MODES = ['fetch', 'literal'] as const
+export type DataSourceMode = typeof DATA_SOURCE_MODES[number]
+
+// A plain object, array, or scalar — modeled shallowly (rather than as a fully
+// recursive JSON type) because TypeORM's DeepPartial mapping over a
+// self-referential union here blows past TS's recursion limit (TS2589).
+export type DataSourceLiteralValue = Record<string, unknown> | unknown[] | string | number | boolean | null
+
 @Entity()
 export class PluginDataSource {
   @PrimaryGeneratedColumn('uuid')
@@ -10,11 +18,14 @@ export class PluginDataSource {
   @Column('text')
   name: string
 
+  @Column('text', { default: 'fetch' })
+  mode: DataSourceMode = 'fetch'
+
   @Column('text', { default: 'GET' })
   method: string = 'GET'
 
-  @Column('text')
-  url: string
+  @Column('text', { nullable: true })
+  url?: string | null
 
   @Column('jsonb', { nullable: true })
   headers?: Record<string, string>
@@ -24,6 +35,9 @@ export class PluginDataSource {
 
   @Column('text', { nullable: true })
   transformJs?: string | null
+
+  @Column('jsonb', { nullable: true })
+  literalValue?: DataSourceLiteralValue
 
   @Column('int', { default: 0 })
   order: number = 0

--- a/packages/api/src/plugins/plugin-data-source-mode.ts
+++ b/packages/api/src/plugins/plugin-data-source-mode.ts
@@ -1,0 +1,60 @@
+import type { DataSourceMode } from './entities/plugin-data-source.entity'
+
+export interface DataSourceModeFields {
+  mode?: DataSourceMode
+  method?: unknown
+  url?: unknown
+  headers?: unknown
+  body?: unknown
+  transformJs?: unknown
+  literalValue?: unknown
+}
+
+function isPresent(value: unknown): boolean {
+  return value !== undefined && value !== null
+}
+
+/**
+ * fetch and literal Data Sources have disjoint required fields; a Data
+ * Source carrying a field from the mode it isn't is rejected rather than
+ * silently ignored — structurally parallel to pluginKindFieldViolation.
+ */
+export function dataSourceModeViolation(fields: DataSourceModeFields): string | null {
+  const { mode = 'fetch', method, url, headers, body, transformJs, literalValue } = fields
+
+  if (mode === 'literal') {
+    // PluginDataSource.method is a non-nullable column defaulting to 'GET'
+    // (shared with fetch mode, which needs a real default there) — a
+    // literal-mode row loaded back from storage always carries 'GET' even
+    // though nothing ever asked for it, so only a caller-supplied
+    // *non*-default method counts as a real fetch-field violation here.
+    if (isPresent(method) && method !== 'GET') {
+      return 'A literal-mode Data Source cannot have a Method'
+    }
+    if (isPresent(url)) {
+      return 'A literal-mode Data Source cannot have a URL'
+    }
+    if (isPresent(headers)) {
+      return 'A literal-mode Data Source cannot have Headers'
+    }
+    if (isPresent(body)) {
+      return 'A literal-mode Data Source cannot have a Body'
+    }
+    if (isPresent(transformJs)) {
+      return 'A literal-mode Data Source cannot have a Transform'
+    }
+    if (!isPresent(literalValue)) {
+      return 'A literal-mode Data Source requires a Value'
+    }
+    return null
+  }
+
+  if (isPresent(literalValue)) {
+    return 'A fetch-mode Data Source cannot have a Value'
+  }
+  if (!isPresent(url)) {
+    return 'A fetch-mode Data Source requires a URL'
+  }
+
+  return null
+}

--- a/packages/api/src/plugins/plugins.service.ts
+++ b/packages/api/src/plugins/plugins.service.ts
@@ -1,6 +1,7 @@
 import type { MashupSlot } from '../mashup/entities/mashup-slot.entity'
 import type { AssignPluginToDeviceDto } from './dto/assign-plugin-to-device.dto'
 import type { CreatePluginDto } from './dto/create-plugin.dto'
+import type { PluginDataSourceDto } from './dto/plugin-data-source.dto'
 import type { PreviewSourceDto } from './dto/preview-plugin.dto'
 import type { UpdateDeviceAssignmentDto } from './dto/update-device-assignment.dto'
 import type { UpdatePluginDto } from './dto/update-plugin.dto'
@@ -17,6 +18,7 @@ import { PluginDataSource } from './entities/plugin-data-source.entity'
 import { PluginField } from './entities/plugin-field.entity'
 import { PluginTemplate } from './entities/plugin-template.entity'
 import { Plugin } from './entities/plugin.entity'
+import { dataSourceModeViolation } from './plugin-data-source-mode'
 import { pluginKindFieldViolation } from './plugin-kind-fields'
 import { PluginDataFetcherService } from './services/plugin-data-fetcher.service'
 import { PluginRendererService } from './services/plugin-renderer.service'
@@ -170,6 +172,7 @@ export class PluginsService implements OnModuleInit {
 
     if (dataSources && Array.isArray(dataSources) && dataSources.length > 0) {
       this.validateDataSourceNames(dataSources, fields || [])
+      this.assertDataSourceModeFields(dataSources)
     }
 
     const kind = basicFields.kind || 'Poll'
@@ -205,13 +208,7 @@ export class PluginsService implements OnModuleInit {
       this.logger.debug(`Creating ${dataSources.length} data sources`)
       for (const [index, sourceData] of dataSources.entries()) {
         const newDataSource = this.dataSourceRepository.create({
-          name: sourceData.name,
-          method: sourceData.method || 'GET',
-          url: sourceData.url,
-          headers: sourceData.headers || {},
-          body: sourceData.body || {},
-          transformJs: sourceData.transformJs || null,
-          order: sourceData.order ?? index,
+          ...this.buildDataSourceFields(sourceData, index),
           plugin: savedPlugin,
         })
         await this.dataSourceRepository.save(newDataSource)
@@ -286,6 +283,10 @@ export class PluginsService implements OnModuleInit {
       this.validateDataSourceNames(finalDataSources, finalFields)
     }
 
+    if (dataSources !== undefined && Array.isArray(dataSources) && dataSources.length > 0) {
+      this.assertDataSourceModeFields(dataSources)
+    }
+
     const mergeStrategy = 'mergeStrategy' in basicFields ? basicFields.mergeStrategy : plugin.mergeStrategy
     const streamLimit = mergeStrategy === 'stream' ? basicFields.streamLimit ?? plugin.streamLimit : basicFields.streamLimit
 
@@ -307,13 +308,7 @@ export class PluginsService implements OnModuleInit {
       if (Array.isArray(dataSources) && dataSources.length > 0) {
         for (const [index, sourceData] of dataSources.entries()) {
           const newDataSource = this.dataSourceRepository.create({
-            name: sourceData.name,
-            method: sourceData.method || 'GET',
-            url: sourceData.url,
-            headers: sourceData.headers || {},
-            body: sourceData.body || {},
-            transformJs: sourceData.transformJs || null,
-            order: sourceData.order ?? index,
+            ...this.buildDataSourceFields(sourceData, index),
             plugin,
           })
           newDataSources.push(await this.dataSourceRepository.save(newDataSource))
@@ -376,6 +371,40 @@ export class PluginsService implements OnModuleInit {
     }
 
     return updated
+  }
+
+  private assertDataSourceModeFields(dataSources: PluginDataSourceDto[]): void {
+    for (const source of dataSources) {
+      const violation = dataSourceModeViolation(source)
+      if (violation) {
+        throw new BadRequestException(`Data source "${source.name}": ${violation}`)
+      }
+    }
+  }
+
+  private buildDataSourceFields(sourceData: PluginDataSourceDto, index: number) {
+    const mode = sourceData.mode || 'fetch'
+    const order = sourceData.order ?? index
+
+    if (mode === 'literal') {
+      return {
+        name: sourceData.name,
+        mode,
+        literalValue: sourceData.literalValue ?? null,
+        order,
+      }
+    }
+
+    return {
+      name: sourceData.name,
+      mode,
+      method: sourceData.method || 'GET',
+      url: sourceData.url,
+      headers: sourceData.headers || {},
+      body: sourceData.body || {},
+      transformJs: sourceData.transformJs || null,
+      order,
+    }
   }
 
   private validateDataSourceNames(dataSources: Array<{ name?: string }>, fields: Array<{ keyname?: string }>): void {
@@ -507,7 +536,7 @@ export class PluginsService implements OnModuleInit {
 
     const results = await Promise.allSettled(
       (sources || []).map(async (source) => {
-        let rawData = await this.dataFetcher.fetchData(source.method, source.url, source.headers, source.body, templateContext)
+        let rawData = await this.dataFetcher.fetchOrLiteral(source, templateContext)
         if (source.transformJs) {
           this.logger.debug(`Applying transform.js to data source: ${source.name}`)
           rawData = this.transformer.transform(source.transformJs, rawData)

--- a/packages/api/src/plugins/services/plugin-data-fetcher.service.ts
+++ b/packages/api/src/plugins/services/plugin-data-fetcher.service.ts
@@ -1,8 +1,21 @@
 import type { JsonObject } from '../../utils/json'
+import type { DataSourceLiteralValue, DataSourceMode } from '../entities/plugin-data-source.entity'
 import { Injectable, Logger } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import { assertPublicUrl } from '../../utils/ssrfGuard'
 import { PluginRendererService } from './plugin-renderer.service'
+
+// The subset of a Data Source's fields fetchOrLiteral needs — shared by the
+// PluginDataSource entity and PreviewSourceDto, which carry the same fields
+// under slightly different types.
+export interface FetchableDataSource {
+  mode?: DataSourceMode
+  method?: string
+  url?: string | null
+  headers?: Record<string, string>
+  body?: JsonObject
+  literalValue?: DataSourceLiteralValue
+}
 
 @Injectable()
 export class PluginDataFetcherService {
@@ -12,6 +25,20 @@ export class PluginDataFetcherService {
     private readonly renderer: PluginRendererService,
     private readonly configService: ConfigService,
   ) {}
+
+  /**
+   * Resolves one Data Source's value regardless of mode: a literal-mode
+   * source contributes its stored value directly, with no network call at
+   * all; a fetch-mode source is fetched as usual. Every render/schedule/
+   * preview path that iterates a Plugin's Data Sources should go through
+   * this rather than re-deriving the mode branch itself.
+   */
+  async fetchOrLiteral(source: FetchableDataSource, templateContext?: object): Promise<unknown> {
+    if (source.mode === 'literal') {
+      return source.literalValue ?? null
+    }
+    return this.fetchData(source.method || 'GET', source.url || '', source.headers, source.body, templateContext)
+  }
 
   async fetchData(
     method: string,

--- a/packages/api/src/plugins/services/plugin-exporter.service.ts
+++ b/packages/api/src/plugins/services/plugin-exporter.service.ts
@@ -32,14 +32,20 @@ export class PluginExporterService {
         refresh_interval: plugin.refreshInterval,
         data_sources: [...plugin.dataSources]
           .sort((a, b) => a.order - b.order)
-          .map(source => ({
-            name: source.name,
-            endpoint: source.url,
-            method: source.method,
-            headers: source.headers || {},
-            body: source.body || {},
-            ...(source.transformJs ? { transform_js: source.transformJs } : {}),
-          })),
+          .map(source => source.mode === 'literal'
+            ? {
+                name: source.name,
+                mode: 'literal',
+                literal_value: source.literalValue ?? null,
+              }
+            : {
+                name: source.name,
+                endpoint: source.url,
+                method: source.method,
+                headers: source.headers || {},
+                body: source.body || {},
+                ...(source.transformJs ? { transform_js: source.transformJs } : {}),
+              }),
       }
 
       const settingsYaml = yaml.dump(settings)

--- a/packages/api/src/plugins/services/plugin-importer.service.ts
+++ b/packages/api/src/plugins/services/plugin-importer.service.ts
@@ -35,11 +35,13 @@ interface CustomField {
 
 interface DataSourceEntry {
   name?: string
+  mode?: string
   endpoint?: string
   method?: string
   headers?: Record<string, string>
   body?: JsonObject
   transform_js?: string
+  literal_value?: JsonObject | JsonObject[] | string | number | boolean | null
 }
 
 interface TerminusSettings {
@@ -72,15 +74,20 @@ interface RecipeSettings extends TerminusSettings {
   description?: string
   oauth_enabled?: boolean
   strategy?: string
+  // Terminus schema: `maybe :hash` — a `strategy: static` recipe's fixed
+  // payload (issue #794 / ADR-0018)
+  static_data?: JsonObject | null
 }
 
 interface ParsedDataSource {
   name: string
-  method: string
-  url: string
+  mode: 'fetch' | 'literal'
+  method?: string
+  url?: string
   headers?: Record<string, string>
   body?: JsonObject
   transformJs?: string | null
+  literalValue?: JsonObject | JsonObject[] | string | number | boolean | null
 }
 
 export interface ParsedPlugin {
@@ -186,7 +193,7 @@ export class PluginImporterService {
     return this.parseZip(zip, fallbackName)
   }
 
-  private parseZip(zip: AdmZip, fallbackName: string): ParsedPlugin {
+  private parseZip(zip: AdmZip, fallbackName: string, forcedDataSources?: ParsedDataSource[]): ParsedPlugin {
     const zipEntries = zip.getEntries()
 
     this.logger.debug(`ZIP contains ${zipEntries.length} entries:`)
@@ -273,7 +280,7 @@ export class PluginImporterService {
       }
     })
 
-    return this.buildParsedPlugin(manifest, settings, templates, fallbackName, transformJs ?? undefined)
+    return this.buildParsedPlugin(manifest, settings, templates, fallbackName, transformJs ?? undefined, forcedDataSources)
   }
 
   parseRecipeId(recipeIdOrUrl: string): string {
@@ -323,7 +330,7 @@ export class PluginImporterService {
     }
 
     if (recipeSettings.strategy === 'static') {
-      throw new Error('Recipes with a "static" strategy are not supported yet')
+      return this.importStaticRecipe(entries, settingsContent, recipeSettings, recipeId)
     }
 
     if (recipeSettings.strategy !== 'polling') {
@@ -332,6 +339,35 @@ export class PluginImporterService {
 
     const reshapedZip = this.reshapeRecipeArchive(entries, settingsContent, recipeSettings)
     const parsed = this.parseZip(reshapedZip, `recipe-${recipeId}`)
+
+    return {
+      ...parsed,
+      fields: parsed.fields.map(field => field.fieldType === 'author_bio' ? { ...field, required: false } : field),
+      sourceRecipeId: recipeId,
+    }
+  }
+
+  // A `strategy: static` Recipe carries its fixed payload as `static_data`
+  // instead of a `polling_*` endpoint — it imports as a single `literal`-mode
+  // Data Source named 'source', matching the existing single-implicit-source
+  // naming convention (issue #794 / ADR-0018). Nothing fetches for a literal
+  // source, so a `transform.js` alongside it has nothing to transform.
+  private importStaticRecipe(entries: AdmZip.IZipEntry[], settingsContent: string, recipeSettings: RecipeSettings, recipeId: string): ParsedPlugin {
+    const hasTransform = entries.some(entry =>
+      entry.entryName === 'transform.js' || entry.entryName.endsWith('/transform.js'),
+    )
+    if (hasTransform) {
+      throw new Error('Static recipes with a transform.js aren\'t supported — nothing to transform')
+    }
+
+    const staticDataSource: ParsedDataSource = {
+      name: 'source',
+      mode: 'literal',
+      literalValue: isPlainObject(recipeSettings.static_data) ? recipeSettings.static_data as JsonObject : {},
+    }
+
+    const reshapedZip = this.reshapeRecipeArchive(entries, settingsContent, recipeSettings)
+    const parsed = this.parseZip(reshapedZip, `recipe-${recipeId}`, [staticDataSource])
 
     return {
       ...parsed,
@@ -423,6 +459,7 @@ export class PluginImporterService {
     templates: Array<{ layout: string, liquidMarkup: string }>,
     fallbackName: string,
     transformJs?: string,
+    forcedDataSources?: ParsedDataSource[],
   ): ParsedPlugin {
     this.logger.debug(`Parsed manifest: ${JSON.stringify(manifest)}`)
     this.logger.debug(`Parsed settings: ${JSON.stringify(settings)}`)
@@ -452,9 +489,10 @@ export class PluginImporterService {
       this.logger.warn('Ignoring src/transform.js: settings.yml uses the "data_sources" array format, where each entry carries its own "transform_js" instead')
     }
 
-    const dataSources = hasDataSourcesArray
-      ? this.parseDataSourcesArray(settings.data_sources!)
-      : [this.parseLegacySingleDataSource(settings, transformJs)]
+    const dataSources = forcedDataSources
+      ?? (hasDataSourcesArray
+        ? this.parseDataSourcesArray(settings.data_sources!)
+        : [this.parseLegacySingleDataSource(settings, transformJs)])
 
     // custom_fields can be in manifest or settings, can be empty object {}, missing, or an array
     const customFieldsSource = Array.isArray(manifest.custom_fields)
@@ -485,14 +523,23 @@ export class PluginImporterService {
 
   private parseDataSourcesArray(entries: DataSourceEntry[]): ParsedDataSource[] {
     return entries.map((entry, index) => {
+      const name = entry.name && entry.name.trim() !== '' ? entry.name.trim() : `source_${index + 1}`
+
+      if (entry.mode === 'literal') {
+        return {
+          name,
+          mode: 'literal' as const,
+          literalValue: entry.literal_value ?? {},
+        }
+      }
+
       if (!entry.endpoint || entry.endpoint.trim() === '') {
         throw new Error(`Data source at index ${index} is missing an "endpoint"`)
       }
 
-      const name = entry.name && entry.name.trim() !== '' ? entry.name.trim() : `source_${index + 1}`
-
       return {
         name,
+        mode: 'fetch' as const,
         method: (entry.method || 'GET').toUpperCase(),
         url: entry.endpoint.trim(),
         headers: entry.headers || {},
@@ -535,6 +582,7 @@ export class PluginImporterService {
 
     return {
       name: 'source',
+      mode: 'fetch',
       method: method?.toUpperCase() || 'GET',
       url: endpoint.trim(),
       headers,

--- a/packages/api/src/plugins/services/plugin-scheduler.service.ts
+++ b/packages/api/src/plugins/services/plugin-scheduler.service.ts
@@ -36,11 +36,11 @@ export class PluginSchedulerService {
         const templateContext = this.pluginTemplateContext.build(plugin, [])
 
         // Fetch all of the plugin's data sources in parallel; a source that fails
-        // gets an error marker instead of aborting the whole render (ADR-0005)
+        // gets an error marker instead of aborting the whole render (ADR-0005).
+        // A literal-mode source has no fetch to make — it contributes its
+        // stored value directly, with no call to the data fetcher at all.
         const results = await Promise.allSettled(
-          plugin.dataSources.map(source =>
-            this.dataFetcher.fetchData(source.method, source.url, source.headers, source.body, templateContext),
-          ),
+          plugin.dataSources.map(source => this.dataFetcher.fetchOrLiteral(source, templateContext)),
         )
 
         const sourceData: Record<string, unknown> = {}

--- a/packages/ui/src/components/PluginDataSourcesEditor.vue
+++ b/packages/ui/src/components/PluginDataSourcesEditor.vue
@@ -3,9 +3,14 @@ import type { PluginDataSource } from '@/types/plugin'
 import { mdiDelete, mdiPlus } from '@mdi/js'
 import { VAlert, VBtn, VExpansionPanel, VExpansionPanels, VExpansionPanelText, VExpansionPanelTitle, VSelect, VTextarea, VTextField } from 'vuetify/components'
 
-export type EditableDataSource = Partial<PluginDataSource> & { headersJson?: string }
+export type EditableDataSource = Partial<PluginDataSource> & { headersJson?: string, literalValueJson?: string }
 
 const dataSources = defineModel<EditableDataSource[]>({ required: true })
+
+const modeOptions = [
+  { title: 'Fetch (HTTP request)', value: 'fetch' },
+  { title: 'Literal (fixed value)', value: 'literal' },
+]
 
 const nameRules = [
   (value: string) => {
@@ -44,10 +49,24 @@ const urlRules = [
   },
 ]
 
+const literalValueRules = [
+  (value: string) => {
+    if (!value || !value.trim())
+      return 'Value is required'
+    try {
+      JSON.parse(value)
+      return true
+    }
+    catch {
+      return 'Enter valid JSON'
+    }
+  },
+]
+
 function addDataSource() {
   dataSources.value = [
     ...dataSources.value,
-    { name: '', method: 'GET', url: '', headers: {}, body: {}, headersJson: '', order: dataSources.value.length },
+    { name: '', mode: 'fetch', method: 'GET', url: '', headers: {}, body: {}, headersJson: '', order: dataSources.value.length },
   ]
 }
 
@@ -65,6 +84,35 @@ function syncHeaders(source: EditableDataSource) {
   }
   catch {
     // Leave the last valid headers in place until the JSON becomes valid again
+  }
+}
+
+function syncLiteralValue(source: EditableDataSource) {
+  if (!source.literalValueJson || !source.literalValueJson.trim()) {
+    source.literalValue = undefined
+    return
+  }
+  try {
+    source.literalValue = JSON.parse(source.literalValueJson)
+  }
+  catch {
+    // Leave the last valid value in place until the JSON becomes valid again
+  }
+}
+
+function onModeChange(source: EditableDataSource) {
+  if (source.mode === 'literal') {
+    source.method = undefined
+    source.url = undefined
+    source.headers = undefined
+    source.body = undefined
+    source.transformJs = undefined
+    source.headersJson = ''
+  }
+  else {
+    source.method = source.method || 'GET'
+    source.literalValue = undefined
+    source.literalValueJson = ''
   }
 }
 </script>
@@ -90,27 +138,56 @@ function syncHeaders(source: EditableDataSource) {
             required
             class="mt-2"
           />
-          <VTextField
-            v-model="source.url"
-            label="URL"
-            :rules="urlRules"
-            required
-            placeholder="https://api.example.com/data"
-            class="mt-4"
-          />
           <VSelect
-            v-model="source.method"
-            label="HTTP Method"
-            :items="['GET', 'POST']"
+            v-model="source.mode"
+            label="Data Source Mode"
+            :items="modeOptions"
+            item-title="title"
+            item-value="value"
+            hint="Fetch makes an HTTP request; Literal is a fixed value you type in"
+            persistent-hint
+            class="mt-4"
+            @update:model-value="onModeChange(source)"
           />
-          <VTextarea
-            v-model="source.headersJson"
-            label="Request Headers (JSON)"
-            rows="3"
-            placeholder="{&quot;Authorization&quot;: &quot;Bearer token&quot;}"
-            hint="Optional: Enter valid JSON for custom headers"
-            @update:model-value="syncHeaders(source)"
-          />
+
+          <template v-if="source.mode === 'literal'">
+            <VTextarea
+              v-model="source.literalValueJson"
+              label="Value (JSON)"
+              :rules="literalValueRules"
+              required
+              rows="5"
+              placeholder="{&quot;title&quot;: &quot;Hello&quot;}"
+              hint="Used in your template as {{ name.field }} — any JSON value"
+              persistent-hint
+              class="mt-4"
+              @update:model-value="syncLiteralValue(source)"
+            />
+          </template>
+          <template v-else>
+            <VTextField
+              v-model="source.url"
+              label="URL"
+              :rules="urlRules"
+              required
+              placeholder="https://api.example.com/data"
+              class="mt-4"
+            />
+            <VSelect
+              v-model="source.method"
+              label="HTTP Method"
+              :items="['GET', 'POST']"
+            />
+            <VTextarea
+              v-model="source.headersJson"
+              label="Request Headers (JSON)"
+              rows="3"
+              placeholder="{&quot;Authorization&quot;: &quot;Bearer token&quot;}"
+              hint="Optional: Enter valid JSON for custom headers"
+              @update:model-value="syncHeaders(source)"
+            />
+          </template>
+
           <VBtn
             variant="text"
             size="small"

--- a/packages/ui/src/components/__test__/PluginDataSourcesEditor.spec.ts
+++ b/packages/ui/src/components/__test__/PluginDataSourcesEditor.spec.ts
@@ -1,0 +1,95 @@
+import type { EditableDataSource } from '../PluginDataSourcesEditor.vue'
+import { mount } from '@vue/test-utils'
+import rop from 'resize-observer-polyfill'
+import { describe, expect, it } from 'vitest'
+import vuetify from '../../plugins/vuetify'
+import PluginDataSourcesEditor from '../PluginDataSourcesEditor.vue'
+
+globalThis.ResizeObserver = rop
+
+function mountEditor(dataSources: EditableDataSource[]) {
+  return mount(PluginDataSourcesEditor, {
+    props: { modelValue: dataSources },
+    global: { plugins: [vuetify] },
+  })
+}
+
+describe('pluginDataSourcesEditor', () => {
+  it('adds a new data source defaulting to fetch mode', async () => {
+    const wrapper = mountEditor([])
+    const vm = wrapper.vm as any
+
+    vm.addDataSource()
+    await wrapper.vm.$nextTick()
+
+    const emitted = wrapper.emitted('update:modelValue')!
+    expect(emitted.at(-1)![0]).toEqual([
+      expect.objectContaining({ name: '', mode: 'fetch', method: 'GET', url: '' }),
+    ])
+  })
+
+  it('clears fetch fields when switching a source to literal mode', async () => {
+    const source: EditableDataSource = { name: 'weather', mode: 'fetch', method: 'GET', url: 'https://api.example.com', headers: { A: 'b' }, headersJson: '{"A":"b"}' }
+    const wrapper = mountEditor([source])
+    const vm = wrapper.vm as any
+
+    vm.dataSources[0].mode = 'literal'
+    vm.onModeChange(vm.dataSources[0])
+    await wrapper.vm.$nextTick()
+
+    expect(vm.dataSources[0].url).toBeUndefined()
+    expect(vm.dataSources[0].method).toBeUndefined()
+    expect(vm.dataSources[0].headers).toBeUndefined()
+    expect(vm.dataSources[0].headersJson).toBe('')
+  })
+
+  it('restores a default method and clears the literal value when switching a source back to fetch mode', async () => {
+    const source: EditableDataSource = { name: 'title', mode: 'literal', literalValue: { text: 'Hi' }, literalValueJson: '{"text":"Hi"}' }
+    const wrapper = mountEditor([source])
+    const vm = wrapper.vm as any
+
+    vm.dataSources[0].mode = 'fetch'
+    vm.onModeChange(vm.dataSources[0])
+    await wrapper.vm.$nextTick()
+
+    expect(vm.dataSources[0].method).toBe('GET')
+    expect(vm.dataSources[0].literalValue).toBeUndefined()
+    expect(vm.dataSources[0].literalValueJson).toBe('')
+  })
+
+  it('parses literalValueJson into literalValue on sync', () => {
+    const source: EditableDataSource = { name: 'title', mode: 'literal', literalValueJson: '' }
+    const wrapper = mountEditor([source])
+    const vm = wrapper.vm as any
+
+    vm.dataSources[0].literalValueJson = '{"text":"Hello"}'
+    vm.syncLiteralValue(vm.dataSources[0])
+
+    expect(vm.dataSources[0].literalValue).toEqual({ text: 'Hello' })
+  })
+
+  it('keeps the last valid literalValue while the JSON is being typed and invalid', () => {
+    const source: EditableDataSource = { name: 'title', mode: 'literal', literalValue: { text: 'Hello' }, literalValueJson: '{"text":"Hello"}' }
+    const wrapper = mountEditor([source])
+    const vm = wrapper.vm as any
+
+    vm.dataSources[0].literalValueJson = '{"text": incomplete'
+    vm.syncLiteralValue(vm.dataSources[0])
+
+    expect(vm.dataSources[0].literalValue).toEqual({ text: 'Hello' })
+  })
+
+  it('removes a data source', async () => {
+    const wrapper = mountEditor([
+      { name: 'one', mode: 'fetch' },
+      { name: 'two', mode: 'fetch' },
+    ])
+    const vm = wrapper.vm as any
+
+    vm.removeDataSource(0)
+    await wrapper.vm.$nextTick()
+
+    const emitted = wrapper.emitted('update:modelValue')!
+    expect(emitted.at(-1)![0]).toEqual([expect.objectContaining({ name: 'two' })])
+  })
+})

--- a/packages/ui/src/types/plugin.ts
+++ b/packages/ui/src/types/plugin.ts
@@ -26,14 +26,19 @@ export interface DeviceAssignment {
   }
 }
 
+export type DataSourceMode = 'fetch' | 'literal'
+export type DataSourceLiteralValue = Record<string, unknown> | unknown[] | string | number | boolean | null
+
 export interface PluginDataSource {
   id: string
   name: string
+  mode: DataSourceMode
   method: string
-  url: string
+  url?: string
   headers?: Record<string, string>
   body?: Record<string, unknown>
   transformJs?: string
+  literalValue?: DataSourceLiteralValue
   order: number
 }
 
@@ -64,11 +69,13 @@ export interface PluginFieldValue {
 
 export interface CreatePluginDataSourcePayload {
   name: string
+  mode?: DataSourceMode
   method?: string
-  url: string
+  url?: string
   headers?: Record<string, string>
   body?: Record<string, unknown>
   transformJs?: string
+  literalValue?: DataSourceLiteralValue
   order?: number
 }
 

--- a/packages/ui/src/views/PluginCreateView.vue
+++ b/packages/ui/src/views/PluginCreateView.vue
@@ -75,6 +75,8 @@ const canProceedStep2 = computed(() => {
   return sources.every((source) => {
     if (!source.name || source.name.trim() === '' || source.name.trim() === 'trmnl')
       return false
+    if (source.mode === 'literal')
+      return source.literalValue !== undefined && source.literalValue !== null
     try {
       const _url = new URL(source.url || '')
       return true
@@ -126,10 +128,12 @@ async function previewPlugin() {
       body: JSON.stringify({
         sources: sources.map(source => ({
           name: source.name,
+          mode: source.mode,
           url: source.url,
           method: source.method,
           headers: source.headers,
           body: source.body,
+          literalValue: source.literalValue,
         })),
         template: pluginData.value.templates[0].liquidMarkup,
       }),
@@ -182,10 +186,12 @@ async function createPlugin() {
       refreshInterval: pluginData.value.refreshInterval,
       dataSources: sources.map((source, index) => ({
         name: source.name,
+        mode: source.mode,
         method: source.method,
         url: source.url,
         headers: source.headers,
         body: source.body,
+        literalValue: source.literalValue,
         order: index,
       })),
       templates: template

--- a/packages/ui/src/views/PluginEditView.vue
+++ b/packages/ui/src/views/PluginEditView.vue
@@ -72,6 +72,7 @@ onMounted(async () => {
       plugin.value.dataSources = (plugin.value.dataSources ?? []).map(source => ({
         ...source,
         headersJson: source.headers ? JSON.stringify(source.headers, null, 2) : '',
+        literalValueJson: source.literalValue !== undefined ? JSON.stringify(source.literalValue, null, 2) : '',
       }))
     }
     // Initialize field values from plugin fields
@@ -110,11 +111,13 @@ async function savePlugin() {
       ...plugin.value,
       dataSources: (plugin.value.dataSources || []).map((source, index): CreatePluginDataSourcePayload => ({
         name: source.name ?? '',
+        mode: source.mode,
         method: source.method,
-        url: source.url ?? '',
+        url: source.url,
         headers: source.headers,
         body: source.body,
         transformJs: source.transformJs,
+        literalValue: source.literalValue,
         order: index,
       })),
     }
@@ -142,11 +145,13 @@ async function previewPlugin() {
       body: JSON.stringify({
         sources: sources.map(source => ({
           name: source.name,
+          mode: source.mode,
           url: source.url,
           method: source.method,
           headers: source.headers,
           body: source.body,
           transformJs: source.transformJs,
+          literalValue: source.literalValue,
         })),
         template: plugin.value.templates[0].liquidMarkup,
         fieldValues: fieldValues.value,


### PR DESCRIPTION
## Summary
- Adds `PluginDataSource.mode: 'fetch' | 'literal'` (default `'fetch'`) plus a nullable `literalValue` jsonb column, per ADR-0018 — a `literal`-mode Data Source carries an admin-typed fixed JSON value instead of making an HTTP request.
- `fetch` and `literal` modes have disjoint required fields, enforced by a new `dataSourceModeViolation` validator structurally parallel to `pluginKindFieldViolation`.
- Every render/schedule/preview path (scheduled cron tick, on-demand device render, Mashup render, Plugin preview) resolves a Data Source's value through a new shared `PluginDataFetcherService.fetchOrLiteral`, so a literal-mode source never triggers a network call.
- `strategy: static` TRMNL Recipe import is now supported: the archive's `static_data` hash imports as one `literal`-mode Data Source named `source`; a static Recipe that also ships a `transform.js` is rejected with a clear error (nothing to transform against).
- Plugin editor UI (create + edit) gains a Data Source Mode toggle; literal mode shows a single JSON value editor instead of the URL/method/headers/body fields.

## Test plan
- [x] `pnpm -r run type-check` (api + ui)
- [x] `pnpm -r run test` — 777 API tests, 170 UI tests, all green
- [x] `pnpm -r run lint` — 0 errors
- [x] Manual smoke test against a real Postgres DB: ran the new migration, created/edited/previewed a literal-mode Plugin via `curl`, and drove the actual Edit-view + Preview dialog in a real browser (Puppeteer) — the literal value round-trips and renders correctly
- [x] `/code-review high` — caught a real bug (the editor didn't clear `method` when switching a source to literal mode, and the entity's non-nullable `method` default made a round-tripped literal source re-fail validation on save) — fixed and covered by new tests in both packages

https://claude.ai/code/session_01KTxV979yhpJFsz29RyACEG
