### PR TITLE
fix(plugins): stop PATCH /plugins/:id from rejecting bodies that omit kind

### DIFF
--- a/packages/api/src/plugins/__test__/plugins.service.spec.ts
+++ b/packages/api/src/plugins/__test__/plugins.service.spec.ts
@@ -5,7 +5,9 @@ import type { PluginDataFetcherService } from '../services/plugin-data-fetcher.s
 import type { PluginRendererService } from '../services/plugin-renderer.service'
 import type { PluginSchedulerService } from '../services/plugin-scheduler.service'
 import type { PluginTransformService } from '../services/plugin-transform.service'
+import { plainToInstance } from 'class-transformer'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { UpdatePluginDto } from '../dto/update-plugin.dto'
 import { PluginsService } from '../plugins.service'
 
 interface MockRepository {
@@ -848,6 +850,63 @@ describe('pluginsService', () => {
 
       await expect(service.clearWebhookPayload('1')).rejects.toThrow('is not a Webhook-kind Plugin')
       expect(pluginRepo.update).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('update through the real DTO transformation pipeline (regression for #828)', () => {
+    // plainToInstance gives every UpdatePluginDto field (incl. `kind`, `mergeStrategy`) an own
+    // property set to `undefined` even when the caller never sent it — a plain object literal
+    // cast `as any` doesn't reproduce that, so these tests go through the real pipeline instead.
+    function transform(body: Record<string, unknown>): UpdatePluginDto {
+      return plainToInstance(UpdatePluginDto, body)
+    }
+
+    it('update accepts a body that omits kind entirely, and leaves kind and other unset fields untouched', async () => {
+      const stored = { ...basePlugin }
+      pluginRepo.findOne.mockResolvedValue(stored)
+      pluginRepo.save.mockImplementation(async (plugin: any) => plugin)
+
+      const result = await service.update('1', transform({ description: 'test only' }))
+
+      expect(result).toMatchObject({
+        description: 'test only',
+        kind: basePlugin.kind,
+        name: basePlugin.name,
+        refreshInterval: basePlugin.refreshInterval,
+      })
+      expect(result?.kind).not.toBeUndefined()
+      expect(result?.name).not.toBeUndefined()
+    })
+
+    it('update accepts a webhook-kind body that omits mergeStrategy entirely, and leaves it untouched', async () => {
+      const stored = {
+        id: '1',
+        name: 'Sensor Feed',
+        kind: 'Webhook',
+        refreshInterval: 15,
+        webhookToken: 'token-abc',
+        mergeStrategy: 'stream',
+        streamLimit: 20,
+      } as unknown as Plugin
+      pluginRepo.findOne.mockResolvedValue(stored)
+      pluginRepo.save.mockImplementation(async (plugin: any) => plugin)
+
+      const result = await service.update('1', transform({ description: 'test only' }))
+
+      expect(result).toMatchObject({
+        description: 'test only',
+        kind: 'Webhook',
+        mergeStrategy: 'stream',
+        streamLimit: 20,
+      })
+    })
+
+    it('update still rejects an explicit kind change sent through the real pipeline', async () => {
+      pluginRepo.findOne.mockResolvedValue({ ...basePlugin })
+
+      await expect(service.update('1', transform({ kind: 'Webhook' }))).rejects.toThrow(
+        'A Plugin\'s Kind is fixed at creation and cannot be changed',
+      )
     })
   })
 })

--- a/packages/api/src/plugins/plugins.service.ts
+++ b/packages/api/src/plugins/plugins.service.ts
@@ -271,9 +271,17 @@ export class PluginsService implements OnModuleInit {
     if (!plugin)
       return null
 
-    const { dataSources, templates, fields, webhookToken, ...basicFields } = pluginData
+    const { dataSources, templates, fields, webhookToken, ...rawBasicFields } = pluginData
 
-    if ('kind' in basicFields && basicFields.kind !== plugin.kind) {
+    // class-transformer's plainToInstance (the real ValidationPipe path) gives every declared
+    // UpdatePluginDto field an own property equal to `undefined` even when the caller never sent
+    // it, so unset fields must be dropped here before they reach the Object.assign below —
+    // otherwise a partial PATCH would blank out every field the caller omitted.
+    const basicFields = Object.fromEntries(
+      Object.entries(rawBasicFields).filter(([, value]) => value !== undefined),
+    ) as typeof rawBasicFields
+
+    if (basicFields.kind !== undefined && basicFields.kind !== plugin.kind) {
       throw new BadRequestException(`A Plugin's Kind is fixed at creation and cannot be changed`)
     }
 
@@ -287,7 +295,7 @@ export class PluginsService implements OnModuleInit {
       this.assertDataSourceModeFields(dataSources)
     }
 
-    const mergeStrategy = 'mergeStrategy' in basicFields ? basicFields.mergeStrategy : plugin.mergeStrategy
+    const mergeStrategy = basicFields.mergeStrategy !== undefined ? basicFields.mergeStrategy : plugin.mergeStrategy
     const streamLimit = mergeStrategy === 'stream' ? basicFields.streamLimit ?? plugin.streamLimit : basicFields.streamLimit
 
     this.assertKindFields({


### PR DESCRIPTION
## Summary
- Fixes #828: any `PATCH /api/plugins/:id` body that didn't echo `kind` back was failing with `400 A Plugin's Kind is fixed at creation and cannot be changed` — in practice every real Plugin edit through the API/UI, since `PluginEditView.vue` never sends `kind`.
- Root cause: `class-transformer`'s `plainToInstance` (used by the real `ValidationPipe({ transform: true })`) gives every declared `UpdatePluginDto` field an own property equal to `undefined` even when the caller never sent it — TypeScript's `useDefineForClassFields` (from `target: es2022`) compiles bare `kind?: PluginKind` field declarations into real `Object.defineProperty` calls at construction time. So `'kind' in basicFields` was always `true`, tripping the guard on every partial PATCH.
- The same latent bug existed for `mergeStrategy` (`'mergeStrategy' in basicFields`), which would have falsely rejected a Webhook-kind Plugin PATCH that omits `mergeStrategy` with "A Webhook-kind Plugin requires a Merge Strategy" — caught while investigating, fixed alongside.
- Switched both checks to explicit `!== undefined` comparisons, and filtered `basicFields` down to only its actually-supplied keys before `Object.assign(plugin, basicFields, ...)` — a `/code-review high` pass caught that fixing only the guard would let the undefined-valued own properties reach `Object.assign` and silently blank out `kind`/`name`/`refreshInterval`/etc. on the returned entity for any partial PATCH.
- New regression tests build the DTO via the real `plainToInstance(UpdatePluginDto, ...)` pipeline (matching this project's existing `update-plugin.dto.spec.ts` pattern) instead of a plain object cast `as any`, since that's what let the original bug slip past the existing test suite.

## Test plan
- [x] `pnpm run type-check` (api + ui)
- [x] `pnpm run test` — 780 API tests, 170 UI tests, all green
- [x] `pnpm run lint` — 0 errors
- [x] Verified regression tests fail (red) against the pre-fix code and pass (green) against the fix
- [x] `/code-review high` — caught the `Object.assign` corruption follow-on bug described above; fixed and covered by strengthened assertions in the same tests

https://claude.ai/code/session_01U98kScwuMVJZ3LuLAGepdS