### PR TITLE
test(types): replace as any / hand-cast fixtures in spec files with typed helpers

### DIFF
--- a/packages/api/eslint.config.mjs
+++ b/packages/api/eslint.config.mjs
@@ -18,10 +18,4 @@ export default antfu(
       'ts/no-explicit-any': 'error',
     },
   },
-  {
-    files: ['**/__test__/**', '**/__tests__/**', '**/*.spec.ts'],
-    rules: {
-      'ts/no-explicit-any': 'warn',
-    },
-  },
 )

--- a/packages/api/src/device-models/__test__/custom-palettes.service.spec.ts
+++ b/packages/api/src/device-models/__test__/custom-palettes.service.spec.ts
@@ -1,40 +1,25 @@
-import type { Repository } from 'typeorm'
 import type { Palette } from '../entities/palette.entity'
 import { BadRequestException, NotFoundException } from '@nestjs/common'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { makePalette } from '../../test/fixtures'
+import { asRepository, createMockRepository } from '../../test/mockRepository'
 import { CustomPalettesService } from '../custom-palettes.service'
 import { CUSTOM_PALETTE_FRAMEWORK_CLASSES } from '../entities/palette.entity'
 
-interface MockRepository {
-  create: ReturnType<typeof vi.fn>
-  save: ReturnType<typeof vi.fn>
-  findOneBy: ReturnType<typeof vi.fn>
-  remove: ReturnType<typeof vi.fn>
-}
-
-function createMockRepository(): MockRepository {
-  return {
-    create: vi.fn(entity => entity),
-    save: vi.fn(async entity => entity),
-    findOneBy: vi.fn(),
-    remove: vi.fn(async entity => entity),
-  }
-}
-
-const validDto = { name: 'My Red', frameworkClass: 'screen--color-3bwr', colors: ['#ff0000', '#ffffff', '#000000'] } as const
+const validDto = { name: 'My Red', frameworkClass: 'screen--color-3bwr' as const, colors: ['#ff0000', '#ffffff', '#000000'] }
 
 describe('customPalettesService', () => {
   let service: CustomPalettesService
-  let repo: MockRepository
+  let repo: ReturnType<typeof createMockRepository<Palette>>
 
   beforeEach(() => {
-    repo = createMockRepository()
-    service = new CustomPalettesService(repo as unknown as Repository<Palette>)
+    repo = createMockRepository<Palette>()
+    service = new CustomPalettesService(asRepository(repo))
   })
 
   describe('create', () => {
     it.each(CUSTOM_PALETTE_FRAMEWORK_CLASSES)('creates a custom palette for the %s family', async (frameworkClass) => {
-      const result = await service.create({ ...validDto, frameworkClass } as any)
+      const result = await service.create({ ...validDto, frameworkClass })
       expect(result.kind).toBe('custom')
       expect(result.frameworkClass).toBe(frameworkClass)
       expect(result.colors).toEqual(validDto.colors)
@@ -42,48 +27,50 @@ describe('customPalettesService', () => {
     })
 
     it('generates an opaque id, not derived from name', async () => {
-      const result = await service.create({ ...validDto } as any)
+      const result = await service.create({ ...validDto })
       expect(result.id).not.toContain('My Red')
       expect(result.id).toMatch(/^[0-9a-f-]{36}$/)
     })
 
     it('generates a different id for every call', async () => {
-      const a = await service.create({ ...validDto } as any)
-      const b = await service.create({ ...validDto } as any)
+      const a = await service.create({ ...validDto })
+      const b = await service.create({ ...validDto })
       expect(a.id).not.toBe(b.id)
     })
 
     it('fixes grays at 2 and leaves grayscaleBitDepth unset', async () => {
-      const result = await service.create({ ...validDto } as any)
+      const result = await service.create({ ...validDto })
       expect(result.grays).toBe(2)
       expect(result.grayscaleBitDepth).toBeNull()
     })
 
     it('rejects a non-colour frameworkClass', async () => {
-      await expect(service.create({ ...validDto, frameworkClass: 'screen--1bit' } as any)).rejects.toThrow(BadRequestException)
+      // @ts-expect-error 'screen--1bit' is not a custom-palette frameworkClass
+      await expect(service.create({ ...validDto, frameworkClass: 'screen--1bit' })).rejects.toThrow(BadRequestException)
       expect(repo.save).not.toHaveBeenCalled()
     })
 
     it('rejects an unrecognised frameworkClass', async () => {
-      await expect(service.create({ ...validDto, frameworkClass: 'not-a-real-family' } as any)).rejects.toThrow(BadRequestException)
+      // @ts-expect-error not a real frameworkClass at all
+      await expect(service.create({ ...validDto, frameworkClass: 'not-a-real-family' })).rejects.toThrow(BadRequestException)
     })
 
     it('rejects an empty colors array', async () => {
-      await expect(service.create({ ...validDto, colors: [] } as any)).rejects.toThrow(BadRequestException)
+      await expect(service.create({ ...validDto, colors: [] })).rejects.toThrow(BadRequestException)
     })
 
     it('rejects a malformed colour value', async () => {
-      await expect(service.create({ ...validDto, colors: ['not-a-hex-color'] } as any)).rejects.toThrow(BadRequestException)
+      await expect(service.create({ ...validDto, colors: ['not-a-hex-color'] })).rejects.toThrow(BadRequestException)
     })
 
     it('rejects a missing name', async () => {
-      await expect(service.create({ ...validDto, name: '' } as any)).rejects.toThrow(BadRequestException)
+      await expect(service.create({ ...validDto, name: '' })).rejects.toThrow(BadRequestException)
     })
   })
 
   describe('delete', () => {
     it('hard-deletes an existing custom palette', async () => {
-      const palette = { id: 'abc', kind: 'custom' } as Palette
+      const palette = makePalette({ id: 'abc', kind: 'custom' })
       repo.findOneBy.mockResolvedValue(palette)
       await service.delete('abc')
       expect(repo.remove).toHaveBeenCalledWith(palette)
@@ -96,7 +83,7 @@ describe('customPalettesService', () => {
     })
 
     it('rejects deleting an official palette', async () => {
-      repo.findOneBy.mockResolvedValue({ id: 'bw', kind: 'official' } as Palette)
+      repo.findOneBy.mockResolvedValue(makePalette({ id: 'bw', kind: 'official' }))
       await expect(service.delete('bw')).rejects.toThrow(BadRequestException)
       expect(repo.remove).not.toHaveBeenCalled()
     })

--- a/packages/api/src/device-models/__test__/device-model-sync.service.spec.ts
+++ b/packages/api/src/device-models/__test__/device-model-sync.service.spec.ts
@@ -1,23 +1,14 @@
+import type { DeviceModel } from '../entities/device-model.entity'
+import type { Palette } from '../entities/palette.entity'
 import { Logger } from '@nestjs/common'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { jsonResponse, stubFetch } from '../../test/fetch'
+import { makeDeviceModel, makePalette } from '../../test/fixtures'
+import { asRepository, createMockRepository } from '../../test/mockRepository'
 import { TRMNL_MODELS_SNAPSHOT, TRMNL_PALETTES_SNAPSHOT } from '../data/trmnl-snapshot'
 import { DeviceModelSyncService } from '../device-model-sync.service'
 
-const mockFetch = vi.fn()
-globalThis.fetch = mockFetch
-
-function createMockRepo() {
-  return {
-    find: vi.fn(),
-    insert: vi.fn(),
-    upsert: vi.fn(),
-    update: vi.fn(),
-  }
-}
-
-function jsonResponse(data: unknown, ok = true) {
-  return { ok, status: ok ? 200 : 502, statusText: ok ? 'OK' : 'Bad Gateway', json: async () => ({ data }) }
-}
+const mockFetch = stubFetch()
 
 const paletteA = { id: 'bw', name: 'Black & White (1-bit)', grays: 2, framework_class: 'screen--1bit' }
 const paletteB = { id: 'gray-4', name: '4 Grays (2-bit)', grays: 4, framework_class: 'screen--2bit' }
@@ -40,14 +31,14 @@ const modelA = {
 
 describe('deviceModelSyncService', () => {
   let service: DeviceModelSyncService
-  let modelRepo: ReturnType<typeof createMockRepo>
-  let paletteRepo: ReturnType<typeof createMockRepo>
+  let modelRepo: ReturnType<typeof createMockRepository<DeviceModel>>
+  let paletteRepo: ReturnType<typeof createMockRepository<Palette>>
 
   beforeEach(() => {
     vi.resetAllMocks()
-    modelRepo = createMockRepo()
-    paletteRepo = createMockRepo()
-    service = new DeviceModelSyncService(modelRepo as any, paletteRepo as any)
+    modelRepo = createMockRepository<DeviceModel>()
+    paletteRepo = createMockRepository<Palette>()
+    service = new DeviceModelSyncService(asRepository(modelRepo), asRepository(paletteRepo))
   })
 
   describe('seedFromSnapshot', () => {
@@ -61,8 +52,8 @@ describe('deviceModelSyncService', () => {
     })
 
     it('only inserts rows that are missing and never touches existing ones', async () => {
-      modelRepo.find.mockResolvedValue(TRMNL_MODELS_SNAPSHOT.filter(m => m.name !== 'v2').map(m => ({ name: m.name })))
-      paletteRepo.find.mockResolvedValue(TRMNL_PALETTES_SNAPSHOT.map(p => ({ id: p.id })))
+      modelRepo.find.mockResolvedValue(TRMNL_MODELS_SNAPSHOT.filter(m => m.name !== 'v2').map(m => makeDeviceModel({ name: m.name })))
+      paletteRepo.find.mockResolvedValue(TRMNL_PALETTES_SNAPSHOT.map(p => makePalette({ id: p.id })))
       const result = await service.seedFromSnapshot()
       expect(result).toEqual({ models: 1, palettes: 0 })
       expect(paletteRepo.insert).not.toHaveBeenCalled()
@@ -74,10 +65,10 @@ describe('deviceModelSyncService', () => {
 
   describe('sync', () => {
     it('upserts the live lists and deprecates rows that vanished upstream without deleting them', async () => {
-      mockFetch.mockImplementation(async (url: string) =>
-        url.endsWith('/palettes') ? jsonResponse([paletteA, paletteB]) : jsonResponse([modelA]))
-      paletteRepo.find.mockResolvedValue([{ id: 'bw' }, { id: 'gray-4' }, { id: 'gray-16' }])
-      modelRepo.find.mockResolvedValue([{ name: 'og_plus' }, { name: 'gone' }])
+      mockFetch.mockImplementation(async url =>
+        url.toString().endsWith('/palettes') ? jsonResponse({ data: [paletteA, paletteB] }) : jsonResponse({ data: [modelA] }))
+      paletteRepo.find.mockResolvedValue([makePalette({ id: 'bw' }), makePalette({ id: 'gray-4' }), makePalette({ id: 'gray-16' })])
+      modelRepo.find.mockResolvedValue([makeDeviceModel({ name: 'og_plus' }), makeDeviceModel({ name: 'gone' })])
 
       const result = await service.sync()
 
@@ -105,10 +96,10 @@ describe('deviceModelSyncService', () => {
     })
 
     it('never upserts or deprecates a kind: custom palette, regardless of what upstream reports', async () => {
-      mockFetch.mockImplementation(async (url: string) =>
-        url.endsWith('/palettes') ? jsonResponse([paletteA]) : jsonResponse([modelA]))
-      paletteRepo.find.mockResolvedValue([{ id: 'bw' }])
-      modelRepo.find.mockResolvedValue([{ name: 'og_plus' }])
+      mockFetch.mockImplementation(async url =>
+        url.toString().endsWith('/palettes') ? jsonResponse({ data: [paletteA] }) : jsonResponse({ data: [modelA] }))
+      paletteRepo.find.mockResolvedValue([makePalette({ id: 'bw' })])
+      modelRepo.find.mockResolvedValue([makeDeviceModel({ name: 'og_plus' })])
 
       await service.sync()
 
@@ -120,10 +111,10 @@ describe('deviceModelSyncService', () => {
     })
 
     it('does not deprecate anything when the live list matches', async () => {
-      mockFetch.mockImplementation(async (url: string) =>
-        url.endsWith('/palettes') ? jsonResponse([paletteA]) : jsonResponse([modelA]))
-      paletteRepo.find.mockResolvedValue([{ id: 'bw' }])
-      modelRepo.find.mockResolvedValue([{ name: 'og_plus' }])
+      mockFetch.mockImplementation(async url =>
+        url.toString().endsWith('/palettes') ? jsonResponse({ data: [paletteA] }) : jsonResponse({ data: [modelA] }))
+      paletteRepo.find.mockResolvedValue([makePalette({ id: 'bw' })])
+      modelRepo.find.mockResolvedValue([makeDeviceModel({ name: 'og_plus' })])
       const result = await service.sync()
       expect(paletteRepo.update).not.toHaveBeenCalled()
       expect(modelRepo.update).not.toHaveBeenCalled()
@@ -131,14 +122,14 @@ describe('deviceModelSyncService', () => {
     })
 
     it('throws and writes nothing when TRMNL is unreachable', async () => {
-      mockFetch.mockResolvedValue(jsonResponse(null, false))
+      mockFetch.mockImplementation(async () => jsonResponse(null, { ok: false }))
       await expect(service.sync()).rejects.toThrow(/request failed/)
       expect(paletteRepo.upsert).not.toHaveBeenCalled()
       expect(modelRepo.upsert).not.toHaveBeenCalled()
     })
 
     it('throws when the response has no data array', async () => {
-      mockFetch.mockResolvedValue({ ok: true, status: 200, statusText: 'OK', json: async () => ({ nope: [] }) })
+      mockFetch.mockImplementation(async () => jsonResponse({ nope: [] }))
       await expect(service.sync()).rejects.toThrow(/no data array/)
     })
 
@@ -152,8 +143,8 @@ describe('deviceModelSyncService', () => {
     it('skips a palette with an invalid colour and logs it, without dropping other valid palettes', async () => {
       const warnSpy = vi.spyOn(Logger.prototype, 'warn').mockImplementation(() => {})
       const badPalette = { ...paletteB, id: 'gray-8', colors: ['#zzzzzz'] }
-      mockFetch.mockImplementation(async (url: string) =>
-        url.endsWith('/palettes') ? jsonResponse([paletteA, badPalette]) : jsonResponse([modelA]))
+      mockFetch.mockImplementation(async url =>
+        url.toString().endsWith('/palettes') ? jsonResponse({ data: [paletteA, badPalette] }) : jsonResponse({ data: [modelA] }))
       paletteRepo.find.mockResolvedValue([])
       modelRepo.find.mockResolvedValue([])
 
@@ -168,8 +159,8 @@ describe('deviceModelSyncService', () => {
     it('skips a model with an invalid id and logs it, without dropping other valid models', async () => {
       const warnSpy = vi.spyOn(Logger.prototype, 'warn').mockImplementation(() => {})
       const badModel = { ...modelA, name: '../evil' }
-      mockFetch.mockImplementation(async (url: string) =>
-        url.endsWith('/palettes') ? jsonResponse([paletteA]) : jsonResponse([modelA, badModel]))
+      mockFetch.mockImplementation(async url =>
+        url.toString().endsWith('/palettes') ? jsonResponse({ data: [paletteA] }) : jsonResponse({ data: [modelA, badModel] }))
       paletteRepo.find.mockResolvedValue([])
       modelRepo.find.mockResolvedValue([])
 
@@ -182,8 +173,8 @@ describe('deviceModelSyncService', () => {
     })
 
     it('coalesces concurrent sync() calls into a single run', async () => {
-      mockFetch.mockImplementation(async (url: string) =>
-        url.endsWith('/palettes') ? jsonResponse([paletteA]) : jsonResponse([modelA]))
+      mockFetch.mockImplementation(async url =>
+        url.toString().endsWith('/palettes') ? jsonResponse({ data: [paletteA] }) : jsonResponse({ data: [modelA] }))
       paletteRepo.find.mockResolvedValue([])
       modelRepo.find.mockResolvedValue([])
 

--- a/packages/api/src/device-models/__test__/device-models.controller.spec.ts
+++ b/packages/api/src/device-models/__test__/device-models.controller.spec.ts
@@ -1,8 +1,13 @@
-import type { MockDeviceModelsService } from './mockDeviceModelsService'
+import type { MockDeviceModelsService } from '../../test/mockDeviceModelsService'
+import type { CustomPalettesService } from '../custom-palettes.service'
+import type { DeviceModelSyncService } from '../device-model-sync.service'
+import type { DeviceModelsService } from '../device-models.service'
+import type { CreateCustomPaletteDto } from '../dto/create-custom-palette.dto'
 import { ServiceUnavailableException } from '@nestjs/common'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { BW, createMockDeviceModelsService, CUSTOM_RED_3BWR, OG_PLUS } from '../../test/mockDeviceModelsService'
+import { asService } from '../../test/mockService'
 import { DeviceModelsController } from '../device-models.controller'
-import { BW, createMockDeviceModelsService, CUSTOM_RED_3BWR, OG_PLUS } from './mockDeviceModelsService'
 
 describe('deviceModelsController', () => {
   let controller: DeviceModelsController
@@ -14,7 +19,11 @@ describe('deviceModelsController', () => {
     deviceModels = createMockDeviceModelsService()
     syncService = { sync: vi.fn() }
     customPalettesService = { create: vi.fn(), delete: vi.fn() }
-    controller = new DeviceModelsController(deviceModels as any, syncService as any, customPalettesService as any)
+    controller = new DeviceModelsController(
+      asService<DeviceModelsService>(deviceModels),
+      asService<DeviceModelSyncService>(syncService),
+      asService<CustomPalettesService>(customPalettesService),
+    )
   })
 
   it('lists device models', async () => {
@@ -39,7 +48,7 @@ describe('deviceModelsController', () => {
   })
 
   it('delegates palette creation to CustomPalettesService', async () => {
-    const dto = { name: 'My Red', frameworkClass: 'screen--color-3bwr', colors: ['#ff0000'] } as any
+    const dto: CreateCustomPaletteDto = { name: 'My Red', frameworkClass: 'screen--color-3bwr', colors: ['#ff0000'] }
     customPalettesService.create.mockResolvedValue(CUSTOM_RED_3BWR)
     await expect(controller.createPalette(dto)).resolves.toBe(CUSTOM_RED_3BWR)
     expect(customPalettesService.create).toHaveBeenCalledWith(dto)

--- a/packages/api/src/device-models/__test__/device-models.service.spec.ts
+++ b/packages/api/src/device-models/__test__/device-models.service.spec.ts
@@ -1,6 +1,10 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { DeviceReport } from '../device-models.service'
+import type { DeviceModel } from '../entities/device-model.entity'
+import type { Palette } from '../entities/palette.entity'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { BW, GRAY_4, GRAY_16, OG_PLUS, V2 } from '../../test/mockDeviceModelsService'
+import { asRepository, createMockRepository } from '../../test/mockRepository'
 import { DeviceModelsService } from '../device-models.service'
-import { BW, GRAY_4, GRAY_16, OG_PLUS, V2 } from './mockDeviceModelsService'
 
 const SEEED_E1003 = { ...V2, name: 'seeed_e1003', label: 'reTerminal E1003', kind: 'byod' }
 const COLOR_6A = { ...BW, id: 'color-6a', name: 'Color (6 colors)', grays: 2, colors: ['#FF0000', '#00FF00', '#0000FF', '#FFFF00', '#000000', '#FFFFFF'], frameworkClass: 'screen--color-6a', grayscaleBitDepth: 1 }
@@ -9,30 +13,35 @@ const OG_BWRY = { ...OG_PLUS, name: 'og_bwry', label: 'TRMNL OG (colour)', kind:
 const OG_PNG = { ...OG_PLUS, name: 'og_png', label: 'TRMNL OG (1-bit)', kind: 'trmnl' }
 const ONYX_BOOX_NOVA_AIR_C = { ...V2, name: 'onxy_boox_nova_air_c', label: 'Onyx Boox Nova Air C', kind: 'byod' }
 
-function createMockRepo() {
-  return {
-    find: vi.fn(),
-    findOneBy: vi.fn(),
-  }
+function firstWhere<T>(where: T | T[] | undefined): T | undefined {
+  return Array.isArray(where) ? where[0] : where
 }
 
 describe('deviceModelsService', () => {
   let service: DeviceModelsService
-  let modelRepo: ReturnType<typeof createMockRepo>
-  let paletteRepo: ReturnType<typeof createMockRepo>
+  let modelRepo: ReturnType<typeof createMockRepository<DeviceModel>>
+  let paletteRepo: ReturnType<typeof createMockRepository<Palette>>
 
   const models = [OG_PLUS, V2, SEEED_E1003, SEEED_E1002, OG_BWRY, OG_PNG, ONYX_BOOX_NOVA_AIR_C]
   const palettes = [BW, GRAY_4, GRAY_16, COLOR_6A]
 
   beforeEach(() => {
-    modelRepo = createMockRepo()
-    paletteRepo = createMockRepo()
-    modelRepo.findOneBy.mockImplementation(async ({ name }) => models.find(m => m.name === name) ?? null)
-    modelRepo.find.mockImplementation(async ({ where } = {}) =>
-      where ? models.filter(m => m.width === where.width && m.height === where.height && m.deprecated === where.deprecated) : models)
+    modelRepo = createMockRepository<DeviceModel>()
+    paletteRepo = createMockRepository<Palette>()
+    modelRepo.findOneBy.mockImplementation(async (where) => {
+      const w = firstWhere(where)
+      return models.find(m => m.name === w?.name) ?? null
+    })
+    modelRepo.find.mockImplementation(async (options = {}) => {
+      const where = firstWhere(options.where)
+      return where ? models.filter(m => m.width === where.width && m.height === where.height && m.deprecated === where.deprecated) : models
+    })
     paletteRepo.find.mockResolvedValue(palettes)
-    paletteRepo.findOneBy.mockImplementation(async ({ id }) => palettes.find(p => p.id === id) ?? null)
-    service = new DeviceModelsService(modelRepo as any, paletteRepo as any)
+    paletteRepo.findOneBy.mockImplementation(async (where) => {
+      const w = firstWhere(where)
+      return palettes.find(p => p.id === w?.id) ?? null
+    })
+    service = new DeviceModelsService(asRepository(modelRepo), asRepository(paletteRepo))
   })
 
   describe('resolve', () => {
@@ -106,14 +115,14 @@ describe('deviceModelsService', () => {
 
   describe('assignResolvedModel', () => {
     it('sets model and default palette on the device', async () => {
-      const device = { reportedModel: 'x', width: 1872, height: 1404 } as any
+      const device: DeviceReport & { deviceModel?: DeviceModel | null, palette?: Palette | null } = { reportedModel: 'x', width: 1872, height: 1404 }
       await expect(service.assignResolvedModel(device)).resolves.toBe(V2)
       expect(device.deviceModel).toBe(V2)
       expect(device.palette).toBe(GRAY_16)
     })
 
     it('leaves the device untouched when nothing resolves', async () => {
-      const device = { reportedModel: 'unknown_board' } as any
+      const device: DeviceReport & { deviceModel?: DeviceModel | null, palette?: Palette | null } = { reportedModel: 'unknown_board' }
       await expect(service.assignResolvedModel(device)).resolves.toBeNull()
       expect(device.deviceModel).toBeUndefined()
       expect(device.palette).toBeUndefined()

--- a/packages/api/src/device-models/__test__/fallback-screens.service.spec.ts
+++ b/packages/api/src/device-models/__test__/fallback-screens.service.spec.ts
@@ -1,7 +1,9 @@
+import type { ConfigService } from '@nestjs/config'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { GRAY_16, V2 } from '../../test/mockDeviceModelsService'
+import { asService } from '../../test/mockService'
 import { FALLBACK_SCREEN_TEMPLATE_VERSION } from '../fallback-screen-templates'
 import { FallbackScreensService } from '../fallback-screens.service'
-import { GRAY_16, V2 } from './mockDeviceModelsService'
 
 const { statMock, renderHtmlToPng } = vi.hoisted(() => ({
   statMock: vi.fn(),
@@ -25,7 +27,7 @@ describe('fallbackScreensService', () => {
 
   beforeEach(() => {
     vi.resetAllMocks()
-    service = new FallbackScreensService({ get: () => 'http://api' } as any)
+    service = new FallbackScreensService(asService<ConfigService>({ get: () => 'http://api' }))
   })
 
   it('generates the placeholder for the target when it does not exist yet', async () => {

--- a/packages/api/src/device-models/__test__/screen-shell.spec.ts
+++ b/packages/api/src/device-models/__test__/screen-shell.spec.ts
@@ -1,10 +1,14 @@
 import type { DeviceRenderTarget } from '../device-models.service'
 import { describe, expect, it } from 'vitest'
 import { SCREEN_SHELL_FIXTURE_BODY, SCREEN_SHELL_FIXTURE_EXPECTED, SCREEN_SHELL_FIXTURE_MODEL, SCREEN_SHELL_FIXTURE_PALETTE } from '../../../../../test/fixtures/screen-shell.fixture'
+import { BW, GRAY_4, GRAY_16, OG_PLUS, V2 } from '../../test/mockDeviceModelsService'
+import { asService } from '../../test/mockService'
 import { screenClasses, screenStyle, viewFull, wrapInScreenShell } from '../screen-shell'
-import { BW, GRAY_4, GRAY_16, OG_PLUS, V2 } from './mockDeviceModelsService'
 
-const fixtureTarget = { model: SCREEN_SHELL_FIXTURE_MODEL, palette: SCREEN_SHELL_FIXTURE_PALETTE } as unknown as DeviceRenderTarget
+// The shared cross-package fixture is deliberately untyped against either package's
+// DeviceModel/Palette entities (see the comment in screen-shell.fixture.ts) — this is the
+// one documented boundary cast into this package's DeviceRenderTarget shape.
+const fixtureTarget = asService<DeviceRenderTarget>({ model: SCREEN_SHELL_FIXTURE_MODEL, palette: SCREEN_SHELL_FIXTURE_PALETTE })
 
 describe('screen shell', () => {
   it('builds the screen class list from model and palette', () => {

--- a/packages/api/src/device-sensors/__test__/device-sensors.service.spec.ts
+++ b/packages/api/src/device-sensors/__test__/device-sensors.service.spec.ts
@@ -1,27 +1,19 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { DeviceSensor } from '../entities/device-sensor.entity'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { makeDevice, makeDeviceSensor } from '../../test/fixtures'
+import { asRepository, createMockRepository } from '../../test/mockRepository'
 import { DeviceSensorsService } from '../device-sensors.service'
-
-function createMockRepo() {
-  return {
-    find: vi.fn(),
-    save: vi.fn(),
-    remove: vi.fn(),
-    create: vi.fn((attrs: any) => attrs),
-  }
-}
 
 describe('deviceSensorsService', () => {
   let service: DeviceSensorsService
-  let sensorRepo: ReturnType<typeof createMockRepo>
+  let sensorRepo: ReturnType<typeof createMockRepository<DeviceSensor>>
 
-  const device = { id: 'device-1' } as any
+  const device = makeDevice({ id: 'device-1' })
 
   beforeEach(() => {
-    sensorRepo = createMockRepo()
+    sensorRepo = createMockRepository<DeviceSensor>()
     sensorRepo.find.mockResolvedValue([])
-    sensorRepo.save.mockImplementation(async (row: any) => row)
-    sensorRepo.remove.mockResolvedValue(undefined)
-    service = new DeviceSensorsService(sensorRepo as any)
+    service = new DeviceSensorsService(asRepository(sensorRepo))
   })
 
   describe('syncFromHeader', () => {
@@ -37,7 +29,7 @@ describe('deviceSensorsService', () => {
     })
 
     it('updates value/unit in place for a kind that already has a row', async () => {
-      const existingRow = { id: 'row-1', kind: 'temperature', value: 20, unit: 'C' }
+      const existingRow = makeDeviceSensor({ id: 'row-1', kind: 'temperature', value: 20, unit: 'C', device })
       sensorRepo.find.mockResolvedValue([existingRow])
 
       await service.syncFromHeader(device, 'kind=temperature;value=22.1;unit=C')
@@ -47,8 +39,8 @@ describe('deviceSensorsService', () => {
     })
 
     it('clears only the kinds missing from this poll, leaving present kinds untouched', async () => {
-      const temperatureRow = { id: 'row-1', kind: 'temperature', value: 20, unit: 'C' }
-      const humidityRow = { id: 'row-2', kind: 'humidity', value: 40, unit: '%' }
+      const temperatureRow = makeDeviceSensor({ id: 'row-1', kind: 'temperature', value: 20, unit: 'C', device })
+      const humidityRow = makeDeviceSensor({ id: 'row-2', kind: 'humidity', value: 40, unit: '%', device })
       sensorRepo.find.mockResolvedValue([temperatureRow, humidityRow])
 
       await service.syncFromHeader(device, 'kind=temperature;value=21;unit=C')
@@ -83,7 +75,7 @@ describe('deviceSensorsService', () => {
     })
 
     it('clears every existing row when the header is absent', async () => {
-      const temperatureRow = { id: 'row-1', kind: 'temperature', value: 20, unit: 'C' }
+      const temperatureRow = makeDeviceSensor({ id: 'row-1', kind: 'temperature', value: 20, unit: 'C', device })
       sensorRepo.find.mockResolvedValue([temperatureRow])
 
       await service.syncFromHeader(device, undefined)
@@ -93,7 +85,7 @@ describe('deviceSensorsService', () => {
     })
 
     it('clears every existing row when the header is blank', async () => {
-      const temperatureRow = { id: 'row-1', kind: 'temperature', value: 20, unit: 'C' }
+      const temperatureRow = makeDeviceSensor({ id: 'row-1', kind: 'temperature', value: 20, unit: 'C', device })
       sensorRepo.find.mockResolvedValue([temperatureRow])
 
       await service.syncFromHeader(device, '')
@@ -111,7 +103,7 @@ describe('deviceSensorsService', () => {
 
   describe('findForDevice', () => {
     it('queries rows scoped to the given device', async () => {
-      const rows = [{ id: 'row-1', kind: 'temperature', value: 21, unit: 'C' }]
+      const rows = [makeDeviceSensor({ id: 'row-1', kind: 'temperature', value: 21, unit: 'C', device })]
       sensorRepo.find.mockResolvedValue(rows)
 
       await expect(service.findForDevice('device-1')).resolves.toBe(rows)

--- a/packages/api/src/devices/__test__/devices.controller.spec.ts
+++ b/packages/api/src/devices/__test__/devices.controller.spec.ts
@@ -3,6 +3,7 @@ import type { CreateDeviceDto } from '../dto/create-device.dto'
 import type { UpdateDeviceDto } from '../dto/update-device.dto'
 import { BadRequestException, NotFoundException } from '@nestjs/common'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { asService } from '../../test/mockService'
 import { DevicesController } from '../devices.controller'
 
 function createMockService() {
@@ -21,7 +22,7 @@ describe('devicesController', () => {
 
   beforeEach(() => {
     service = createMockService()
-    controller = new DevicesController(service as unknown as DevicesService)
+    controller = new DevicesController(asService<DevicesService>(service))
   })
 
   it('getAll returns all devices', async () => {

--- a/packages/api/src/devices/__test__/devices.service.spec.ts
+++ b/packages/api/src/devices/__test__/devices.service.spec.ts
@@ -1,45 +1,37 @@
-import type { Repository } from 'typeorm'
-import type { MockDeviceModelsService } from '../../device-models/__test__/mockDeviceModelsService'
+import type { DeviceModelsService } from '../../device-models/device-models.service'
+import type { FirmwareService } from '../../firmware/firmware.service'
+import type { ScreensService } from '../../screens/screens.service'
+import type { MockDeviceModelsService } from '../../test/mockDeviceModelsService'
 import type { Device } from '../devices.entity'
 import { BadRequestException } from '@nestjs/common'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { BW, createMockDeviceModelsService, CUSTOM_RED_3BWR, GRAY_4, GRAY_16, OG_PLUS, V2 } from '../../device-models/__test__/mockDeviceModelsService'
+import { makeDevice, makeFirmware } from '../../test/fixtures'
+import { BW, createMockDeviceModelsService, CUSTOM_RED_3BWR, GRAY_4, GRAY_16, OG_PLUS, V2 } from '../../test/mockDeviceModelsService'
+import { asRepository, createMockRepository } from '../../test/mockRepository'
+import { asService } from '../../test/mockService'
 import { DevicesService } from '../devices.service'
-
-interface MockRepository {
-  find: ReturnType<typeof vi.fn>
-  findOneBy: ReturnType<typeof vi.fn>
-  create: ReturnType<typeof vi.fn>
-  save: ReturnType<typeof vi.fn>
-  remove: ReturnType<typeof vi.fn>
-}
-
-function createMockRepository(): MockRepository {
-  return {
-    find: vi.fn(),
-    findOneBy: vi.fn(),
-    create: vi.fn(),
-    save: vi.fn(),
-    remove: vi.fn(),
-  }
-}
 
 describe('devicesService', () => {
   let service: DevicesService
-  let repo: MockRepository
+  let repo: ReturnType<typeof createMockRepository<Device>>
   let deviceModels: MockDeviceModelsService
   let firmwareService: { findById: ReturnType<typeof vi.fn> }
   let screensService: { reconvertImageScreens: ReturnType<typeof vi.fn> }
 
   beforeEach(() => {
-    repo = createMockRepository()
+    repo = createMockRepository<Device>()
     deviceModels = createMockDeviceModelsService()
     firmwareService = { findById: vi.fn() }
     screensService = { reconvertImageScreens: vi.fn().mockResolvedValue(0) }
-    service = new DevicesService(repo as unknown as Repository<Device>, deviceModels as any, firmwareService as any, screensService as any)
+    service = new DevicesService(
+      asRepository(repo),
+      asService<DeviceModelsService>(deviceModels),
+      asService<FirmwareService>(firmwareService),
+      asService<ScreensService>(screensService),
+    )
   })
 
-  const baseDevice = {
+  const baseDevice: Device = makeDevice({
     id: '1',
     friendlyId: 'abc',
     mac: '00:11:22:33:44:55',
@@ -47,19 +39,8 @@ describe('devicesService', () => {
     refreshRate: 60,
     resetDevice: false,
     updateFirmware: false,
-    screens: [],
-    // Optional fields
-    batteryVoltage: undefined,
-    fwVersion: undefined,
-    rssi: undefined,
-    userAgent: undefined,
-    width: undefined,
-    height: undefined,
-    mirrorEnabled: undefined,
-    mirrorMac: undefined,
-    mirrorApikey: undefined,
     specialFunction: 'identify',
-  } as unknown as Device
+  })
 
   it('findAll returns all devices ordered by friendlyId', async () => {
     const devices = [baseDevice]
@@ -77,10 +58,10 @@ describe('devicesService', () => {
   })
 
   it('create creates and saves a new device with a friendlyId', async () => {
-    const device: Partial<Device> = { mac: '00:11:22:33:44:55' }
+    const device = { mac: '00:11:22:33:44:55', name: 'Test Device' }
     repo.create.mockReturnValue(baseDevice)
     repo.save.mockResolvedValue(baseDevice)
-    const result = await service.create(device as any)
+    const result = await service.create(device)
     expect(repo.create).toHaveBeenCalled()
     expect(repo.save).toHaveBeenCalledWith(baseDevice)
     expect(result).toBe(baseDevice)
@@ -88,9 +69,9 @@ describe('devicesService', () => {
 
   it('update updates and saves an existing device', async () => {
     repo.findOneBy.mockResolvedValue(baseDevice)
-    const updated = { ...baseDevice, mac: 'AA:BB:CC:DD:EE:FF' } as unknown as Device
+    const updated = makeDevice({ ...baseDevice, mac: 'AA:BB:CC:DD:EE:FF' })
     repo.save.mockResolvedValue(updated)
-    const result = await service.update('1', { mac: 'AA:BB:CC:DD:EE:FF' } as any)
+    const result = await service.update('1', { mac: 'AA:BB:CC:DD:EE:FF' })
     expect(repo.findOneBy).toHaveBeenCalledWith({ id: '1' })
     expect(repo.save).toHaveBeenCalledWith({ ...baseDevice, mac: 'AA:BB:CC:DD:EE:FF' })
     expect(result).toEqual(updated)
@@ -98,41 +79,41 @@ describe('devicesService', () => {
 
   it('update returns null if device not found', async () => {
     repo.findOneBy.mockResolvedValue(null)
-    const result = await service.update('1', { mac: 'AA:BB:CC:DD:EE:FF' } as any)
+    const result = await service.update('1', { mac: 'AA:BB:CC:DD:EE:FF' })
     expect(result).toBeNull()
   })
 
   describe('update with sleep mode', () => {
     it('rejects a PATCH that clears the window while sleep mode is already enabled', async () => {
-      repo.findOneBy.mockResolvedValue({ ...baseDevice, sleepModeEnabled: true, sleepStartTime: 79200, sleepEndTime: 21600 })
-      await expect(service.update('1', { sleepStartTime: null } as any)).rejects.toThrow(BadRequestException)
+      repo.findOneBy.mockResolvedValue(makeDevice({ ...baseDevice, sleepModeEnabled: true, sleepStartTime: 79200, sleepEndTime: 21600 }))
+      await expect(service.update('1', { sleepStartTime: null })).rejects.toThrow(BadRequestException)
       expect(repo.save).not.toHaveBeenCalled()
     })
 
     it('allows disabling sleep mode without sending the window', async () => {
-      const device = { ...baseDevice, sleepModeEnabled: true, sleepStartTime: 79200, sleepEndTime: 21600 }
+      const device = makeDevice({ ...baseDevice, sleepModeEnabled: true, sleepStartTime: 79200, sleepEndTime: 21600 })
       repo.findOneBy.mockResolvedValue(device)
       repo.save.mockResolvedValue({ ...device, sleepModeEnabled: false })
-      await expect(service.update('1', { sleepModeEnabled: false } as any)).resolves.toBeTruthy()
+      await expect(service.update('1', { sleepModeEnabled: false })).resolves.toBeTruthy()
     })
 
     it('allows enabling sleep mode together with a full window in the same request', async () => {
-      repo.findOneBy.mockResolvedValue({ ...baseDevice, sleepModeEnabled: false, sleepStartTime: null, sleepEndTime: null })
-      repo.save.mockResolvedValue({ ...baseDevice, sleepModeEnabled: true, sleepStartTime: 79200, sleepEndTime: 21600 })
-      await expect(service.update('1', { sleepModeEnabled: true, sleepStartTime: 79200, sleepEndTime: 21600 } as any)).resolves.toBeTruthy()
+      repo.findOneBy.mockResolvedValue(makeDevice({ ...baseDevice, sleepModeEnabled: false, sleepStartTime: null, sleepEndTime: null }))
+      repo.save.mockResolvedValue(makeDevice({ ...baseDevice, sleepModeEnabled: true, sleepStartTime: 79200, sleepEndTime: 21600 }))
+      await expect(service.update('1', { sleepModeEnabled: true, sleepStartTime: 79200, sleepEndTime: 21600 })).resolves.toBeTruthy()
     })
   })
 
   describe('update with device model and palette', () => {
     beforeEach(() => {
-      repo.save.mockImplementation(async (device: Device) => device)
+      repo.save.mockImplementation(async device => device as Device)
     })
 
     it('assigns a new model with its default palette', async () => {
-      repo.findOneBy.mockResolvedValue({ ...baseDevice, deviceModel: OG_PLUS, palette: GRAY_4 })
+      repo.findOneBy.mockResolvedValue(makeDevice({ ...baseDevice, deviceModel: OG_PLUS, palette: GRAY_4 }))
       deviceModels.findByName.mockResolvedValue(V2)
       deviceModels.defaultPaletteFor.mockResolvedValue(GRAY_16)
-      const result = (await service.update('1', { deviceModelName: 'v2' } as any))!
+      const result = (await service.update('1', { deviceModelName: 'v2' }))!
       expect(deviceModels.findByName).toHaveBeenCalledWith('v2')
       expect(result.deviceModel).toBe(V2)
       expect(result.palette).toBe(GRAY_16)
@@ -140,19 +121,19 @@ describe('devicesService', () => {
     })
 
     it('assigns a new model together with an explicitly chosen palette', async () => {
-      repo.findOneBy.mockResolvedValue({ ...baseDevice, deviceModel: OG_PLUS, palette: GRAY_4 })
+      repo.findOneBy.mockResolvedValue(makeDevice({ ...baseDevice, deviceModel: OG_PLUS, palette: GRAY_4 }))
       deviceModels.findByName.mockResolvedValue(V2)
       deviceModels.findPalette.mockResolvedValue(BW)
-      const result = (await service.update('1', { deviceModelName: 'v2', paletteId: 'bw' } as any))!
+      const result = (await service.update('1', { deviceModelName: 'v2', paletteId: 'bw' }))!
       expect(result.deviceModel).toBe(V2)
       expect(result.palette).toBe(BW)
       expect(deviceModels.defaultPaletteFor).not.toHaveBeenCalled()
     })
 
     it('changes only the palette when the model stays the same', async () => {
-      repo.findOneBy.mockResolvedValue({ ...baseDevice, deviceModel: OG_PLUS, palette: GRAY_4 })
+      repo.findOneBy.mockResolvedValue(makeDevice({ ...baseDevice, deviceModel: OG_PLUS, palette: GRAY_4 }))
       deviceModels.findPalette.mockResolvedValue(BW)
-      const result = (await service.update('1', { deviceModelName: 'og_plus', paletteId: 'bw' } as any))!
+      const result = (await service.update('1', { deviceModelName: 'og_plus', paletteId: 'bw' }))!
       expect(deviceModels.findByName).not.toHaveBeenCalled()
       expect(result.deviceModel).toBe(OG_PLUS)
       expect(result.palette).toBe(BW)
@@ -160,106 +141,106 @@ describe('devicesService', () => {
     })
 
     it('does not reconvert images when neither model nor palette changed', async () => {
-      repo.findOneBy.mockResolvedValue({ ...baseDevice, deviceModel: OG_PLUS, palette: GRAY_4 })
+      repo.findOneBy.mockResolvedValue(makeDevice({ ...baseDevice, deviceModel: OG_PLUS, palette: GRAY_4 }))
       deviceModels.findPalette.mockResolvedValue(GRAY_4)
-      await service.update('1', { name: 'renamed', deviceModelName: 'og_plus', paletteId: 'gray-4' } as any)
+      await service.update('1', { name: 'renamed', deviceModelName: 'og_plus', paletteId: 'gray-4' })
       expect(screensService.reconvertImageScreens).not.toHaveBeenCalled()
     })
 
     it('rejects an unknown model', async () => {
-      repo.findOneBy.mockResolvedValue({ ...baseDevice, deviceModel: OG_PLUS })
+      repo.findOneBy.mockResolvedValue(makeDevice({ ...baseDevice, deviceModel: OG_PLUS }))
       deviceModels.findByName.mockResolvedValue(null)
-      await expect(service.update('1', { deviceModelName: 'nope' } as any)).rejects.toThrow(BadRequestException)
+      await expect(service.update('1', { deviceModelName: 'nope' })).rejects.toThrow(BadRequestException)
       expect(repo.save).not.toHaveBeenCalled()
     })
 
     it('rejects a palette the model does not support', async () => {
-      repo.findOneBy.mockResolvedValue({ ...baseDevice, deviceModel: OG_PLUS, palette: GRAY_4 })
+      repo.findOneBy.mockResolvedValue(makeDevice({ ...baseDevice, deviceModel: OG_PLUS, palette: GRAY_4 }))
       deviceModels.findPalette.mockResolvedValue(GRAY_16)
-      await expect(service.update('1', { paletteId: 'gray-16' } as any)).rejects.toThrow(BadRequestException)
+      await expect(service.update('1', { paletteId: 'gray-16' })).rejects.toThrow(BadRequestException)
       expect(repo.save).not.toHaveBeenCalled()
     })
 
     it('rejects a palette sent for a device with no assigned device model', async () => {
-      repo.findOneBy.mockResolvedValue({ ...baseDevice, deviceModel: null, palette: null })
-      await expect(service.update('1', { paletteId: 'bw' } as any)).rejects.toThrow(BadRequestException)
+      repo.findOneBy.mockResolvedValue(makeDevice({ ...baseDevice, deviceModel: null, palette: null }))
+      await expect(service.update('1', { paletteId: 'bw' })).rejects.toThrow(BadRequestException)
       expect(deviceModels.findPalette).not.toHaveBeenCalled()
       expect(repo.save).not.toHaveBeenCalled()
     })
 
     it('fills in the default palette for a device that has a model but no palette', async () => {
-      repo.findOneBy.mockResolvedValue({ ...baseDevice, deviceModel: OG_PLUS, palette: null })
+      repo.findOneBy.mockResolvedValue(makeDevice({ ...baseDevice, deviceModel: OG_PLUS, palette: null }))
       deviceModels.defaultPaletteFor.mockResolvedValue(GRAY_4)
-      const result = (await service.update('1', { name: 'renamed' } as any))!
+      const result = (await service.update('1', { name: 'renamed' }))!
       expect(result.name).toBe('renamed')
       expect(result.palette).toBe(GRAY_4)
     })
 
     it('accepts a custom palette whose colour family is compatible with the device model', async () => {
-      repo.findOneBy.mockResolvedValue({ ...baseDevice, deviceModel: OG_PLUS, palette: GRAY_4 })
+      repo.findOneBy.mockResolvedValue(makeDevice({ ...baseDevice, deviceModel: OG_PLUS, palette: GRAY_4 }))
       deviceModels.findPalette.mockResolvedValue(CUSTOM_RED_3BWR)
       deviceModels.compatibleFamiliesFor.mockResolvedValue(new Set(['screen--color-3bwr']))
-      const result = (await service.update('1', { paletteId: CUSTOM_RED_3BWR.id } as any))!
+      const result = (await service.update('1', { paletteId: CUSTOM_RED_3BWR.id }))!
       expect(deviceModels.compatibleFamiliesFor).toHaveBeenCalledWith(OG_PLUS)
       expect(result.palette).toBe(CUSTOM_RED_3BWR)
     })
 
     it('rejects a custom palette whose colour family is not compatible with the device model', async () => {
-      repo.findOneBy.mockResolvedValue({ ...baseDevice, deviceModel: OG_PLUS, palette: GRAY_4 })
+      repo.findOneBy.mockResolvedValue(makeDevice({ ...baseDevice, deviceModel: OG_PLUS, palette: GRAY_4 }))
       deviceModels.findPalette.mockResolvedValue(CUSTOM_RED_3BWR)
       deviceModels.compatibleFamiliesFor.mockResolvedValue(new Set())
-      await expect(service.update('1', { paletteId: CUSTOM_RED_3BWR.id } as any)).rejects.toThrow(BadRequestException)
+      await expect(service.update('1', { paletteId: CUSTOM_RED_3BWR.id })).rejects.toThrow(BadRequestException)
       expect(repo.save).not.toHaveBeenCalled()
     })
   })
 
   describe('update with target firmware', () => {
-    const compatibleFirmware = { id: 'fw-1', version: '1.5.6', kind: 'official-synced', compatibleModels: ['og_plus'] }
-    const universalFirmware = { id: 'fw-2', version: '1.0.0', kind: 'custom', compatibleModels: [] }
+    const compatibleFirmware = makeFirmware({ id: 'fw-1', version: '1.5.6', kind: 'official-synced', compatibleModels: ['og_plus'] })
+    const universalFirmware = makeFirmware({ id: 'fw-2', version: '1.0.0', kind: 'custom', compatibleModels: [] })
 
     beforeEach(() => {
-      repo.save.mockImplementation(async (device: Device) => device)
+      repo.save.mockImplementation(async device => device as Device)
     })
 
     it('assigns a firmware compatible with the device model', async () => {
-      repo.findOneBy.mockResolvedValue({ ...baseDevice, deviceModel: OG_PLUS })
+      repo.findOneBy.mockResolvedValue(makeDevice({ ...baseDevice, deviceModel: OG_PLUS }))
       firmwareService.findById.mockResolvedValue(compatibleFirmware)
-      const result = (await service.update('1', { targetFirmwareId: 'fw-1' } as any))!
+      const result = (await service.update('1', { targetFirmwareId: 'fw-1' }))!
       expect(firmwareService.findById).toHaveBeenCalledWith('fw-1')
       expect(result.targetFirmware).toBe(compatibleFirmware)
     })
 
     it('assigns a universal firmware (empty compatibleModels) regardless of device model', async () => {
-      repo.findOneBy.mockResolvedValue({ ...baseDevice, deviceModel: null })
+      repo.findOneBy.mockResolvedValue(makeDevice({ ...baseDevice, deviceModel: null }))
       firmwareService.findById.mockResolvedValue(universalFirmware)
-      const result = (await service.update('1', { targetFirmwareId: 'fw-2' } as any))!
+      const result = (await service.update('1', { targetFirmwareId: 'fw-2' }))!
       expect(result.targetFirmware).toBe(universalFirmware)
     })
 
     it('rejects a firmware incompatible with the device model', async () => {
-      repo.findOneBy.mockResolvedValue({ ...baseDevice, deviceModel: V2 })
+      repo.findOneBy.mockResolvedValue(makeDevice({ ...baseDevice, deviceModel: V2 }))
       firmwareService.findById.mockResolvedValue(compatibleFirmware)
-      await expect(service.update('1', { targetFirmwareId: 'fw-1' } as any)).rejects.toThrow(BadRequestException)
+      await expect(service.update('1', { targetFirmwareId: 'fw-1' })).rejects.toThrow(BadRequestException)
       expect(repo.save).not.toHaveBeenCalled()
     })
 
     it('rejects an unknown firmware id', async () => {
-      repo.findOneBy.mockResolvedValue({ ...baseDevice, deviceModel: OG_PLUS })
+      repo.findOneBy.mockResolvedValue(makeDevice({ ...baseDevice, deviceModel: OG_PLUS }))
       firmwareService.findById.mockResolvedValue(null)
-      await expect(service.update('1', { targetFirmwareId: 'nope' } as any)).rejects.toThrow(BadRequestException)
+      await expect(service.update('1', { targetFirmwareId: 'nope' })).rejects.toThrow(BadRequestException)
       expect(repo.save).not.toHaveBeenCalled()
     })
 
     it('is a no-op when targetFirmwareId is not provided', async () => {
-      repo.findOneBy.mockResolvedValue({ ...baseDevice, deviceModel: OG_PLUS })
-      await service.update('1', { name: 'renamed' } as any)
+      repo.findOneBy.mockResolvedValue(makeDevice({ ...baseDevice, deviceModel: OG_PLUS }))
+      await service.update('1', { name: 'renamed' })
       expect(firmwareService.findById).not.toHaveBeenCalled()
     })
   })
 
   it('remove deletes a device and returns true', async () => {
     repo.findOneBy.mockResolvedValue(baseDevice)
-    repo.remove.mockResolvedValue(undefined)
+    repo.remove.mockResolvedValue(baseDevice)
     const result = await service.remove('1')
     expect(repo.findOneBy).toHaveBeenCalledWith({ id: '1' })
     expect(repo.remove).toHaveBeenCalledWith(baseDevice)

--- a/packages/api/src/devices/__test__/display.controller.spec.ts
+++ b/packages/api/src/devices/__test__/display.controller.spec.ts
@@ -1,6 +1,7 @@
 import type { DeviceDisplayService } from '../display.service'
 import { BadRequestException } from '@nestjs/common'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { asService } from '../../test/mockService'
 import { Display } from '../display'
 import { DisplayController } from '../display.controller'
 
@@ -10,7 +11,7 @@ describe('displayController (unit)', () => {
 
   beforeEach(() => {
     service = { getCurrentImage: vi.fn(), getCurrentImageWithoutProgressing: vi.fn() }
-    controller = new DisplayController(service as unknown as DeviceDisplayService)
+    controller = new DisplayController(asService<DeviceDisplayService>(service))
   })
 
   it('display should return display from service', async () => {
@@ -27,7 +28,7 @@ describe('displayController (unit)', () => {
       update_firmware: false,
     })
     service.getCurrentImage.mockResolvedValue(display)
-    const result = await controller.getCurrentImage(headers as any)
+    const result = await controller.getCurrentImage(headers)
     expect(service.getCurrentImage).toHaveBeenCalledWith(headers)
     expect(result).toBe(display)
   })
@@ -37,7 +38,8 @@ describe('displayController (unit)', () => {
     service.getCurrentImage.mockImplementation(() => {
       throw new BadRequestException('Missing headers')
     })
-    await expect(controller.getCurrentImage({} as any)).rejects.toThrow(BadRequestException)
+    // @ts-expect-error deliberately missing the required id/access-token headers
+    await expect(controller.getCurrentImage({})).rejects.toThrow(BadRequestException)
   })
 
   it('current_screen should return display from service', async () => {
@@ -54,7 +56,7 @@ describe('displayController (unit)', () => {
       update_firmware: false,
     })
     service.getCurrentImageWithoutProgressing.mockResolvedValue(display)
-    const result = await controller.getCurrentImageWithoutProgressing(headers as any)
+    const result = await controller.getCurrentImageWithoutProgressing(headers)
     expect(service.getCurrentImageWithoutProgressing).toHaveBeenCalledWith(headers)
     expect(result).toBe(display)
   })
@@ -64,6 +66,7 @@ describe('displayController (unit)', () => {
     service.getCurrentImageWithoutProgressing.mockImplementation(() => {
       throw new BadRequestException('Missing headers')
     })
-    await expect(controller.getCurrentImageWithoutProgressing({} as any)).rejects.toThrow(BadRequestException)
+    // @ts-expect-error deliberately missing the required id/access-token headers
+    await expect(controller.getCurrentImageWithoutProgressing({})).rejects.toThrow(BadRequestException)
   })
 })

--- a/packages/api/src/devices/__test__/display.service.spec.ts
+++ b/packages/api/src/devices/__test__/display.service.spec.ts
@@ -1,11 +1,28 @@
-import type { MockDeviceModelsService, MockFallbackScreensService } from '../../device-models/__test__/mockDeviceModelsService'
+import type { ConfigService } from '@nestjs/config'
+import type { DeviceModelsService } from '../../device-models/device-models.service'
+import type { FallbackScreensService } from '../../device-models/fallback-screens.service'
 import type { MockDeviceSensorsService } from '../../device-sensors/__test__/mockDeviceSensorsService'
+import type { DeviceSensorsService } from '../../device-sensors/device-sensors.service'
+import type { FirmwareService } from '../../firmware/firmware.service'
+import type { PluginDataFetcherService } from '../../plugins/services/plugin-data-fetcher.service'
+import type { PluginRendererService } from '../../plugins/services/plugin-renderer.service'
+import type { PluginTransformService } from '../../plugins/services/plugin-transform.service'
+import type { Schedule } from '../../schedule/schedule.entity'
+import type { Screen } from '../../screens/screens.entity'
+import type { MockDeviceModelsService, MockFallbackScreensService } from '../../test/mockDeviceModelsService'
+import type { Device } from '../devices.entity'
+import type { TrmnlScreenResponse } from '../display.service'
+import type { DisplayRequestHeadersDto } from '../dto/display-request-headers.dto'
 import { promises as fs } from 'node:fs'
 import { NotFoundException, UnauthorizedException } from '@nestjs/common'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { createMockDeviceModelsService, createMockFallbackScreensService, GRAY_4, GRAY_16, OG_PLUS, primeMockDeviceModelsService, primeMockFallbackScreensService, V2 } from '../../device-models/__test__/mockDeviceModelsService'
 import { createMockDeviceSensorsService, primeMockDeviceSensorsService } from '../../device-sensors/__test__/mockDeviceSensorsService'
 import { PluginTemplateContextService } from '../../plugins/services/plugin-template-context.service'
+import { jsonResponse, stubFetch } from '../../test/fetch'
+import { makeDevice, makeFirmware, makeMashupConfiguration, makeMashupSlot, makePlugin, makePluginDataSource, makePluginTemplate, makeSchedule, makeScreen } from '../../test/fixtures'
+import { createMockDeviceModelsService, createMockFallbackScreensService, GRAY_4, GRAY_16, OG_PLUS, primeMockDeviceModelsService, primeMockFallbackScreensService, V2 } from '../../test/mockDeviceModelsService'
+import { asRepository, createMockRepository } from '../../test/mockRepository'
+import { asService, injectPrivate } from '../../test/mockService'
 import { Display } from '../display'
 import { DeviceDisplayService } from '../display.service'
 import { DisplayScreen } from '../displayScreen'
@@ -48,23 +65,12 @@ function primePuppeteer() {
   puppeteerLaunch.mockResolvedValue({ newPage: vi.fn().mockResolvedValue(puppeteerPage), close: vi.fn() })
 }
 
-const mockFetch = vi.fn()
-globalThis.fetch = mockFetch
-
-function createMockRepo() {
-  return {
-    find: vi.fn(),
-    findOneBy: vi.fn(),
-    findOne: vi.fn(),
-    save: vi.fn(),
-    update: vi.fn(),
-  }
-}
+const mockFetch = stubFetch()
 
 describe('deviceDisplayService', () => {
   let service: DeviceDisplayService
-  let deviceRepo: ReturnType<typeof createMockRepo>
-  let screenRepo: ReturnType<typeof createMockRepo>
+  let deviceRepo: ReturnType<typeof createMockRepository<Device>>
+  let screenRepo: ReturnType<typeof createMockRepository<Screen>>
   let configService: { get: ReturnType<typeof vi.fn> }
   let deviceModels: MockDeviceModelsService
   let fallbackScreens: MockFallbackScreensService
@@ -72,24 +78,24 @@ describe('deviceDisplayService', () => {
   let deviceSensors: MockDeviceSensorsService
 
   beforeEach(() => {
-    deviceRepo = createMockRepo()
-    screenRepo = createMockRepo()
+    deviceRepo = createMockRepository<Device>()
+    screenRepo = createMockRepository<Screen>()
     configService = { get: vi.fn() }
     deviceModels = createMockDeviceModelsService()
     fallbackScreens = createMockFallbackScreensService()
     firmwareService = { verifyChecksum: vi.fn(), fileUrl: vi.fn() }
     deviceSensors = createMockDeviceSensorsService()
     service = new DeviceDisplayService(
-      deviceRepo as any,
-      screenRepo as any,
-      configService as any,
-      deviceModels as any,
-      fallbackScreens as any,
-      firmwareService as any,
-      {} as any,
-      {} as any,
-      {} as any,
-      deviceSensors as any,
+      asRepository(deviceRepo),
+      asRepository(screenRepo),
+      asService<ConfigService>(configService),
+      asService<DeviceModelsService>(deviceModels),
+      asService<FallbackScreensService>(fallbackScreens),
+      asService<FirmwareService>(firmwareService),
+      asService<PluginDataFetcherService>({}),
+      asService<PluginRendererService>({}),
+      asService<PluginTransformService>({}),
+      asService<DeviceSensorsService>(deviceSensors),
       new PluginTemplateContextService(),
     )
     vi.resetAllMocks()
@@ -99,7 +105,7 @@ describe('deviceDisplayService', () => {
     primePuppeteer()
   })
 
-  const baseDevice = {
+  const baseDevice: Device = makeDevice({
     id: '1',
     mac: 'mac',
     apikey: 'token',
@@ -108,20 +114,18 @@ describe('deviceDisplayService', () => {
     updateFirmware: false,
     specialFunction: 'identify',
     mirrorEnabled: false,
-    width: undefined,
-    height: undefined,
-  }
+  })
 
-  const headers = { 'id': 'mac', 'access-token': 'token' }
+  const headers: DisplayRequestHeadersDto = { 'id': 'mac', 'access-token': 'token' }
 
   it('throws NotFoundException if device not found', async () => {
     deviceRepo.findOneBy.mockResolvedValue(null)
-    await expect(service.getCurrentImage(headers as any)).rejects.toThrow(NotFoundException)
+    await expect(service.getCurrentImage(headers)).rejects.toThrow(NotFoundException)
   })
 
   it('throws UnauthorizedException if API key is invalid', async () => {
-    deviceRepo.findOneBy.mockResolvedValue({ ...baseDevice, apikey: 'wrong' })
-    await expect(service.getCurrentImage(headers as any)).rejects.toThrow(UnauthorizedException)
+    deviceRepo.findOneBy.mockResolvedValue(makeDevice({ ...baseDevice, apikey: 'wrong' }))
+    await expect(service.getCurrentImage(headers)).rejects.toThrow(UnauthorizedException)
   })
 
   describe('device report handling', () => {
@@ -131,32 +135,32 @@ describe('deviceDisplayService', () => {
     })
 
     it('records the reported dimensions and model without rejecting changed values', async () => {
-      const device = { ...baseDevice, width: 100, height: 200, deviceModel: OG_PLUS }
+      const device = makeDevice({ ...baseDevice, width: 100, height: 200, deviceModel: OG_PLUS })
       deviceRepo.findOneBy.mockResolvedValue(device)
-      await service.getCurrentImage({ ...headers, width: '1872', height: '1404', model: 'x' } as any)
+      await service.getCurrentImage({ ...headers, width: '1872', height: '1404', model: 'x' })
       expect(deviceRepo.save).toHaveBeenCalledWith(expect.objectContaining({ width: 1872, height: 1404, reportedModel: 'x' }))
     })
 
     it('keeps the stored dimensions when the headers are missing or unparsable', async () => {
-      const device = { ...baseDevice, width: 800, height: 480, reportedModel: 'og', deviceModel: OG_PLUS }
+      const device = makeDevice({ ...baseDevice, width: 800, height: 480, reportedModel: 'og', deviceModel: OG_PLUS })
       deviceRepo.findOneBy.mockResolvedValue(device)
-      await service.getCurrentImage({ ...headers, width: 'abc' } as any)
+      await service.getCurrentImage({ ...headers, width: 'abc' })
       expect(deviceRepo.save).toHaveBeenCalledWith(expect.objectContaining({ width: 800, height: 480, reportedModel: 'og' }))
     })
 
     it('resolves and assigns a device model when the device has none', async () => {
-      const device = { ...baseDevice, deviceModel: null }
+      const device = makeDevice({ ...baseDevice, deviceModel: null })
       deviceRepo.findOneBy.mockResolvedValue(device)
       deviceModels.assignResolvedModel.mockResolvedValue(V2)
-      await service.getCurrentImage({ ...headers, width: '1872', height: '1404', model: 'x' } as any)
+      await service.getCurrentImage({ ...headers, width: '1872', height: '1404', model: 'x' })
       expect(deviceModels.assignResolvedModel).toHaveBeenCalledWith(expect.objectContaining({ reportedModel: 'x', width: 1872, height: 1404 }))
       expect(deviceRepo.save).toHaveBeenCalled()
     })
 
     it('never re-resolves a device that already has a model', async () => {
-      const device = { ...baseDevice, deviceModel: OG_PLUS }
+      const device = makeDevice({ ...baseDevice, deviceModel: OG_PLUS })
       deviceRepo.findOneBy.mockResolvedValue(device)
-      await service.getCurrentImage({ ...headers, model: 'x' } as any)
+      await service.getCurrentImage({ ...headers, model: 'x' })
       expect(deviceModels.assignResolvedModel).not.toHaveBeenCalled()
     })
   })
@@ -168,40 +172,42 @@ describe('deviceDisplayService', () => {
     })
 
     it('syncs sensor readings from the resolved device and the raw sensors header', async () => {
-      const device = { ...baseDevice, deviceModel: OG_PLUS }
+      const device = makeDevice({ ...baseDevice, deviceModel: OG_PLUS })
       deviceRepo.findOneBy.mockResolvedValue(device)
 
-      await service.getCurrentImage({ ...headers, sensors: 'kind=temperature;value=21.5;unit=C' } as any)
+      await service.getCurrentImage({ ...headers, sensors: 'kind=temperature;value=21.5;unit=C' })
 
       expect(deviceSensors.syncFromHeader).toHaveBeenCalledWith(device, 'kind=temperature;value=21.5;unit=C')
     })
 
     it('syncs even when the sensors header is absent, clearing any stale readings', async () => {
-      const device = { ...baseDevice, deviceModel: OG_PLUS }
+      const device = makeDevice({ ...baseDevice, deviceModel: OG_PLUS })
       deviceRepo.findOneBy.mockResolvedValue(device)
 
-      await service.getCurrentImage(headers as any)
+      await service.getCurrentImage(headers)
 
       expect(deviceSensors.syncFromHeader).toHaveBeenCalledWith(device, undefined)
     })
   })
 
   describe('rendering in the device model shell', () => {
-    function primeRotation(nextScreen: Record<string, unknown>, device: Record<string, unknown>) {
-      const activeScreen = { id: 'screen1', order: 1, device, isActive: true, generatedAt: new Date() }
+    function primeRotation(nextScreenOverrides: Partial<Screen>, device: Device) {
+      const activeScreen = makeScreen({ id: 'screen1', order: 1, device, isActive: true })
+      const nextScreen = makeScreen({ device, ...nextScreenOverrides })
       deviceRepo.findOneBy.mockResolvedValue(device)
       screenRepo.find.mockResolvedValue([activeScreen, nextScreen])
       screenRepo.findOne.mockResolvedValue(nextScreen)
       screenRepo.save.mockResolvedValue(nextScreen)
       configService.get.mockReturnValue('http://api')
+      return nextScreen
     }
 
     it('renders HTML screens at the model size inside the model shell', async () => {
-      const device = { ...baseDevice, deviceModel: V2, palette: GRAY_16 }
+      const device = makeDevice({ ...baseDevice, deviceModel: V2, palette: GRAY_16 })
       deviceModels.renderTargetFor.mockResolvedValue({ model: V2, palette: GRAY_16 })
-      primeRotation({ id: 'screen2', type: 'html', order: 2, device, html: '<p>hi</p>', filename: 'x', generatedAt: new Date() }, device)
+      primeRotation({ id: 'screen2', type: 'html', order: 2, html: '<p>hi</p>', filename: 'x' }, device)
 
-      const result = await service.getCurrentImage(headers as any)
+      const result = await service.getCurrentImage(headers)
 
       expect(puppeteerPage.setViewport).toHaveBeenCalledWith({ width: 1872, height: 1404 })
       const html: string = puppeteerPage.setContent.mock.calls[0][0]
@@ -215,10 +221,10 @@ describe('deviceDisplayService', () => {
     })
 
     it('wraps cached plugin output in a full view and the shell', async () => {
-      const device = { ...baseDevice, deviceModel: OG_PLUS }
-      primeRotation({ id: 'screen2', type: 'plugin', order: 2, device, plugin: { id: 'p1' }, cachedPluginOutput: '<span>cached</span>', filename: 'x', generatedAt: new Date() }, device)
+      const device = makeDevice({ ...baseDevice, deviceModel: OG_PLUS })
+      primeRotation({ id: 'screen2', type: 'plugin', order: 2, plugin: makePlugin({ id: 'p1' }), cachedPluginOutput: '<span>cached</span>', filename: 'x' }, device)
 
-      await service.getCurrentImage(headers as any)
+      await service.getCurrentImage(headers)
 
       expect(puppeteerPage.setViewport).toHaveBeenCalledWith({ width: 800, height: 480 })
       const html: string = puppeteerPage.setContent.mock.calls[0][0]
@@ -228,16 +234,18 @@ describe('deviceDisplayService', () => {
     })
 
     it('caches only the rendered plugin body when rendering on demand', async () => {
-      const device = { ...baseDevice, deviceModel: OG_PLUS }
-      const plugin = { id: 'p1', name: 'P', dataSources: [{ name: 'source', method: 'GET', url: 'http://x' }], templates: [{ layout: 'full', liquidMarkup: '{{ v }}' }] }
-      primeRotation({ id: 'screen2', type: 'plugin', order: 2, device, plugin, filename: 'x', generatedAt: new Date() }, device)
-      ;(service as any).pluginDataFetcher = {
-        fetchData: vi.fn().mockResolvedValue({ v: 1 }),
-        fetchOrLiteral: vi.fn().mockResolvedValue({ v: 1 }),
-      } as any
-      ;(service as any).pluginRenderer = { render: vi.fn().mockResolvedValue('<b>1</b>') } as any
+      const device = makeDevice({ ...baseDevice, deviceModel: OG_PLUS })
+      const plugin = makePlugin({
+        id: 'p1',
+        name: 'P',
+        dataSources: [makePluginDataSource({ name: 'source', method: 'GET', url: 'http://x' })],
+        templates: [makePluginTemplate({ layout: 'full', liquidMarkup: '{{ v }}' })],
+      })
+      primeRotation({ id: 'screen2', type: 'plugin', order: 2, plugin, filename: 'x' }, device)
+      injectPrivate(service, 'pluginDataFetcher', { fetchOrLiteral: vi.fn().mockResolvedValue({ v: 1 }) })
+      injectPrivate(service, 'pluginRenderer', { render: vi.fn().mockResolvedValue('<b>1</b>') })
 
-      await service.getCurrentImage(headers as any)
+      await service.getCurrentImage(headers)
 
       expect(screenRepo.update).toHaveBeenCalledWith({ id: 'screen2' }, expect.objectContaining({ cachedPluginOutput: '<b>1</b>' }))
       const html: string = puppeteerPage.setContent.mock.calls[0][0]
@@ -245,11 +253,11 @@ describe('deviceDisplayService', () => {
     })
 
     it('places cached mashup markup directly inside the shell', async () => {
-      const device = { ...baseDevice, deviceModel: OG_PLUS }
-      primeRotation({ id: 'screen2', type: 'mashup', order: 2, device, cachedPluginOutput: '<div class="mashup mashup--1Lx1R">m</div>', mashupConfiguration: { id: 'c' }, filename: 'x', generatedAt: new Date() }, device)
-      ;(service as any).mashupRenderer = { renderMashup: vi.fn() } as any
+      const device = makeDevice({ ...baseDevice, deviceModel: OG_PLUS })
+      primeRotation({ id: 'screen2', type: 'mashup', order: 2, cachedPluginOutput: '<div class="mashup mashup--1Lx1R">m</div>', mashupConfiguration: makeMashupConfiguration({ id: 'c' }), filename: 'x' }, device)
+      injectPrivate(service, 'mashupRenderer', { renderMashup: vi.fn() })
 
-      await service.getCurrentImage(headers as any)
+      await service.getCurrentImage(headers)
 
       const html: string = puppeteerPage.setContent.mock.calls[0][0]
       expect(html).toMatch(/screen--2bit"[^>]*><div class="mashup mashup--1Lx1R">m<\/div><\/div>/)
@@ -258,39 +266,36 @@ describe('deviceDisplayService', () => {
   })
 
   it('returns default no screen image if the device has no screens and is not mirrored', async () => {
-    deviceRepo.findOneBy.mockResolvedValue({ ...baseDevice, apikey: 'token' })
+    deviceRepo.findOneBy.mockResolvedValue(makeDevice({ ...baseDevice, apikey: 'token' }))
     screenRepo.find.mockResolvedValue([])
     configService.get.mockReturnValue('http://api')
-    deviceRepo.save.mockResolvedValue(undefined)
-    const result = await service.getCurrentImage(headers as any)
+    const result = await service.getCurrentImage(headers)
     expect(result).toBeInstanceOf(Display)
     expect(result.filename).toBe('noScreen.png')
     expect(result.image_url).toBe('http://api/screens/noScreen.png')
   })
 
   it('cycles screens and returns next screen if not mirrored', async () => {
-    const device = { ...baseDevice, apikey: 'token', id: '1', mirrorEnabled: false }
+    const device = makeDevice({ ...baseDevice, apikey: 'token', id: '1', mirrorEnabled: false })
     const filename = 'file.png'
     const generatedAt = new Date()
     const dynamicFilename = `${filename}_${generatedAt.toISOString()}`
-    const activeScreen = { id: 'screen1', order: 1, device, isActive: true, fetchManual: false, externalLink: null, filename, generatedAt }
-    const nextScreen = { ...activeScreen, id: 'screen2', order: 2, isActive: false }
+    const activeScreen = makeScreen({ id: 'screen1', order: 1, device, isActive: true, fetchManual: false, externalLink: null, filename, generatedAt })
+    const nextScreen = makeScreen({ ...activeScreen, id: 'screen2', order: 2, isActive: false })
     deviceRepo.findOneBy.mockResolvedValue(device)
     screenRepo.find.mockResolvedValue([activeScreen, nextScreen])
-    screenRepo.update.mockResolvedValue(undefined)
     screenRepo.save.mockResolvedValue(nextScreen)
     configService.get.mockReturnValue('http://api')
-    deviceRepo.save.mockResolvedValue(undefined)
     fileExists.mockResolvedValue(true)
-    const result = await service.getCurrentImage(headers as any)
+    const result = await service.getCurrentImage(headers)
     expect(result).toBeInstanceOf(Display)
     expect(result.filename).toBe(dynamicFilename)
     expect(result.image_url).toBe('http://api/screens/devices/1/screen2.png')
   })
 
   it('processes external link images when fetchManual is false', async () => {
-    const device = { ...baseDevice, apikey: 'token', id: '1', mirrorEnabled: false }
-    const activeScreen = {
+    const device = makeDevice({ ...baseDevice, apikey: 'token', id: '1', mirrorEnabled: false })
+    const activeScreen = makeScreen({
       id: 'screen1',
       order: 1,
       device,
@@ -298,22 +303,21 @@ describe('deviceDisplayService', () => {
       externalLink: 'http://example.com/image.jpg',
       fetchManual: false,
       filename: 'test.png',
-      generatedAt: new Date(),
-    }
-    const nextScreen = { ...activeScreen, id: 'screen2', order: 2, isActive: false }
+    })
+    const nextScreen = makeScreen({ ...activeScreen, id: 'screen2', order: 2, isActive: false })
 
     deviceRepo.findOneBy.mockResolvedValue(device)
     screenRepo.find.mockResolvedValue([activeScreen, nextScreen])
     configService.get.mockReturnValue('http://api')
 
-    const result = await service.getCurrentImage(headers as any)
+    const result = await service.getCurrentImage(headers)
     expect(result).toBeInstanceOf(Display)
     expect(result.image_url).toBe('http://api/screens/devices/1/screen2.png')
     expect(fs.unlink).toHaveBeenCalledWith(expect.stringContaining('tmp-source'))
   })
 
   it('handles mirroring with proxy when MACs are identical', async () => {
-    const device = {
+    const device = makeDevice({
       ...baseDevice,
       apikey: 'token',
       id: '1',
@@ -322,14 +326,14 @@ describe('deviceDisplayService', () => {
       mirrorEnabled: true,
       mirrorMac: 'mac',
       mirrorApikey: 'mirror-token',
-    }
+    })
 
-    const testHeaders = { ...headers, width: 800, height: 480 }
+    const testHeaders = { ...headers, width: '800', height: '480' }
 
     deviceRepo.findOneBy.mockResolvedValue(device)
     configService.get.mockReturnValue('http://api')
 
-    const mockResponse = {
+    const mockResponse: TrmnlScreenResponse = {
       filename: 'mirror.png',
       image_url: 'http://example.com/image.jpg',
       refresh_rate: 30,
@@ -339,14 +343,12 @@ describe('deviceDisplayService', () => {
       update_firmware: true,
     }
 
-    mockFetch.mockResolvedValueOnce({
-      json: () => Promise.resolve(mockResponse),
-    })
+    mockFetch.mockResolvedValueOnce(jsonResponse(mockResponse))
 
     const { downloadImage, convertToPng } = await import('../../utils/imageUtils.js')
 
     vi.mocked(fs.unlink).mockResolvedValueOnce()
-    const result = await service.getCurrentImage(testHeaders as any)
+    const result = await service.getCurrentImage(testHeaders)
     expect(result).toBeInstanceOf(Display)
     expect(result.filename).toBe('mirror.png')
     expect(result.image_url).toContain('mirror.png')
@@ -358,7 +360,7 @@ describe('deviceDisplayService', () => {
   })
 
   it('handles mirroring without proxy when MACs are different', async () => {
-    const device = {
+    const device = makeDevice({
       ...baseDevice,
       apikey: 'token',
       id: '1',
@@ -367,26 +369,24 @@ describe('deviceDisplayService', () => {
       mirrorEnabled: true,
       mirrorMac: 'different-mac',
       mirrorApikey: 'mirror-token',
-    }
+    })
 
-    const testHeaders = { ...headers, width: 800, height: 480 }
+    const testHeaders = { ...headers, width: '800', height: '480' }
 
     deviceRepo.findOneBy.mockResolvedValue(device)
     configService.get.mockReturnValue('http://api')
 
-    const mockResponse = {
+    const mockResponse: TrmnlScreenResponse = {
       filename: 'mirror.png',
       image_url: 'http://example.com/image.jpg',
     }
 
-    mockFetch.mockResolvedValueOnce({
-      json: () => Promise.resolve(mockResponse),
-    })
+    mockFetch.mockResolvedValueOnce(jsonResponse(mockResponse))
 
     const { downloadImage, convertToPng } = await import('../../utils/imageUtils.js')
 
     vi.mocked(fs.unlink).mockResolvedValueOnce()
-    const result = await service.getCurrentImage(testHeaders as any)
+    const result = await service.getCurrentImage(testHeaders)
     expect(result).toBeInstanceOf(Display)
     expect(result.filename).toBe('mirror.png')
     expect(result.image_url).toContain('mirror.png')
@@ -397,36 +397,36 @@ describe('deviceDisplayService', () => {
   })
 
   describe('special function acknowledgement and protocol fields', () => {
-    function primeNoScreen(device: Record<string, unknown>) {
+    function primeNoScreen(device: Device) {
       deviceRepo.findOneBy.mockResolvedValue(device)
       screenRepo.find.mockResolvedValue([])
       configService.get.mockReturnValue('http://api')
     }
 
-    function primeCycling(device: Record<string, unknown>) {
-      const activeScreen = { id: 'screen1', order: 1, device, isActive: true, fetchManual: false, externalLink: null, filename: 'file.png', generatedAt: new Date() }
+    function primeCycling(device: Device) {
+      const activeScreen = makeScreen({ id: 'screen1', order: 1, device, isActive: true, fetchManual: false, externalLink: null, filename: 'file.png' })
       deviceRepo.findOneBy.mockResolvedValue(device)
-      screenRepo.find.mockResolvedValue([activeScreen, { ...activeScreen, id: 'screen2', order: 2, isActive: false }])
+      screenRepo.find.mockResolvedValue([activeScreen, makeScreen({ ...activeScreen, id: 'screen2', order: 2, isActive: false })])
       configService.get.mockReturnValue('http://api')
       fileExists.mockResolvedValue(true)
     }
 
-    function primeMirror(device: Record<string, unknown>, response: Record<string, unknown>) {
+    function primeMirror(device: Device, response: TrmnlScreenResponse) {
       deviceRepo.findOneBy.mockResolvedValue(device)
       configService.get.mockReturnValue('http://api')
-      mockFetch.mockResolvedValueOnce({ json: () => Promise.resolve(response) })
+      mockFetch.mockResolvedValueOnce(jsonResponse(response))
     }
 
     function mirroredDevice(mirrorMac: string) {
-      return { ...baseDevice, deviceModel: OG_PLUS, mirrorEnabled: true, mirrorMac, mirrorApikey: 'mirror-token' }
+      return makeDevice({ ...baseDevice, deviceModel: OG_PLUS, mirrorEnabled: true, mirrorMac, mirrorApikey: 'mirror-token' })
     }
 
-    const upstreamResponse = { filename: 'mirror.png', image_url: 'http://example.com/image.jpg', special_function: 'sleep', action: 'sleep' }
+    const upstreamResponse: TrmnlScreenResponse = { filename: 'mirror.png', image_url: 'http://example.com/image.jpg', special_function: 'sleep', action: 'sleep' }
 
     it('acknowledges the pending special function and clears it for the next poll', async () => {
-      primeNoScreen({ ...baseDevice, deviceModel: OG_PLUS, specialFunction: 'sleep' })
+      primeNoScreen(makeDevice({ ...baseDevice, deviceModel: OG_PLUS, specialFunction: 'sleep' }))
 
-      const result = await service.getCurrentImage(headers as any)
+      const result = await service.getCurrentImage(headers)
 
       expect(result.special_function).toBe('sleep')
       expect(result.action).toBe('sleep')
@@ -434,9 +434,9 @@ describe('deviceDisplayService', () => {
     })
 
     it('echoes none as the action when nothing is pending', async () => {
-      primeNoScreen({ ...baseDevice, deviceModel: OG_PLUS, specialFunction: 'none' })
+      primeNoScreen(makeDevice({ ...baseDevice, deviceModel: OG_PLUS, specialFunction: 'none' }))
 
-      const result = await service.getCurrentImage(headers as any)
+      const result = await service.getCurrentImage(headers)
 
       expect(result.special_function).toBe('none')
       expect(result.action).toBe('none')
@@ -444,9 +444,9 @@ describe('deviceDisplayService', () => {
     })
 
     it('acknowledges and clears the pending special function while cycling screens', async () => {
-      primeCycling({ ...baseDevice, deviceModel: OG_PLUS, specialFunction: 'add_wifi' })
+      primeCycling(makeDevice({ ...baseDevice, deviceModel: OG_PLUS, specialFunction: 'add_wifi' }))
 
-      const result = await service.getCurrentImage(headers as any)
+      const result = await service.getCurrentImage(headers)
 
       expect(result.special_function).toBe('add_wifi')
       expect(result.action).toBe('add_wifi')
@@ -454,36 +454,36 @@ describe('deviceDisplayService', () => {
     })
 
     it('relays the upstream special function and action when proxying', async () => {
-      primeMirror({ ...mirroredDevice('mac'), specialFunction: 'identify' }, upstreamResponse)
+      primeMirror(makeDevice({ ...mirroredDevice('mac'), specialFunction: 'identify' }), upstreamResponse)
 
-      const result = await service.getCurrentImage(headers as any)
+      const result = await service.getCurrentImage(headers)
 
       expect(result.special_function).toBe('sleep')
       expect(result.action).toBe('sleep')
     })
 
     it('falls back to the upstream special function when a proxied response omits the action', async () => {
-      primeMirror({ ...mirroredDevice('mac'), specialFunction: 'identify' }, { filename: 'mirror.png', image_url: 'http://example.com/image.jpg', special_function: 'rewind' })
+      primeMirror(makeDevice({ ...mirroredDevice('mac'), specialFunction: 'identify' }), { filename: 'mirror.png', image_url: 'http://example.com/image.jpg', special_function: 'rewind' })
 
-      const result = await service.getCurrentImage(headers as any)
+      const result = await service.getCurrentImage(headers)
 
       expect(result.special_function).toBe('rewind')
       expect(result.action).toBe('rewind')
     })
 
     it('reports none on both fields when a proxied response carries neither', async () => {
-      primeMirror({ ...mirroredDevice('mac'), specialFunction: 'identify' }, { filename: 'mirror.png', image_url: 'http://example.com/image.jpg' })
+      primeMirror(makeDevice({ ...mirroredDevice('mac'), specialFunction: 'identify' }), { filename: 'mirror.png', image_url: 'http://example.com/image.jpg' })
 
-      const result = await service.getCurrentImage(headers as any)
+      const result = await service.getCurrentImage(headers)
 
       expect(result.special_function).toBe('none')
       expect(result.action).toBe('none')
     })
 
     it('keeps the locally pending special function and action when mirroring another device', async () => {
-      primeMirror({ ...mirroredDevice('different-mac'), specialFunction: 'identify' }, upstreamResponse)
+      primeMirror(makeDevice({ ...mirroredDevice('different-mac'), specialFunction: 'identify' }), upstreamResponse)
 
-      const result = await service.getCurrentImage(headers as any)
+      const result = await service.getCurrentImage(headers)
 
       expect(result.special_function).toBe('identify')
       expect(result.action).toBe('identify')
@@ -491,67 +491,67 @@ describe('deviceDisplayService', () => {
     })
 
     it.each([
-      ['without a screen', () => primeNoScreen({ ...baseDevice, deviceModel: OG_PLUS })],
-      ['while cycling screens', () => primeCycling({ ...baseDevice, deviceModel: OG_PLUS })],
+      ['without a screen', () => primeNoScreen(makeDevice({ ...baseDevice, deviceModel: OG_PLUS }))],
+      ['while cycling screens', () => primeCycling(makeDevice({ ...baseDevice, deviceModel: OG_PLUS }))],
       ['while mirroring', () => primeMirror(mirroredDevice('different-mac'), upstreamResponse)],
     ])('reports the default temperature profile and omits unsupported firmware fields %s', async (_path, prime) => {
       prime()
 
-      const result: any = await service.getCurrentImage(headers as any)
+      const result = await service.getCurrentImage(headers)
 
       expect(result.temperature_profile).toBe('default')
-      expect(result.touchbar_mode).toBeUndefined()
-      expect(result.maximum_compatibility).toBeUndefined()
-      expect(result.image_url_timeout).toBeUndefined()
+      expect('touchbar_mode' in result).toBe(false)
+      expect('maximum_compatibility' in result).toBe(false)
+      expect('image_url_timeout' in result).toBe(false)
     })
   })
 
   describe('reset device delivery', () => {
-    function primeNoScreen(device: Record<string, unknown>) {
+    function primeNoScreen(device: Device) {
       deviceRepo.findOneBy.mockResolvedValue(device)
       screenRepo.find.mockResolvedValue([])
       configService.get.mockReturnValue('http://api')
     }
 
-    function primeCycling(device: Record<string, unknown>) {
-      const activeScreen = { id: 'screen1', order: 1, device, isActive: true, fetchManual: false, externalLink: null, filename: 'file.png', generatedAt: new Date() }
+    function primeCycling(device: Device) {
+      const activeScreen = makeScreen({ id: 'screen1', order: 1, device, isActive: true, fetchManual: false, externalLink: null, filename: 'file.png' })
       deviceRepo.findOneBy.mockResolvedValue(device)
-      screenRepo.find.mockResolvedValue([activeScreen, { ...activeScreen, id: 'screen2', order: 2, isActive: false }])
+      screenRepo.find.mockResolvedValue([activeScreen, makeScreen({ ...activeScreen, id: 'screen2', order: 2, isActive: false })])
       configService.get.mockReturnValue('http://api')
       fileExists.mockResolvedValue(true)
     }
 
-    function primeMirror(device: Record<string, unknown>, response: Record<string, unknown>) {
+    function primeMirror(device: Device, response: TrmnlScreenResponse) {
       deviceRepo.findOneBy.mockResolvedValue(device)
       configService.get.mockReturnValue('http://api')
-      mockFetch.mockResolvedValueOnce({ json: () => Promise.resolve(response) })
+      mockFetch.mockResolvedValueOnce(jsonResponse(response))
     }
 
     function mirroredDevice(mirrorMac: string, resetDevice: boolean) {
-      return { ...baseDevice, deviceModel: OG_PLUS, mirrorEnabled: true, mirrorMac, mirrorApikey: 'mirror-token', resetDevice }
+      return makeDevice({ ...baseDevice, deviceModel: OG_PLUS, mirrorEnabled: true, mirrorMac, mirrorApikey: 'mirror-token', resetDevice })
     }
 
     it('delivers a pending reset and clears the flag when the device has no screen', async () => {
-      primeNoScreen({ ...baseDevice, deviceModel: OG_PLUS, resetDevice: true })
+      primeNoScreen(makeDevice({ ...baseDevice, deviceModel: OG_PLUS, resetDevice: true }))
 
-      const result = await service.getCurrentImage(headers as any)
+      const result = await service.getCurrentImage(headers)
 
       expect(result.reset_firmware).toBe(true)
       expect(deviceRepo.save).toHaveBeenCalledWith(expect.objectContaining({ resetDevice: false }))
     })
 
     it('delivers a pending reset while cycling screens', async () => {
-      primeCycling({ ...baseDevice, deviceModel: OG_PLUS, resetDevice: true })
+      primeCycling(makeDevice({ ...baseDevice, deviceModel: OG_PLUS, resetDevice: true }))
 
-      const result = await service.getCurrentImage(headers as any)
+      const result = await service.getCurrentImage(headers)
 
       expect(result.reset_firmware).toBe(true)
     })
 
     it('does not report a reset while cycling screens when none is pending', async () => {
-      primeCycling({ ...baseDevice, deviceModel: OG_PLUS, resetDevice: false })
+      primeCycling(makeDevice({ ...baseDevice, deviceModel: OG_PLUS, resetDevice: false }))
 
-      const result = await service.getCurrentImage(headers as any)
+      const result = await service.getCurrentImage(headers)
 
       expect(result.reset_firmware).toBe(false)
     })
@@ -559,7 +559,7 @@ describe('deviceDisplayService', () => {
     it('lets the upstream response own reset_firmware when proxying', async () => {
       primeMirror(mirroredDevice('mac', true), { filename: 'mirror.png', image_url: 'http://example.com/image.jpg', reset_firmware: false })
 
-      const result = await service.getCurrentImage(headers as any)
+      const result = await service.getCurrentImage(headers)
 
       expect(result.reset_firmware).toBe(false)
     })
@@ -567,7 +567,7 @@ describe('deviceDisplayService', () => {
     it('falls back to the locally pending reset when a proxied response omits it', async () => {
       primeMirror(mirroredDevice('mac', true), { filename: 'mirror.png', image_url: 'http://example.com/image.jpg' })
 
-      const result = await service.getCurrentImage(headers as any)
+      const result = await service.getCurrentImage(headers)
 
       expect(result.reset_firmware).toBe(true)
     })
@@ -575,7 +575,7 @@ describe('deviceDisplayService', () => {
     it('delivers a pending reset on a non-proxy mirrored device', async () => {
       primeMirror(mirroredDevice('different-mac', true), { filename: 'mirror.png', image_url: 'http://example.com/image.jpg' })
 
-      const result = await service.getCurrentImage(headers as any)
+      const result = await service.getCurrentImage(headers)
 
       expect(result.reset_firmware).toBe(true)
     })
@@ -583,28 +583,28 @@ describe('deviceDisplayService', () => {
     it('does not report a reset on a non-proxy mirrored device when none is pending', async () => {
       primeMirror(mirroredDevice('different-mac', false), { filename: 'mirror.png', image_url: 'http://example.com/image.jpg' })
 
-      const result = await service.getCurrentImage(headers as any)
+      const result = await service.getCurrentImage(headers)
 
       expect(result.reset_firmware).toBe(false)
     })
   })
 
   describe('firmware push', () => {
-    const targetFirmware = { id: 'fw-1', version: '1.5.6', checksum: 'abc123' }
+    const targetFirmware = makeFirmware({ id: 'fw-1', version: '1.5.6', checksum: 'abc123' })
 
-    function primeNoScreen(device: Record<string, unknown>) {
+    function primeNoScreen(device: Device) {
       deviceRepo.findOneBy.mockResolvedValue(device)
       screenRepo.find.mockResolvedValue([])
       configService.get.mockReturnValue('http://api')
     }
 
     it('serves the target firmware url and clears the flag when the checksum matches', async () => {
-      const device = { ...baseDevice, deviceModel: OG_PLUS, updateFirmware: true, targetFirmware }
+      const device = makeDevice({ ...baseDevice, deviceModel: OG_PLUS, updateFirmware: true, targetFirmware })
       primeNoScreen(device)
       firmwareService.verifyChecksum.mockResolvedValue(true)
       firmwareService.fileUrl.mockReturnValue('http://api/firmware/fw-1.bin')
 
-      const result = await service.getCurrentImage(headers as any)
+      const result = await service.getCurrentImage(headers)
 
       expect(firmwareService.verifyChecksum).toHaveBeenCalledWith(targetFirmware)
       expect(result.firmware_url).toBe('http://api/firmware/fw-1.bin')
@@ -613,11 +613,11 @@ describe('deviceDisplayService', () => {
     })
 
     it('skips serving the url and leaves the flag set when the checksum does not match', async () => {
-      const device = { ...baseDevice, deviceModel: OG_PLUS, updateFirmware: true, targetFirmware }
+      const device = makeDevice({ ...baseDevice, deviceModel: OG_PLUS, updateFirmware: true, targetFirmware })
       primeNoScreen(device)
       firmwareService.verifyChecksum.mockResolvedValue(false)
 
-      const result = await service.getCurrentImage(headers as any)
+      const result = await service.getCurrentImage(headers)
 
       expect(result.firmware_url).toBe('')
       expect(result.update_firmware).toBe(false)
@@ -625,9 +625,9 @@ describe('deviceDisplayService', () => {
     })
 
     it('does nothing when updateFirmware is false', async () => {
-      primeNoScreen({ ...baseDevice, deviceModel: OG_PLUS, updateFirmware: false, targetFirmware })
+      primeNoScreen(makeDevice({ ...baseDevice, deviceModel: OG_PLUS, updateFirmware: false, targetFirmware }))
 
-      const result = await service.getCurrentImage(headers as any)
+      const result = await service.getCurrentImage(headers)
 
       expect(firmwareService.verifyChecksum).not.toHaveBeenCalled()
       expect(result.firmware_url).toBe('')
@@ -635,21 +635,21 @@ describe('deviceDisplayService', () => {
     })
 
     it('does nothing when no firmware is targeted', async () => {
-      primeNoScreen({ ...baseDevice, deviceModel: OG_PLUS, updateFirmware: true, targetFirmware: null })
+      primeNoScreen(makeDevice({ ...baseDevice, deviceModel: OG_PLUS, updateFirmware: true, targetFirmware: null }))
 
-      const result = await service.getCurrentImage(headers as any)
+      const result = await service.getCurrentImage(headers)
 
       expect(firmwareService.verifyChecksum).not.toHaveBeenCalled()
       expect(result.update_firmware).toBe(false)
     })
 
     it('leaves a mirrored device unaffected by any firmware assignment', async () => {
-      const device = { ...baseDevice, deviceModel: OG_PLUS, mirrorEnabled: true, mirrorMac: 'different-mac', updateFirmware: true, targetFirmware }
+      const device = makeDevice({ ...baseDevice, deviceModel: OG_PLUS, mirrorEnabled: true, mirrorMac: 'different-mac', updateFirmware: true, targetFirmware })
       deviceRepo.findOneBy.mockResolvedValue(device)
       configService.get.mockReturnValue('http://api')
-      mockFetch.mockResolvedValueOnce({ json: () => Promise.resolve({ filename: 'mirror.png', image_url: 'http://example.com/image.jpg' }) })
+      mockFetch.mockResolvedValueOnce(jsonResponse({ filename: 'mirror.png', image_url: 'http://example.com/image.jpg' }))
 
-      const result = await service.getCurrentImage(headers as any)
+      const result = await service.getCurrentImage(headers)
 
       expect(firmwareService.verifyChecksum).not.toHaveBeenCalled()
       expect(result.firmware_url).toBeNull()
@@ -664,12 +664,12 @@ describe('deviceDisplayService', () => {
     })
 
     it('throws UnauthorizedException if API key is invalid', async () => {
-      deviceRepo.findOneBy.mockResolvedValue({ ...baseDevice, apikey: 'wrong' })
+      deviceRepo.findOneBy.mockResolvedValue(makeDevice({ ...baseDevice, apikey: 'wrong' }))
       await expect(service.getCurrentImageWithoutProgressing(headers)).rejects.toThrow(UnauthorizedException)
     })
 
     it('returns default no screen image if no active screen and not mirrored', async () => {
-      deviceRepo.findOneBy.mockResolvedValue({ ...baseDevice, apikey: 'token' })
+      deviceRepo.findOneBy.mockResolvedValue(makeDevice({ ...baseDevice, apikey: 'token' }))
       screenRepo.findOneBy.mockResolvedValue(null)
       configService.get.mockReturnValue('http://api')
 
@@ -681,7 +681,7 @@ describe('deviceDisplayService', () => {
     })
 
     it('returns mirror image if device is mirrored and file exists', async () => {
-      const device = { ...baseDevice, apikey: 'token', id: '1', mirrorEnabled: true }
+      const device = makeDevice({ ...baseDevice, apikey: 'token', id: '1', mirrorEnabled: true })
       deviceRepo.findOneBy.mockResolvedValue(device)
       configService.get.mockReturnValue('http://api')
       fileExists.mockResolvedValue(true)
@@ -695,7 +695,7 @@ describe('deviceDisplayService', () => {
     })
 
     it('fetches the mirror image on demand if it is missing on disk', async () => {
-      const device = {
+      const device = makeDevice({
         ...baseDevice,
         apikey: 'token',
         id: '1',
@@ -704,13 +704,11 @@ describe('deviceDisplayService', () => {
         mirrorEnabled: true,
         mirrorMac: 'different-mac',
         mirrorApikey: 'mirror-token',
-      }
+      })
       deviceRepo.findOneBy.mockResolvedValue(device)
       configService.get.mockReturnValue('http://api')
       fileExists.mockResolvedValue(false)
-      mockFetch.mockResolvedValueOnce({
-        json: () => Promise.resolve({ filename: 'remote.png', image_url: 'http://example.com/image.jpg' }),
-      })
+      mockFetch.mockResolvedValueOnce(jsonResponse({ filename: 'remote.png', image_url: 'http://example.com/image.jpg' }))
 
       const { downloadImage, convertToPng } = await import('../../utils/imageUtils.js')
 
@@ -727,7 +725,7 @@ describe('deviceDisplayService', () => {
     })
 
     it('returns error image if device is mirrored, file does not exist and on-demand fetch fails', async () => {
-      const device = { ...baseDevice, apikey: 'token', id: '1', mirrorEnabled: true }
+      const device = makeDevice({ ...baseDevice, apikey: 'token', id: '1', mirrorEnabled: true })
       deviceRepo.findOneBy.mockResolvedValue(device)
       configService.get.mockReturnValue('http://api')
       fileExists.mockResolvedValue(false)
@@ -741,13 +739,13 @@ describe('deviceDisplayService', () => {
     })
 
     it('returns active screen image if not mirrored', async () => {
-      const device = { ...baseDevice, apikey: 'token', id: '1', mirrorEnabled: false }
-      const activeScreen = {
+      const device = makeDevice({ ...baseDevice, apikey: 'token', id: '1', mirrorEnabled: false })
+      const activeScreen = makeScreen({
         id: 'screen1',
+        device,
         filename: 'test.png',
-        generatedAt: new Date(),
         isActive: true,
-      }
+      })
 
       deviceRepo.findOneBy.mockResolvedValue(device)
       screenRepo.findOneBy.mockResolvedValue(activeScreen)
@@ -762,15 +760,15 @@ describe('deviceDisplayService', () => {
     })
 
     it('generates the screen image on demand if it is missing on disk', async () => {
-      const device = { ...baseDevice, apikey: 'token', id: '1', width: 800, height: 480, mirrorEnabled: false }
-      const activeScreen = {
+      const device = makeDevice({ ...baseDevice, apikey: 'token', id: '1', width: 800, height: 480, mirrorEnabled: false })
+      const activeScreen = makeScreen({
         id: 'screen1',
+        device,
         filename: 'test.png',
-        generatedAt: new Date(),
         isActive: true,
         externalLink: 'http://example.com/image.jpg',
         fetchManual: false,
-      }
+      })
 
       deviceRepo.findOneBy.mockResolvedValue(device)
       screenRepo.findOneBy.mockResolvedValue(activeScreen)
@@ -787,14 +785,14 @@ describe('deviceDisplayService', () => {
     })
 
     it('returns error image if the screen image is missing and cannot be regenerated', async () => {
-      const device = { ...baseDevice, apikey: 'token', id: '1', mirrorEnabled: false }
-      const activeScreen = {
+      const device = makeDevice({ ...baseDevice, apikey: 'token', id: '1', mirrorEnabled: false })
+      const activeScreen = makeScreen({
         id: 'screen1',
+        device,
         type: 'file',
         filename: 'test.png',
-        generatedAt: new Date(),
         isActive: true,
-      }
+      })
 
       deviceRepo.findOneBy.mockResolvedValue(device)
       screenRepo.findOneBy.mockResolvedValue(activeScreen)
@@ -807,16 +805,17 @@ describe('deviceDisplayService', () => {
     })
 
     it('returns fresh generation metadata after on-demand generation', async () => {
-      const device = { ...baseDevice, apikey: 'token', id: '1', width: 800, height: 480, mirrorEnabled: false }
+      const device = makeDevice({ ...baseDevice, apikey: 'token', id: '1', width: 800, height: 480, mirrorEnabled: false })
       const staleDate = new Date('2026-01-01T00:00:00.000Z')
-      const activeScreen = {
+      const activeScreen = makeScreen({
         id: 'screen1',
+        device,
         filename: 'test.png',
         generatedAt: staleDate,
         isActive: true,
         externalLink: 'http://example.com/image.jpg',
         fetchManual: false,
-      }
+      })
 
       deviceRepo.findOneBy.mockResolvedValue(device)
       screenRepo.findOneBy.mockResolvedValue(activeScreen)
@@ -832,121 +831,113 @@ describe('deviceDisplayService', () => {
 
   describe('mashup screen rendering', () => {
     beforeEach(() => {
-      // Inject services needed for mashup
-      ;(service as any).pluginDataFetcher = { fetchData: vi.fn(), fetchOrLiteral: vi.fn() } as any
-      ;(service as any).pluginRenderer = { render: vi.fn() } as any
-      ;(service as any).pluginTransformer = { transform: vi.fn() } as any
+      injectPrivate(service, 'pluginDataFetcher', { fetchOrLiteral: vi.fn() })
+      injectPrivate(service, 'pluginRenderer', { render: vi.fn() })
+      injectPrivate(service, 'pluginTransformer', { transform: vi.fn() })
     })
 
     it('should detect mashup screen and call renderer', async () => {
-      const device = { ...baseDevice, width: 800, height: 480, apikey: 'token', id: 'device-1' }
+      const device = makeDevice({ ...baseDevice, width: 800, height: 480, apikey: 'token', id: 'device-1' })
 
-      const mashupConfig = {
+      const mashupConfig = makeMashupConfiguration({
         id: 'config-1',
         layout: '2x2',
         slots: [
-          { id: 'slot-1', plugin: { id: 'p1', name: 'Weather', dataSources: [], templates: [] } },
-          { id: 'slot-2', plugin: { id: 'p2', name: 'Calendar', dataSources: [], templates: [] } },
+          makeMashupSlot({ id: 'slot-1', plugin: makePlugin({ id: 'p1', name: 'Weather' }) }),
+          makeMashupSlot({ id: 'slot-2', plugin: makePlugin({ id: 'p2', name: 'Calendar' }) }),
         ],
-      }
+      })
 
-      const activeScreen = {
+      const activeScreen = makeScreen({
         id: 'screen1',
         type: 'file',
         filename: 'First',
         order: 1,
         isActive: true,
         device,
-      }
+      })
 
-      const nextScreenBase = {
+      const nextScreenBase = makeScreen({
         id: 'screen2',
         type: 'mashup',
         filename: 'Dashboard',
         order: 2,
         isActive: false,
-        generatedAt: new Date(),
         device,
-      }
+      })
 
       deviceRepo.findOneBy.mockResolvedValue(device)
       deviceRepo.save.mockResolvedValue(device)
       screenRepo.find.mockResolvedValue([activeScreen, nextScreenBase])
       screenRepo.findOne.mockResolvedValue({ ...nextScreenBase, mashupConfiguration: mashupConfig })
-      screenRepo.update.mockResolvedValue(undefined)
       screenRepo.save.mockResolvedValue({ ...nextScreenBase, isActive: true })
       configService.get.mockReturnValue('http://api')
 
-      // Mock MashupRendererService
       const mockMashupRenderer = {
         renderMashup: vi.fn().mockResolvedValue('<html>Mashup HTML</html>'),
       }
-      ;(service as any).mashupRenderer = mockMashupRenderer
+      injectPrivate(service, 'mashupRenderer', mockMashupRenderer)
 
-      const result = await service.getCurrentImage({ ...headers, width: 800, height: 480 } as any)
+      const result = await service.getCurrentImage({ ...headers, width: '800', height: '480' })
 
       expect(mockMashupRenderer.renderMashup).toHaveBeenCalled()
       expect(result).toBeInstanceOf(Display)
     })
 
     it('should handle mashup with cached output', async () => {
-      const device = { ...baseDevice, width: 800, height: 480, apikey: 'token' }
-      const activeScreen = { id: 'screen1', isActive: true, order: 1, device }
-      const nextScreen = {
+      const device = makeDevice({ ...baseDevice, width: 800, height: 480, apikey: 'token' })
+      const activeScreen = makeScreen({ id: 'screen1', isActive: true, order: 1, device })
+      const nextScreen = makeScreen({
         id: 'screen2',
         type: 'mashup',
         filename: 'Dashboard',
         order: 2,
         isActive: false,
-        generatedAt: new Date(),
         device,
         cachedPluginOutput: '<html>Cached mashup</html>',
-        mashupConfiguration: { id: 'config-1' },
-      }
+        mashupConfiguration: makeMashupConfiguration({ id: 'config-1' }),
+      })
 
       deviceRepo.findOneBy.mockResolvedValue(device)
       deviceRepo.save.mockResolvedValue(device)
       screenRepo.find.mockResolvedValue([activeScreen, nextScreen])
       screenRepo.findOne.mockResolvedValue(nextScreen)
-      screenRepo.update.mockResolvedValue(undefined)
       screenRepo.save.mockResolvedValue(nextScreen)
       configService.get.mockReturnValue('http://api')
       fileExists.mockResolvedValue(true)
 
-      const result = await service.getCurrentImage({ ...headers, width: 800, height: 480 } as any)
+      const result = await service.getCurrentImage({ ...headers, width: '800', height: '480' })
 
       expect(result).toBeInstanceOf(Display)
       expect(result.image_url).toContain('/screens/devices/')
     })
 
     it('should fallback to error.png if mashup rendering fails', async () => {
-      const device = { ...baseDevice, width: 800, height: 480, apikey: 'token' }
-      const activeScreen = { id: 'screen1', isActive: true, order: 1, device }
-      const nextScreen = {
+      const device = makeDevice({ ...baseDevice, width: 800, height: 480, apikey: 'token' })
+      const activeScreen = makeScreen({ id: 'screen1', isActive: true, order: 1, device })
+      const nextScreen = makeScreen({
         id: 'screen2',
         type: 'mashup',
         filename: 'Dashboard',
         order: 2,
         isActive: false,
-        generatedAt: new Date(),
         device,
-        mashupConfiguration: { id: 'config-1', slots: [] },
-      }
+        mashupConfiguration: makeMashupConfiguration({ id: 'config-1', slots: [] }),
+      })
 
       deviceRepo.findOneBy.mockResolvedValue(device)
       deviceRepo.save.mockResolvedValue(device)
       screenRepo.find.mockResolvedValue([activeScreen, nextScreen])
       screenRepo.findOne.mockResolvedValue(nextScreen)
-      screenRepo.update.mockResolvedValue(undefined)
       screenRepo.save.mockResolvedValue(nextScreen)
       configService.get.mockReturnValue('http://api')
 
       const mockMashupRenderer = {
         renderMashup: vi.fn().mockRejectedValue(new Error('Render failed')),
       }
-      ;(service as any).mashupRenderer = mockMashupRenderer
+      injectPrivate(service, 'mashupRenderer', mockMashupRenderer)
 
-      const result = await service.getCurrentImage({ ...headers, width: 800, height: 480 } as any)
+      const result = await service.getCurrentImage({ ...headers, width: '800', height: '480' })
 
       expect(result).toBeInstanceOf(Display)
       expect(result.image_url).toBe('http://api/screens/error.png')
@@ -954,10 +945,11 @@ describe('deviceDisplayService', () => {
   })
 
   describe('schedule-gated rotation', () => {
-    const scheduledDevice = { ...baseDevice, apikey: 'token', id: '1', mirrorEnabled: false }
+    const scheduledDevice = makeDevice({ ...baseDevice, apikey: 'token', id: '1', mirrorEnabled: false })
 
-    function screen(overrides: Record<string, unknown>) {
-      return {
+    function screen(overrides: Partial<Omit<Screen, 'schedule'>> & { schedule?: Partial<Schedule> | null } = {}): Screen {
+      const { schedule, ...rest } = overrides
+      return makeScreen({
         device: scheduledDevice,
         type: 'file',
         isActive: false,
@@ -965,18 +957,15 @@ describe('deviceDisplayService', () => {
         externalLink: null,
         filename: 'file.png',
         generatedAt: new Date('2026-08-21T00:00:00'),
-        schedule: null,
-        ...overrides,
-      }
+        schedule: schedule == null ? null : makeSchedule(schedule),
+        ...rest,
+      })
     }
 
-    function primeRotation(screens: Record<string, unknown>[]) {
+    function primeRotation(screens: Screen[]) {
       deviceRepo.findOneBy.mockResolvedValue(scheduledDevice)
-      deviceRepo.save.mockResolvedValue(undefined)
       screenRepo.find.mockResolvedValue(screens)
-      screenRepo.findOne.mockResolvedValue(undefined)
-      screenRepo.update.mockResolvedValue(undefined)
-      screenRepo.save.mockResolvedValue(undefined)
+      screenRepo.findOne.mockResolvedValue(null)
       configService.get.mockReturnValue('http://api')
       fileExists.mockResolvedValue(true)
     }
@@ -998,7 +987,7 @@ describe('deviceDisplayService', () => {
         screen({ id: 'screen3', order: 3 }),
       ])
 
-      const result = await service.getCurrentImage(headers as any)
+      const result = await service.getCurrentImage(headers)
 
       expect(result.image_url).toBe('http://api/screens/devices/1/screen3.png')
       expect(screenRepo.save).toHaveBeenCalledWith(expect.objectContaining({ id: 'screen3', isActive: true }))
@@ -1012,7 +1001,7 @@ describe('deviceDisplayService', () => {
         screen({ id: 'screen3', order: 3, schedule: { enabled: true, weekdays: [1, 2, 3, 4, 5] } }),
       ])
 
-      const result = await service.getCurrentImage(headers as any)
+      const result = await service.getCurrentImage(headers)
 
       expect(result.image_url).toBe('http://api/screens/devices/1/screen1.png')
     })
@@ -1025,7 +1014,7 @@ describe('deviceDisplayService', () => {
         screen({ id: 'screen3', order: 3 }),
       ])
 
-      const result = await service.getCurrentImage(headers as any)
+      const result = await service.getCurrentImage(headers)
 
       expect(result.image_url).toBe('http://api/screens/devices/1/screen3.png')
     })
@@ -1037,7 +1026,7 @@ describe('deviceDisplayService', () => {
         screen({ id: 'screen2', order: 2, schedule: { enabled: false } }),
       ])
 
-      const result = await service.getCurrentImage(headers as any)
+      const result = await service.getCurrentImage(headers)
 
       expect(result).toBeInstanceOf(Display)
       expect(result.filename).toBe('noScreen.png')
@@ -1052,7 +1041,7 @@ describe('deviceDisplayService', () => {
         screen({ id: 'screen1', order: 1, schedule: { enabled: true, startTime: '07:00', endTime: '09:00' } }),
       ])
 
-      const result = await service.getCurrentImage(headers as any)
+      const result = await service.getCurrentImage(headers)
 
       expect(result.image_url).toBe('http://api/screens/devices/1/screen1.png')
       expect(screenRepo.save).toHaveBeenCalledWith(expect.objectContaining({ id: 'screen1', isActive: true }))
@@ -1064,7 +1053,7 @@ describe('deviceDisplayService', () => {
         screen({ id: 'screen1', order: 1, schedule: { enabled: true, startTime: '07:00', endTime: '09:00' } }),
       ])
 
-      const result = await service.getCurrentImage(headers as any)
+      const result = await service.getCurrentImage(headers)
 
       expect(result.filename).toBe('noScreen.png')
     })
@@ -1074,15 +1063,15 @@ describe('deviceDisplayService', () => {
 
       vi.setSystemTime(new Date('2026-08-21T23:00:00'))
       primeRotation([screen({ id: 'screen1', order: 1, schedule: overnight })])
-      expect((await service.getCurrentImage(headers as any)).image_url).toBe('http://api/screens/devices/1/screen1.png')
+      expect((await service.getCurrentImage(headers)).image_url).toBe('http://api/screens/devices/1/screen1.png')
 
       vi.setSystemTime(new Date('2026-08-21T01:00:00'))
       primeRotation([screen({ id: 'screen1', order: 1, schedule: overnight })])
-      expect((await service.getCurrentImage(headers as any)).image_url).toBe('http://api/screens/devices/1/screen1.png')
+      expect((await service.getCurrentImage(headers)).image_url).toBe('http://api/screens/devices/1/screen1.png')
 
       vi.setSystemTime(new Date('2026-08-21T12:00:00'))
       primeRotation([screen({ id: 'screen1', order: 1, schedule: overnight })])
-      expect((await service.getCurrentImage(headers as any)).filename).toBe('noScreen.png')
+      expect((await service.getCurrentImage(headers)).filename).toBe('noScreen.png')
     })
 
     it('drops a seasonal screen from the rotation once its date range has passed', async () => {
@@ -1090,16 +1079,16 @@ describe('deviceDisplayService', () => {
 
       vi.setSystemTime(new Date('2026-12-13T12:00:00'))
       primeRotation([screen({ id: 'screen1', order: 1, schedule: december })])
-      expect((await service.getCurrentImage(headers as any)).image_url).toBe('http://api/screens/devices/1/screen1.png')
+      expect((await service.getCurrentImage(headers)).image_url).toBe('http://api/screens/devices/1/screen1.png')
 
       vi.setSystemTime(new Date('2026-12-26T12:00:00'))
       primeRotation([screen({ id: 'screen1', order: 1, schedule: december })])
-      expect((await service.getCurrentImage(headers as any)).filename).toBe('noScreen.png')
+      expect((await service.getCurrentImage(headers)).filename).toBe('noScreen.png')
     })
   })
 
   describe('sleep mode', () => {
-    const sleepingDevice = { ...baseDevice, apikey: 'token', id: '1', deviceModel: OG_PLUS, mirrorEnabled: false, sleepModeEnabled: true, sleepStartTime: 22 * 3600, sleepEndTime: 6 * 3600, sleepScreenEnabled: false }
+    const sleepingDevice = makeDevice({ ...baseDevice, apikey: 'token', id: '1', deviceModel: OG_PLUS, mirrorEnabled: false, sleepModeEnabled: true, sleepStartTime: 22 * 3600, sleepEndTime: 6 * 3600, sleepScreenEnabled: false })
 
     beforeEach(() => {
       vi.useFakeTimers({ toFake: ['Date'] })
@@ -1112,25 +1101,25 @@ describe('deviceDisplayService', () => {
     })
 
     it('leaves rotation and refresh rate unaffected when sleep mode is disabled', async () => {
-      const device = { ...sleepingDevice, sleepModeEnabled: false, refreshRate: 60 }
-      const activeScreen = { id: 'screen1', order: 1, device, isActive: true, fetchManual: false, externalLink: null, filename: 'file.png', generatedAt: new Date() }
+      const device = makeDevice({ ...sleepingDevice, sleepModeEnabled: false, refreshRate: 60 })
+      const activeScreen = makeScreen({ id: 'screen1', order: 1, device, isActive: true, fetchManual: false, externalLink: null, filename: 'file.png' })
       deviceRepo.findOneBy.mockResolvedValue(device)
-      screenRepo.find.mockResolvedValue([activeScreen, { ...activeScreen, id: 'screen2', order: 2, isActive: false }])
+      screenRepo.find.mockResolvedValue([activeScreen, makeScreen({ ...activeScreen, id: 'screen2', order: 2, isActive: false })])
 
       vi.setSystemTime(new Date('2026-08-22T23:00:00'))
-      const result = await service.getCurrentImage(headers as any)
+      const result = await service.getCurrentImage(headers)
 
       expect(result.image_url).toBe('http://api/screens/devices/1/screen2.png')
       expect(result.refresh_rate).toBe(60)
     })
 
     it('does not advance the active screen while asleep', async () => {
-      const activeScreen = { id: 'screen1', order: 1, device: sleepingDevice, isActive: true, fetchManual: false, externalLink: null, filename: 'file.png', generatedAt: new Date() }
+      const activeScreen = makeScreen({ id: 'screen1', order: 1, device: sleepingDevice, isActive: true, fetchManual: false, externalLink: null, filename: 'file.png' })
       deviceRepo.findOneBy.mockResolvedValue(sleepingDevice)
-      screenRepo.find.mockResolvedValue([activeScreen, { ...activeScreen, id: 'screen2', order: 2, isActive: false }])
+      screenRepo.find.mockResolvedValue([activeScreen, makeScreen({ ...activeScreen, id: 'screen2', order: 2, isActive: false })])
 
       vi.setSystemTime(new Date('2026-08-22T23:00:00'))
-      await service.getCurrentImage(headers as any)
+      await service.getCurrentImage(headers)
 
       expect(screenRepo.update).not.toHaveBeenCalled()
       expect(screenRepo.save).not.toHaveBeenCalled()
@@ -1141,7 +1130,7 @@ describe('deviceDisplayService', () => {
       screenRepo.findOneBy.mockResolvedValue(null)
 
       vi.setSystemTime(new Date('2026-08-22T23:00:00'))
-      const result = await service.getCurrentImage(headers as any)
+      const result = await service.getCurrentImage(headers)
 
       expect(result.refresh_rate).toBe(7 * 3600)
     })
@@ -1151,28 +1140,28 @@ describe('deviceDisplayService', () => {
       screenRepo.findOneBy.mockResolvedValue(null)
 
       vi.setSystemTime(new Date('2026-08-22T05:59:30'))
-      const result = await service.getCurrentImage(headers as any)
+      const result = await service.getCurrentImage(headers)
 
       expect(result.refresh_rate).toBe(60)
     })
 
     it('is not asleep outside the configured window', async () => {
-      const device = { ...sleepingDevice, refreshRate: 60 }
+      const device = makeDevice({ ...sleepingDevice, refreshRate: 60 })
       deviceRepo.findOneBy.mockResolvedValue(device)
       screenRepo.find.mockResolvedValue([])
 
       vi.setSystemTime(new Date('2026-08-22T12:00:00'))
-      const result = await service.getCurrentImage(headers as any)
+      const result = await service.getCurrentImage(headers)
 
       expect(result.refresh_rate).toBe(60)
     })
 
     it('serves the dedicated sleep screen when enabled, even for a screenless device', async () => {
-      const device = { ...sleepingDevice, sleepScreenEnabled: true }
+      const device = makeDevice({ ...sleepingDevice, sleepScreenEnabled: true })
       deviceRepo.findOneBy.mockResolvedValue(device)
 
       vi.setSystemTime(new Date('2026-08-22T23:00:00'))
-      const result = await service.getCurrentImage(headers as any)
+      const result = await service.getCurrentImage(headers)
 
       expect(result.filename).toBe('sleep.png')
       expect(result.image_url).toBe('http://api/screens/sleep.png')
@@ -1184,7 +1173,7 @@ describe('deviceDisplayService', () => {
       screenRepo.findOneBy.mockResolvedValue(null)
 
       vi.setSystemTime(new Date('2026-08-22T23:00:00'))
-      const result = await service.getCurrentImage(headers as any)
+      const result = await service.getCurrentImage(headers)
 
       expect(result.filename).toBe('noScreen.png')
       expect(result.image_url).toBe('http://api/screens/noScreen.png')
@@ -1192,31 +1181,31 @@ describe('deviceDisplayService', () => {
 
     it('freezes the existing active screen image when the sleep screen is disabled', async () => {
       const generatedAt = new Date('2026-08-20T00:00:00Z')
-      const activeScreen = { id: 'screen1', device: sleepingDevice, isActive: true, filename: 'file.png', generatedAt }
+      const activeScreen = makeScreen({ id: 'screen1', device: sleepingDevice, isActive: true, filename: 'file.png', generatedAt })
       deviceRepo.findOneBy.mockResolvedValue(sleepingDevice)
       screenRepo.findOneBy.mockResolvedValue(activeScreen)
 
       vi.setSystemTime(new Date('2026-08-22T23:00:00'))
-      const result = await service.getCurrentImage(headers as any)
+      const result = await service.getCurrentImage(headers)
 
       expect(result.filename).toBe(`file.png_${generatedAt.toISOString()}`)
       expect(result.image_url).toBe('http://api/screens/devices/1/screen1.png')
     })
 
     it('skips sleep mode entirely for a mirrored device', async () => {
-      const device = { ...sleepingDevice, mirrorEnabled: true, mirrorMac: 'different-mac', mirrorApikey: 'mirror-token' }
+      const device = makeDevice({ ...sleepingDevice, mirrorEnabled: true, mirrorMac: 'different-mac', mirrorApikey: 'mirror-token' })
       deviceRepo.findOneBy.mockResolvedValue(device)
-      mockFetch.mockResolvedValueOnce({ json: () => Promise.resolve({ filename: 'mirror.png', image_url: 'http://example.com/image.jpg', refresh_rate: 30 }) })
+      mockFetch.mockResolvedValueOnce(jsonResponse({ filename: 'mirror.png', image_url: 'http://example.com/image.jpg', refresh_rate: 30 }))
 
       vi.setSystemTime(new Date('2026-08-22T23:00:00'))
-      const result = await service.getCurrentImage(headers as any)
+      const result = await service.getCurrentImage(headers)
 
       expect(result.filename).toBe('mirror.png')
     })
 
     describe('getCurrentImageWithoutProgressing', () => {
       it('mirrors the sleep-screen resolution used by the poll handler', async () => {
-        const device = { ...sleepingDevice, sleepScreenEnabled: true }
+        const device = makeDevice({ ...sleepingDevice, sleepScreenEnabled: true })
         deviceRepo.findOneBy.mockResolvedValue(device)
 
         vi.setSystemTime(new Date('2026-08-22T23:00:00'))
@@ -1228,7 +1217,7 @@ describe('deviceDisplayService', () => {
       })
 
       it('keeps showing the active screen when the sleep screen is disabled', async () => {
-        const activeScreen = { id: 'screen1', filename: 'file.png', generatedAt: new Date(), isActive: true }
+        const activeScreen = makeScreen({ id: 'screen1', device: sleepingDevice, filename: 'file.png', isActive: true })
         deviceRepo.findOneBy.mockResolvedValue(sleepingDevice)
         screenRepo.findOneBy.mockResolvedValue(activeScreen)
 

--- a/packages/api/src/devices/__test__/setup.controller.spec.ts
+++ b/packages/api/src/devices/__test__/setup.controller.spec.ts
@@ -1,6 +1,7 @@
 import type { DeviceSetupService } from '../setup.service'
 import { BadRequestException } from '@nestjs/common'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { asService } from '../../test/mockService'
 import { SetupController } from '../setup.controller'
 
 describe('setupController (unit)', () => {
@@ -9,7 +10,7 @@ describe('setupController (unit)', () => {
 
   beforeEach(() => {
     service = { setupDevice: vi.fn() }
-    controller = new SetupController(service as unknown as DeviceSetupService)
+    controller = new SetupController(asService<DeviceSetupService>(service))
   })
 
   it('should return setup response from service', async () => {
@@ -22,7 +23,7 @@ describe('setupController (unit)', () => {
       friendly_id: 'friendly',
     }
     service.setupDevice.mockResolvedValue(response)
-    const result = await controller.setupDevice(headers as any)
+    const result = await controller.setupDevice(headers)
     expect(service.setupDevice).toHaveBeenCalledWith(headers)
     expect(result).toBe(response)
   })
@@ -31,6 +32,7 @@ describe('setupController (unit)', () => {
     service.setupDevice.mockImplementation(() => {
       throw new BadRequestException('Missing headers')
     })
-    await expect(controller.setupDevice({} as any)).rejects.toThrow(BadRequestException)
+    // @ts-expect-error deliberately missing the required id header
+    await expect(controller.setupDevice({})).rejects.toThrow(BadRequestException)
   })
 })

--- a/packages/api/src/devices/__test__/setup.service.spec.ts
+++ b/packages/api/src/devices/__test__/setup.service.spec.ts
@@ -1,7 +1,12 @@
-import type { MockDeviceModelsService, MockFallbackScreensService } from '../../device-models/__test__/mockDeviceModelsService'
+import type { DeviceModelsService } from '../../device-models/device-models.service'
+import type { FallbackScreensService } from '../../device-models/fallback-screens.service'
 import type { Device } from '../devices.entity'
+import type { SetupRequestHeadersDto } from '../dto/setup-request-headers.dto'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { createMockDeviceModelsService, createMockFallbackScreensService, OG_PLUS, primeMockDeviceModelsService, primeMockFallbackScreensService, V2 } from '../../device-models/__test__/mockDeviceModelsService'
+import { makeDevice } from '../../test/fixtures'
+import { createMockDeviceModelsService, createMockFallbackScreensService, OG_PLUS, primeMockDeviceModelsService, primeMockFallbackScreensService, V2 } from '../../test/mockDeviceModelsService'
+import { asRepository, createMockRepository } from '../../test/mockRepository'
+import { asService } from '../../test/mockService'
 import { DeviceSetupService } from '../setup.service'
 
 vi.mock('../../utils/generateApikey', () => ({
@@ -11,38 +16,30 @@ vi.mock('../../utils/generateFriendlyName', () => ({
   default: vi.fn(() => 'mocked-friendly-id'),
 }))
 
-function createMockRepo() {
-  return {
-    findOneBy: vi.fn(),
-    create: vi.fn(),
-    save: vi.fn(),
-  }
-}
-
 describe('deviceSetupService', () => {
   let service: DeviceSetupService
-  let deviceRepo: ReturnType<typeof createMockRepo>
-  let deviceModels: MockDeviceModelsService
-  let fallbackScreens: MockFallbackScreensService
+  let deviceRepo: ReturnType<typeof createMockRepository<Device>>
+  let deviceModels: ReturnType<typeof createMockDeviceModelsService>
+  let fallbackScreens: ReturnType<typeof createMockFallbackScreensService>
 
   beforeEach(() => {
-    deviceRepo = createMockRepo()
+    deviceRepo = createMockRepository<Device>()
     deviceModels = createMockDeviceModelsService()
     fallbackScreens = createMockFallbackScreensService()
     service = new DeviceSetupService(
-      deviceRepo as any,
-      deviceModels as any,
-      fallbackScreens as any,
+      asRepository(deviceRepo),
+      asService<DeviceModelsService>(deviceModels),
+      asService<FallbackScreensService>(fallbackScreens),
     )
     vi.resetAllMocks()
     primeMockDeviceModelsService(deviceModels)
     primeMockFallbackScreensService(fallbackScreens)
   })
 
-  const headers = { id: 'mac' }
+  const headers: SetupRequestHeadersDto = { id: 'mac' }
 
   it('returns existing credentials if device exists', async () => {
-    const device = { apikey: 'existing-key', friendlyId: 'existing-id' } as Device
+    const device = makeDevice({ apikey: 'existing-key', friendlyId: 'existing-id' })
     deviceRepo.findOneBy.mockResolvedValue(device)
     const result = await service.setupDevice(headers)
     expect(result.api_key).toBe('existing-key')
@@ -53,7 +50,7 @@ describe('deviceSetupService', () => {
   })
 
   it('creates new device and returns new credentials if device does not exist', async () => {
-    const newDevice = { id: 'new', mac: 'mac', friendlyId: 'mocked-friendly-id', apikey: 'mocked-api-key' }
+    const newDevice = makeDevice({ id: 'new', mac: 'mac', friendlyId: 'mocked-friendly-id', apikey: 'mocked-api-key', name: 'mocked-friendly-id' })
     deviceRepo.findOneBy.mockResolvedValue(null)
     deviceRepo.create.mockReturnValue(newDevice)
     deviceRepo.save.mockResolvedValue(newDevice)
@@ -76,7 +73,7 @@ describe('deviceSetupService', () => {
   })
 
   it('serves the welcome image converted for the device render target', async () => {
-    deviceRepo.findOneBy.mockResolvedValue({ apikey: 'key', friendlyId: 'id', deviceModel: V2 } as unknown as Device)
+    deviceRepo.findOneBy.mockResolvedValue(makeDevice({ apikey: 'key', friendlyId: 'id', deviceModel: V2 }))
     deviceModels.renderTargetFor.mockResolvedValue({ model: V2, palette: OG_PLUS })
     fallbackScreens.urlFor.mockResolvedValue('http://api/screens/fallback/v2-gray-16/welcome.png')
 
@@ -87,7 +84,7 @@ describe('deviceSetupService', () => {
   })
 
   it('records the reported firmware version and model, and resolves a model when none is assigned', async () => {
-    const device = { apikey: 'key', friendlyId: 'id', deviceModel: null } as unknown as Device
+    const device = makeDevice({ apikey: 'key', friendlyId: 'id', deviceModel: null })
     deviceRepo.findOneBy.mockResolvedValue(device)
     deviceModels.assignResolvedModel.mockResolvedValue(OG_PLUS)
 
@@ -98,7 +95,7 @@ describe('deviceSetupService', () => {
   })
 
   it('leaves an already assigned model alone', async () => {
-    const device = { apikey: 'key', friendlyId: 'id', deviceModel: OG_PLUS } as unknown as Device
+    const device = makeDevice({ apikey: 'key', friendlyId: 'id', deviceModel: OG_PLUS })
     deviceRepo.findOneBy.mockResolvedValue(device)
 
     await service.setupDevice({ id: 'mac', model: 'x' })

--- a/packages/api/src/devices/display.service.ts
+++ b/packages/api/src/devices/display.service.ts
@@ -29,7 +29,7 @@ import { Display } from './display'
 import { DisplayScreen } from './displayScreen'
 import { isDeviceAsleep, secondsUntilSleepEnd } from './sleep-mode'
 
-interface TrmnlScreenResponse {
+export interface TrmnlScreenResponse {
   action?: string
   filename: string
   image_url: string

--- a/packages/api/src/firmware/__test__/firmware-sync.service.spec.ts
+++ b/packages/api/src/firmware/__test__/firmware-sync.service.spec.ts
@@ -1,4 +1,8 @@
+import type { Firmware } from '../entities/firmware.entity'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { jsonResponse, stubFetch } from '../../test/fetch'
+import { makeFirmware } from '../../test/fixtures'
+import { asRepository, createMockRepository } from '../../test/mockRepository'
 import { FirmwareSyncService } from '../firmware-sync.service'
 
 const { fsMock, cronMock } = vi.hoisted(() => ({
@@ -17,42 +21,29 @@ vi.mock('node-cron', () => ({
   default: cronMock,
 }))
 
-const mockFetch = vi.fn()
-globalThis.fetch = mockFetch
+const mockFetch = stubFetch()
 
-function createMockRepo() {
-  return {
-    findOne: vi.fn(),
-    insert: vi.fn(),
-    update: vi.fn(),
-  }
-}
-
-function jsonResponse(data: unknown, ok = true) {
-  return { ok, status: ok ? 200 : 502, statusText: ok ? 'OK' : 'Bad Gateway', json: async () => data }
-}
-
-function binaryResponse(ok = true) {
-  return { ok, status: ok ? 200 : 502, statusText: ok ? 'OK' : 'Bad Gateway', arrayBuffer: async () => new Uint8Array([1, 2, 3]).buffer }
+function binaryResponse(ok = true): Response {
+  return new Response(new Uint8Array([1, 2, 3]), { status: ok ? 200 : 502, statusText: ok ? 'OK' : 'Bad Gateway' })
 }
 
 const latestPayload = { url: 'https://trmnl-fw.example.com/trmnl_og/FW1.5.6.bin', version: '1.5.6' }
 
 describe('firmwareSyncService', () => {
   let service: FirmwareSyncService
-  let firmwareRepo: ReturnType<typeof createMockRepo>
+  let firmwareRepo: ReturnType<typeof createMockRepository<Firmware>>
 
   beforeEach(() => {
     vi.resetAllMocks()
     fsMock.mkdir.mockResolvedValue(undefined)
     fsMock.writeFile.mockResolvedValue(undefined)
-    firmwareRepo = createMockRepo()
-    service = new FirmwareSyncService(firmwareRepo as any)
+    firmwareRepo = createMockRepository<Firmware>()
+    service = new FirmwareSyncService(asRepository(firmwareRepo))
   })
 
   describe('onApplicationBootstrap', () => {
     it('schedules the daily sync and swallows a boot-time sync failure instead of throwing', async () => {
-      mockFetch.mockResolvedValue(jsonResponse(null, false))
+      mockFetch.mockImplementation(async () => jsonResponse(null, { ok: false }))
       await expect(service.onApplicationBootstrap()).resolves.toBeUndefined()
       expect(cronMock.schedule).toHaveBeenCalledWith('0 4 * * *', expect.any(Function))
     })
@@ -63,7 +54,7 @@ describe('firmwareSyncService', () => {
       mockFetch
         .mockResolvedValueOnce(jsonResponse(latestPayload))
         .mockResolvedValueOnce(binaryResponse())
-      firmwareRepo.findOne.mockResolvedValue({ id: 'old', version: '1.5.5' })
+      firmwareRepo.findOne.mockResolvedValue(makeFirmware({ id: 'old', version: '1.5.5' }))
 
       const result = await service.sync()
 
@@ -82,7 +73,7 @@ describe('firmwareSyncService', () => {
 
     it('is a no-op when the version matches the newest existing row', async () => {
       mockFetch.mockResolvedValueOnce(jsonResponse(latestPayload))
-      firmwareRepo.findOne.mockResolvedValue({ id: 'current', version: '1.5.6' })
+      firmwareRepo.findOne.mockResolvedValue(makeFirmware({ id: 'current', version: '1.5.6' }))
 
       const result = await service.sync()
 
@@ -105,8 +96,8 @@ describe('firmwareSyncService', () => {
     })
 
     it('coalesces concurrent sync() calls into a single run', async () => {
-      mockFetch.mockResolvedValue(jsonResponse(latestPayload))
-      firmwareRepo.findOne.mockResolvedValue({ id: 'current', version: '1.5.6' })
+      mockFetch.mockImplementation(async () => jsonResponse(latestPayload))
+      firmwareRepo.findOne.mockResolvedValue(makeFirmware({ id: 'current', version: '1.5.6' }))
 
       const [first, second] = await Promise.all([service.sync(), service.sync()])
 
@@ -118,7 +109,7 @@ describe('firmwareSyncService', () => {
     })
 
     it('throws and writes nothing when TRMNL is unreachable', async () => {
-      mockFetch.mockResolvedValueOnce(jsonResponse(null, false))
+      mockFetch.mockResolvedValueOnce(jsonResponse(null, { ok: false }))
       await expect(service.sync()).rejects.toThrow(/request failed/)
       expect(firmwareRepo.insert).not.toHaveBeenCalled()
     })
@@ -139,7 +130,7 @@ describe('firmwareSyncService', () => {
       mockFetch
         .mockResolvedValueOnce(jsonResponse(latestPayload))
         .mockResolvedValueOnce(binaryResponse(false))
-      firmwareRepo.findOne.mockResolvedValue({ id: 'old', version: '1.5.5' })
+      firmwareRepo.findOne.mockResolvedValue(makeFirmware({ id: 'old', version: '1.5.5' }))
 
       await expect(service.sync()).rejects.toThrow(/Failed to download firmware binary/)
       expect(firmwareRepo.insert).not.toHaveBeenCalled()

--- a/packages/api/src/firmware/__test__/firmware.controller.spec.ts
+++ b/packages/api/src/firmware/__test__/firmware.controller.spec.ts
@@ -1,6 +1,10 @@
+import type { FirmwareSyncService } from '../firmware-sync.service'
+import type { FirmwareService } from '../firmware.service'
 import buffer from 'node:buffer'
 import { BadRequestException, ServiceUnavailableException } from '@nestjs/common'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { makeMulterFile } from '../../test/fs'
+import { asService } from '../../test/mockService'
 import { FirmwareController } from '../firmware.controller'
 
 describe('firmwareController', () => {
@@ -11,7 +15,7 @@ describe('firmwareController', () => {
   beforeEach(() => {
     firmwareService = { findAll: vi.fn(), upload: vi.fn(), delete: vi.fn() }
     syncService = { sync: vi.fn() }
-    controller = new FirmwareController(firmwareService as any, syncService as any)
+    controller = new FirmwareController(asService<FirmwareService>(firmwareService), asService<FirmwareSyncService>(syncService))
   })
 
   it('lists firmware', async () => {
@@ -32,10 +36,11 @@ describe('firmwareController', () => {
   })
 
   describe('upload', () => {
-    const file = { buffer: buffer.Buffer.from('x'), originalname: 'og.bin', mimetype: 'application/octet-stream', size: 1 } as Express.Multer.File
+    const file = makeMulterFile({ buffer: buffer.Buffer.from('x'), originalname: 'og.bin', mimetype: 'application/octet-stream', size: 1 })
 
     it('rejects when no file is provided', async () => {
-      await expect(controller.upload(undefined as any, '1.0.0')).rejects.toThrow(BadRequestException)
+      // @ts-expect-error deliberately omitting the required file
+      await expect(controller.upload(undefined, '1.0.0')).rejects.toThrow(BadRequestException)
       expect(firmwareService.upload).not.toHaveBeenCalled()
     })
 

--- a/packages/api/src/firmware/__test__/firmware.service.spec.ts
+++ b/packages/api/src/firmware/__test__/firmware.service.spec.ts
@@ -1,7 +1,11 @@
+import type { Firmware } from '../entities/firmware.entity'
 import nodeBuffer from 'node:buffer'
 import * as crypto from 'node:crypto'
 import { BadRequestException, NotFoundException } from '@nestjs/common'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { makeFirmware } from '../../test/fixtures'
+import { asRepository, createMockRepository } from '../../test/mockRepository'
+import { asService } from '../../test/mockService'
 import { FirmwareService } from '../firmware.service'
 
 const { fsMock, fileExistsMock } = vi.hoisted(() => ({
@@ -22,26 +26,12 @@ vi.mock('../../utils/fileExists', () => ({
   fileExists: fileExistsMock,
 }))
 
-function createMockRepo() {
-  const queryBuilder = {
-    orderBy: vi.fn(),
-    getMany: vi.fn(),
-  }
-  queryBuilder.orderBy.mockReturnValue(queryBuilder)
-  return {
-    find: vi.fn(),
-    findOneBy: vi.fn(),
-    create: vi.fn(),
-    save: vi.fn(),
-    remove: vi.fn(),
-    createQueryBuilder: vi.fn().mockReturnValue(queryBuilder),
-    queryBuilder,
-  }
-}
-
 describe('firmwareService', () => {
   let service: FirmwareService
-  let repo: ReturnType<typeof createMockRepo>
+  let repo: ReturnType<typeof createMockRepository<Firmware>> & {
+    queryBuilder: { orderBy: ReturnType<typeof vi.fn>, getMany: ReturnType<typeof vi.fn> }
+    createQueryBuilder: ReturnType<typeof vi.fn>
+  }
   let configService: { get: ReturnType<typeof vi.fn> }
 
   beforeEach(() => {
@@ -49,18 +39,27 @@ describe('firmwareService', () => {
     fsMock.mkdir.mockResolvedValue(undefined)
     fsMock.writeFile.mockResolvedValue(undefined)
     fsMock.unlink.mockResolvedValue(undefined)
-    repo = createMockRepo()
+
+    const queryBuilder = {
+      orderBy: vi.fn(),
+      getMany: vi.fn(),
+    }
+    queryBuilder.orderBy.mockReturnValue(queryBuilder)
+
+    repo = {
+      ...createMockRepository<Firmware>(),
+      queryBuilder,
+      createQueryBuilder: vi.fn().mockReturnValue(queryBuilder),
+    }
+
     configService = { get: vi.fn().mockReturnValue('http://api') }
-    service = new FirmwareService(repo as any, configService as any)
+    service = new FirmwareService(asRepository(repo), asService(configService))
   })
 
   describe('upload', () => {
     const file = { buffer: nodeBuffer.Buffer.from('binary-content'), originalname: 'og.bin', mimetype: 'application/octet-stream', size: 14 }
 
     it('computes and stores a correct checksum', async () => {
-      repo.create.mockImplementation(attrs => attrs)
-      repo.save.mockImplementation(async attrs => attrs)
-
       const result = await service.upload(file, { version: '1.0.0' })
 
       const expectedChecksum = crypto.createHash('sha256').update(file.buffer).digest('hex')
@@ -71,9 +70,6 @@ describe('firmwareService', () => {
     })
 
     it('defaults the label to the original filename and compatibleModels to empty', async () => {
-      repo.create.mockImplementation(attrs => attrs)
-      repo.save.mockImplementation(async attrs => attrs)
-
       const result = await service.upload(file, { version: '1.0.0' })
 
       expect(result.label).toBe('og.bin')
@@ -98,7 +94,7 @@ describe('firmwareService', () => {
 
   describe('delete', () => {
     it('deletes a custom firmware', async () => {
-      const firmware = { id: 'fw-1', kind: 'custom' }
+      const firmware = makeFirmware({ id: 'fw-1', kind: 'custom' })
       repo.findOneBy.mockResolvedValue(firmware)
 
       await service.delete('fw-1')
@@ -108,7 +104,7 @@ describe('firmwareService', () => {
     })
 
     it('refuses to delete an official-synced firmware', async () => {
-      repo.findOneBy.mockResolvedValue({ id: 'fw-1', kind: 'official-synced' })
+      repo.findOneBy.mockResolvedValue(makeFirmware({ id: 'fw-1', kind: 'official-synced' }))
       await expect(service.delete('fw-1')).rejects.toThrow(BadRequestException)
       expect(repo.remove).not.toHaveBeenCalled()
     })
@@ -121,14 +117,14 @@ describe('firmwareService', () => {
 
   describe('findAll / findById', () => {
     it('lists firmware ordered by most recent first, coalescing uploadedAt and syncedAt', async () => {
-      const rows = [{ id: 'fw-1' }]
+      const rows = [makeFirmware({ id: 'fw-1' })]
       repo.queryBuilder.getMany.mockResolvedValue(rows)
       await expect(service.findAll()).resolves.toBe(rows)
       expect(repo.queryBuilder.orderBy).toHaveBeenCalledWith('COALESCE(firmware.uploadedAt, firmware.syncedAt)', 'DESC')
     })
 
     it('finds a firmware by id', async () => {
-      const firmware = { id: 'fw-1' }
+      const firmware = makeFirmware({ id: 'fw-1' })
       repo.findOneBy.mockResolvedValue(firmware)
       await expect(service.findById('fw-1')).resolves.toBe(firmware)
     })
@@ -141,19 +137,19 @@ describe('firmwareService', () => {
       fileExistsMock.mockResolvedValue(true)
       fsMock.readFile.mockResolvedValue(fileBuffer)
 
-      await expect(service.verifyChecksum({ id: 'fw-1', checksum } as any)).resolves.toBe(true)
+      await expect(service.verifyChecksum(makeFirmware({ id: 'fw-1', checksum }))).resolves.toBe(true)
     })
 
     it('returns false when the on-disk checksum does not match', async () => {
       fileExistsMock.mockResolvedValue(true)
       fsMock.readFile.mockResolvedValue(nodeBuffer.Buffer.from('corrupted'))
 
-      await expect(service.verifyChecksum({ id: 'fw-1', checksum: 'deadbeef' } as any)).resolves.toBe(false)
+      await expect(service.verifyChecksum(makeFirmware({ id: 'fw-1', checksum: 'deadbeef' }))).resolves.toBe(false)
     })
 
     it('returns false when the binary is missing on disk', async () => {
       fileExistsMock.mockResolvedValue(false)
-      await expect(service.verifyChecksum({ id: 'fw-1', checksum: 'deadbeef' } as any)).resolves.toBe(false)
+      await expect(service.verifyChecksum(makeFirmware({ id: 'fw-1', checksum: 'deadbeef' }))).resolves.toBe(false)
       expect(fsMock.readFile).not.toHaveBeenCalled()
     })
   })

--- a/packages/api/src/logs/__test__/logs.controller.spec.ts
+++ b/packages/api/src/logs/__test__/logs.controller.spec.ts
@@ -1,7 +1,8 @@
 import type { CreateLogDto } from '../dto/create-log.dto'
-import type { LogEntry } from '../logs.entity'
 import type { LogsService } from '../logs.service'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { makeLogEntry } from '../../test/fixtures'
+import { asService } from '../../test/mockService'
 import { LogsController } from '../logs.controller'
 
 function createMockService() {
@@ -18,7 +19,7 @@ describe('logsController (unit)', () => {
 
   beforeEach(() => {
     service = createMockService()
-    controller = new LogsController(service as unknown as LogsService)
+    controller = new LogsController(asService<LogsService>(service))
   })
 
   it('consumeLog calls the service', async () => {
@@ -29,7 +30,7 @@ describe('logsController (unit)', () => {
   })
 
   it('getLogsByDevice returns logs for a device', async () => {
-    const logs = [{ } as LogEntry]
+    const logs = [makeLogEntry()]
     service.getByDevice.mockResolvedValue(logs)
     const result = await controller.getLogsByDevice('dev')
     expect(service.getByDevice).toHaveBeenCalledWith('dev')

--- a/packages/api/src/logs/__test__/logs.service.spec.ts
+++ b/packages/api/src/logs/__test__/logs.service.spec.ts
@@ -2,36 +2,24 @@ import type { Device } from '../../devices/devices.entity'
 import type { CreateLogDto } from '../dto/create-log.dto'
 import type { LogEntry } from '../logs.entity'
 
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { makeDevice, makeLogEntry } from '../../test/fixtures'
+import { asRepository, createMockRepository } from '../../test/mockRepository'
 import { LogsService } from '../logs.service'
-
-function createMockRepo() {
-  return {
-    find: vi.fn(),
-    findOne: vi.fn(),
-    findOneBy: vi.fn(),
-    create: vi.fn(),
-    save: vi.fn(),
-    update: vi.fn(),
-    remove: vi.fn(),
-    delete: vi.fn(),
-  }
-}
 
 describe('logsService', () => {
   let service: LogsService
-  let logsRepo: ReturnType<typeof createMockRepo>
-  let devicesRepo: ReturnType<typeof createMockRepo>
+  let logsRepo: ReturnType<typeof createMockRepository<LogEntry>>
+  let devicesRepo: ReturnType<typeof createMockRepository<Device>>
   const deviceMac = '2d:34:e2:27:5b:46'
 
   beforeEach(() => {
-    logsRepo = createMockRepo()
-    devicesRepo = createMockRepo()
+    logsRepo = createMockRepository<LogEntry>()
+    devicesRepo = createMockRepository<Device>()
     service = new LogsService(
-      logsRepo as any,
-      devicesRepo as any,
+      asRepository(logsRepo),
+      asRepository(devicesRepo),
     )
-    vi.resetAllMocks()
   })
 
   it('addLogToDevice throws if device is not found', async () => {
@@ -41,7 +29,7 @@ describe('logsService', () => {
 
   it('addLogToDevice is not saving duplicate log entries', async () => {
     const dto: CreateLogDto = { log: { logs_array: [{ log_id: 1 }, { log_id: 2 }] } }
-    const device = { id: 'dev', screens: [], width: 100, height: 100, logs: [{ logId: 1 }, { logId: 2 }] } as unknown as Device
+    const device = makeDevice({ id: 'dev', width: 100, height: 100, logs: [makeLogEntry({ logId: 1 }), makeLogEntry({ logId: 2 })] })
     devicesRepo.findOne.mockResolvedValue(device)
     await service.addLogToDevice(deviceMac, dto)
     expect(logsRepo.save).not.toHaveBeenCalled()
@@ -49,14 +37,14 @@ describe('logsService', () => {
 
   it('addLogToDevice saves new log entries', async () => {
     const dto: CreateLogDto = { log: { logs_array: [{ log_id: 1 }, { log_id: 2 }, { log_id: 3 }] } }
-    const device = { id: 'dev', screens: [], width: 100, height: 100, logs: [{ logId: 1 }, { logId: 2 }] } as unknown as Device
+    const device = makeDevice({ id: 'dev', width: 100, height: 100, logs: [makeLogEntry({ logId: 1 }), makeLogEntry({ logId: 2 })] })
     devicesRepo.findOne.mockResolvedValue(device)
     await service.addLogToDevice(deviceMac, dto)
     expect(logsRepo.save).toHaveBeenCalledOnce()
   })
 
   it('getByDevice returns logs for a device', async () => {
-    const logs = [{ logId: 1 } as LogEntry]
+    const logs = [makeLogEntry({ logId: 1 })]
     logsRepo.find.mockResolvedValue(logs)
     const result = await service.getByDevice('dev')
     expect(result).toBe(logs)

--- a/packages/api/src/maintenance/__test__/maintenance.controller.spec.ts
+++ b/packages/api/src/maintenance/__test__/maintenance.controller.spec.ts
@@ -1,19 +1,20 @@
 import type { CleanupResult, MaintenanceIssues, MaintenanceService } from '../maintenance.service'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { asService } from '../../test/mockService'
 import { MaintenanceController } from '../maintenance.controller'
 
 describe('maintenanceController', () => {
   let controller: MaintenanceController
-  let service: MaintenanceService
+  let service: { scan: ReturnType<typeof vi.fn>, cleanup: ReturnType<typeof vi.fn>, getStats: ReturnType<typeof vi.fn> }
 
   beforeEach(() => {
     service = {
       scan: vi.fn(),
       cleanup: vi.fn(),
       getStats: vi.fn(),
-    } as any
+    }
 
-    controller = new MaintenanceController(service)
+    controller = new MaintenanceController(asService<MaintenanceService>(service))
   })
 
   describe('scan', () => {

--- a/packages/api/src/maintenance/__test__/maintenance.service.spec.ts
+++ b/packages/api/src/maintenance/__test__/maintenance.service.spec.ts
@@ -2,36 +2,26 @@ import type { Device } from '../../devices/devices.entity'
 import type { Screen } from '../../screens/screens.entity'
 import * as fs from 'node:fs'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { makeDevice, makeScreen } from '../../test/fixtures'
+import { makeDirent, makeStats, mockReaddir, mockStat } from '../../test/fs'
+import { asRepository, createMockRepository } from '../../test/mockRepository'
 import { MaintenanceService } from '../maintenance.service'
 
 vi.mock('../../utils/pathHelper', () => ({
   resolveAppPath: vi.fn((...parts: string[]) => `/mock/${parts.join('/')}`),
 }))
 
-function createMockRepo() {
-  return {
-    find: vi.fn(),
-    findOne: vi.fn(),
-    findOneBy: vi.fn(),
-    create: vi.fn(),
-    save: vi.fn(),
-    update: vi.fn(),
-    remove: vi.fn(),
-    delete: vi.fn(),
-  }
-}
-
 describe('maintenanceService', () => {
   let service: MaintenanceService
-  let deviceRepo: ReturnType<typeof createMockRepo>
-  let screenRepo: ReturnType<typeof createMockRepo>
+  let deviceRepo: ReturnType<typeof createMockRepository<Device>>
+  let screenRepo: ReturnType<typeof createMockRepository<Screen>>
 
   beforeEach(() => {
-    deviceRepo = createMockRepo()
-    screenRepo = createMockRepo()
+    deviceRepo = createMockRepository<Device>()
+    screenRepo = createMockRepository<Screen>()
     service = new MaintenanceService(
-      deviceRepo as any,
-      screenRepo as any,
+      asRepository(deviceRepo),
+      asRepository(screenRepo),
     )
     vi.resetAllMocks()
   })
@@ -40,7 +30,9 @@ describe('maintenanceService', () => {
     it('returns empty issues when no devices exist', async () => {
       deviceRepo.find.mockResolvedValue([])
       screenRepo.find.mockResolvedValue([])
-      vi.spyOn(fs.promises, 'stat').mockRejectedValue(new Error('ENOENT'))
+      mockStat(async () => {
+        throw new Error('ENOENT')
+      })
 
       const result = await service.scan()
 
@@ -53,26 +45,26 @@ describe('maintenanceService', () => {
     })
 
     it('detects orphaned screen files', async () => {
-      const device = { id: 'device-1' } as Device
+      const device = makeDevice({ id: 'device-1' })
       deviceRepo.find.mockResolvedValue([device])
       screenRepo.find.mockResolvedValue([])
 
-      vi.spyOn(fs.promises, 'stat').mockImplementation(async (path: any) => {
+      mockStat(async (path) => {
         if (path === '/mock/public/screens/devices')
-          return { isDirectory: () => true } as any
+          return makeStats({ directory: true })
         if (path === '/mock/public/screens/devices/device-1')
-          return { isDirectory: () => true } as any
+          return makeStats({ directory: true })
         if (path === '/mock/public/screens/devices/device-1/orphaned-123.png')
-          return { isDirectory: () => false, size: 1024, mtimeMs: Date.now() } as any
+          return makeStats({ size: 1024, mtimeMs: Date.now() })
         throw new Error('ENOENT')
       })
 
-      vi.spyOn(fs.promises, 'readdir').mockImplementation(async (path: any) => {
+      mockReaddir(async (path) => {
         if (path === '/mock/public/screens/devices')
-          return ['device-1'] as any
+          return ['device-1']
         if (path === '/mock/public/screens/devices/device-1')
-          return ['orphaned-123.png'] as any
-        return [] as any
+          return ['orphaned-123.png']
+        return []
       })
 
       const result = await service.scan()
@@ -86,21 +78,21 @@ describe('maintenanceService', () => {
     })
 
     it('treats retained originals like screen images: orphaned without a screen, kept with one', async () => {
-      const device = { id: 'device-1' } as Device
+      const device = makeDevice({ id: 'device-1' })
       deviceRepo.find.mockResolvedValue([device])
-      screenRepo.find.mockResolvedValue([{ id: 'kept', type: 'file', device } as any])
+      screenRepo.find.mockResolvedValue([makeScreen({ id: 'kept', type: 'file', device })])
 
-      vi.spyOn(fs.promises, 'stat').mockImplementation(async (path: any) => {
+      mockStat(async (path) => {
         if (path === '/mock/public/screens/devices' || path === '/mock/public/screens/devices/device-1')
-          return { isDirectory: () => true } as any
-        return { isDirectory: () => false, size: 10, mtimeMs: Date.now() } as any
+          return makeStats({ directory: true })
+        return makeStats({ size: 10, mtimeMs: Date.now() })
       })
-      vi.spyOn(fs.promises, 'readdir').mockImplementation(async (path: any) => {
+      mockReaddir(async (path) => {
         if (path === '/mock/public/screens/devices')
-          return ['device-1'] as any
+          return ['device-1']
         if (path === '/mock/public/screens/devices/device-1')
-          return ['kept.png', 'kept.original', 'gone.original'] as any
-        return [] as any
+          return ['kept.png', 'kept.original', 'gone.original']
+        return []
       })
 
       const result = await service.scan()
@@ -113,22 +105,22 @@ describe('maintenanceService', () => {
       deviceRepo.find.mockResolvedValue([])
       screenRepo.find.mockResolvedValue([])
 
-      vi.spyOn(fs.promises, 'stat').mockImplementation(async (path: any) => {
+      mockStat(async (path) => {
         if (path === '/mock/public/screens/devices')
-          return { isDirectory: () => true } as any
+          return makeStats({ directory: true })
         if (path === '/mock/public/screens/devices/orphaned-device')
-          return { isDirectory: () => true } as any
+          return makeStats({ directory: true })
         if (path === '/mock/public/screens/devices/orphaned-device/screen.png')
-          return { isDirectory: () => false, size: 2048, mtimeMs: Date.now() } as any
+          return makeStats({ size: 2048, mtimeMs: Date.now() })
         throw new Error('ENOENT')
       })
 
-      vi.spyOn(fs.promises, 'readdir').mockImplementation(async (path: any, _options?: any) => {
+      mockReaddir(async (path) => {
         if (path === '/mock/public/screens/devices')
-          return ['orphaned-device'] as any
+          return ['orphaned-device']
         if (path === '/mock/public/screens/devices/orphaned-device')
-          return [{ name: 'screen.png', isDirectory: () => false }] as any
-        return [] as any
+          return [makeDirent('screen.png', false)]
+        return []
       })
 
       const result = await service.scan()
@@ -142,29 +134,29 @@ describe('maintenanceService', () => {
     })
 
     it('detects broken screens', async () => {
-      const device = { id: 'device-1' } as Device
-      const screen = {
+      const device = makeDevice({ id: 'device-1' })
+      const screen = makeScreen({
         id: 'screen-1',
         device,
         filename: 'missing.png',
         type: 'file',
-      } as Screen
+      })
 
       deviceRepo.find.mockResolvedValue([device])
       screenRepo.find.mockResolvedValue([screen])
 
-      vi.spyOn(fs.promises, 'stat').mockImplementation(async (path: any) => {
+      mockStat(async (path) => {
         if (path === '/mock/public/screens/devices')
-          return { isDirectory: () => true } as any
+          return makeStats({ directory: true })
         if (path === '/mock/public/screens/devices/device-1')
-          return { isDirectory: () => true } as any
+          return makeStats({ directory: true })
         throw new Error('ENOENT')
       })
 
-      vi.spyOn(fs.promises, 'readdir').mockImplementation(async (path: any) => {
+      mockReaddir(async (path) => {
         if (path === '/mock/public/screens/devices')
-          return ['device-1'] as any
-        return [] as any
+          return ['device-1']
+        return []
       })
 
       vi.spyOn(fs.promises, 'access').mockRejectedValue(new Error('ENOENT'))
@@ -181,28 +173,28 @@ describe('maintenanceService', () => {
     })
 
     it('detects temp files older than threshold', async () => {
-      const device = { id: 'device-1' } as Device
+      const device = makeDevice({ id: 'device-1' })
       deviceRepo.find.mockResolvedValue([device])
       screenRepo.find.mockResolvedValue([])
 
       const oldDate = Date.now() - (25 * 60 * 60 * 1000)
 
-      vi.spyOn(fs.promises, 'stat').mockImplementation(async (path: any) => {
+      mockStat(async (path) => {
         if (path === '/mock/public/screens/devices')
-          return { isDirectory: () => true } as any
+          return makeStats({ directory: true })
         if (path === '/mock/public/screens/devices/device-1')
-          return { isDirectory: () => true } as any
+          return makeStats({ directory: true })
         if (path === '/mock/public/screens/devices/device-1/tmp-source')
-          return { isDirectory: () => false, size: 512, mtimeMs: oldDate } as any
+          return makeStats({ size: 512, mtimeMs: oldDate })
         throw new Error('ENOENT')
       })
 
-      vi.spyOn(fs.promises, 'readdir').mockImplementation(async (path: any) => {
+      mockReaddir(async (path) => {
         if (path === '/mock/public/screens/devices')
-          return ['device-1'] as any
+          return ['device-1']
         if (path === '/mock/public/screens/devices/device-1')
-          return ['tmp-source'] as any
-        return [] as any
+          return ['tmp-source']
+        return []
       })
 
       const result = await service.scan()
@@ -216,26 +208,26 @@ describe('maintenanceService', () => {
     })
 
     it('ignores mirror.png files', async () => {
-      const device = { id: 'device-1' } as Device
+      const device = makeDevice({ id: 'device-1' })
       deviceRepo.find.mockResolvedValue([device])
       screenRepo.find.mockResolvedValue([])
 
-      vi.spyOn(fs.promises, 'stat').mockImplementation(async (path: any) => {
+      mockStat(async (path) => {
         if (path === '/mock/public/screens/devices')
-          return { isDirectory: () => true } as any
+          return makeStats({ directory: true })
         if (path === '/mock/public/screens/devices/device-1')
-          return { isDirectory: () => true } as any
+          return makeStats({ directory: true })
         if (path === '/mock/public/screens/devices/device-1/mirror.png')
-          return { isDirectory: () => false, size: 1024, mtimeMs: Date.now() } as any
+          return makeStats({ size: 1024, mtimeMs: Date.now() })
         throw new Error('ENOENT')
       })
 
-      vi.spyOn(fs.promises, 'readdir').mockImplementation(async (path: any) => {
+      mockReaddir(async (path) => {
         if (path === '/mock/public/screens/devices')
-          return ['device-1'] as any
+          return ['device-1']
         if (path === '/mock/public/screens/devices/device-1')
-          return ['mirror.png'] as any
-        return [] as any
+          return ['mirror.png']
+        return []
       })
 
       const result = await service.scan()
@@ -244,33 +236,33 @@ describe('maintenanceService', () => {
     })
 
     it('skips plugin and mashup screens when checking for broken screens', async () => {
-      const device = { id: 'device-1' } as Device
-      const pluginScreen = {
+      const device = makeDevice({ id: 'device-1' })
+      const pluginScreen = makeScreen({
         id: 'screen-1',
         device,
         type: 'plugin',
-      } as Screen
-      const mashupScreen = {
+      })
+      const mashupScreen = makeScreen({
         id: 'screen-2',
         device,
         type: 'mashup',
-      } as Screen
+      })
 
       deviceRepo.find.mockResolvedValue([device])
       screenRepo.find.mockResolvedValue([pluginScreen, mashupScreen])
 
-      vi.spyOn(fs.promises, 'stat').mockImplementation(async (path: any) => {
+      mockStat(async (path) => {
         if (path === '/mock/public/screens/devices')
-          return { isDirectory: () => true } as any
+          return makeStats({ directory: true })
         if (path === '/mock/public/screens/devices/device-1')
-          return { isDirectory: () => true } as any
+          return makeStats({ directory: true })
         throw new Error('ENOENT')
       })
 
-      vi.spyOn(fs.promises, 'readdir').mockImplementation(async (path: any) => {
+      mockReaddir(async (path) => {
         if (path === '/mock/public/screens/devices')
-          return ['device-1'] as any
-        return [] as any
+          return ['device-1']
+        return []
       })
 
       const result = await service.scan()
@@ -282,7 +274,7 @@ describe('maintenanceService', () => {
   describe('cleanup', () => {
     it('deletes orphaned files in non-dry-run mode', async () => {
       const unlinkMock = vi.spyOn(fs.promises, 'unlink').mockResolvedValue(undefined)
-      vi.spyOn(fs.promises, 'stat').mockResolvedValue({ size: 1024 } as any)
+      mockStat(async () => makeStats({ size: 1024 }))
 
       const result = await service.cleanup(
         ['/mock/public/screens/devices/device-1/orphaned.png'],
@@ -300,7 +292,7 @@ describe('maintenanceService', () => {
 
     it('does not delete files in dry-run mode', async () => {
       const unlinkMock = vi.spyOn(fs.promises, 'unlink').mockResolvedValue(undefined)
-      vi.spyOn(fs.promises, 'stat').mockResolvedValue({ size: 1024 } as any)
+      mockStat(async () => makeStats({ size: 1024 }))
 
       const result = await service.cleanup(
         ['/mock/public/screens/devices/device-1/orphaned.png'],
@@ -318,7 +310,7 @@ describe('maintenanceService', () => {
 
     it('protects system files from deletion', async () => {
       const unlinkMock = vi.spyOn(fs.promises, 'unlink').mockResolvedValue(undefined)
-      vi.spyOn(fs.promises, 'stat').mockResolvedValue({ size: 1024 } as any)
+      mockStat(async () => makeStats({ size: 1024 }))
 
       const result = await service.cleanup(
         ['/mock/public/screens/devices/noScreen.png'],
@@ -355,8 +347,8 @@ describe('maintenanceService', () => {
 
     it('deletes orphaned directories recursively', async () => {
       const rmMock = vi.spyOn(fs.promises, 'rm').mockResolvedValue(undefined)
-      vi.spyOn(fs.promises, 'readdir').mockResolvedValue([{ name: 'file.png', isDirectory: () => false }] as any)
-      vi.spyOn(fs.promises, 'stat').mockResolvedValue({ size: 2048 } as any)
+      mockReaddir(async () => [makeDirent('file.png', false)])
+      mockStat(async () => makeStats({ size: 2048 }))
 
       const result = await service.cleanup(
         [],
@@ -389,7 +381,7 @@ describe('maintenanceService', () => {
 
     it('handles deletion errors gracefully', async () => {
       vi.spyOn(fs.promises, 'unlink').mockRejectedValue(new Error('Permission denied'))
-      vi.spyOn(fs.promises, 'stat').mockResolvedValue({ size: 1024 } as any)
+      mockStat(async () => makeStats({ size: 1024 }))
 
       const result = await service.cleanup(
         ['/mock/public/screens/devices/device-1/orphaned.png'],
@@ -408,25 +400,22 @@ describe('maintenanceService', () => {
 
   describe('getStats', () => {
     it('returns stats for devices directory', async () => {
-      vi.spyOn(fs.promises, 'stat').mockImplementation(async (path: any) => {
+      mockStat(async (path) => {
         if (path === '/mock/public/screens/devices')
-          return { isDirectory: () => true } as any
-        return { isDirectory: () => false, size: 1024 } as any
+          return makeStats({ directory: true })
+        return makeStats({ size: 1024 })
       })
 
-      vi.spyOn(fs.promises, 'readdir').mockImplementation(async (path: any, _options?: any) => {
-        if (path === '/mock/public/screens/devices') {
-          return [
-            { name: 'device-1', isDirectory: () => true },
-          ] as any
-        }
+      mockReaddir(async (path) => {
+        if (path === '/mock/public/screens/devices')
+          return [makeDirent('device-1', true)]
         if (path === '/mock/public/screens/devices/device-1') {
           return [
-            { name: 'screen-1.png', isDirectory: () => false },
-            { name: 'screen-2.png', isDirectory: () => false },
-          ] as any
+            makeDirent('screen-1.png', false),
+            makeDirent('screen-2.png', false),
+          ]
         }
-        return [] as any
+        return []
       })
 
       const result = await service.getStats()
@@ -436,7 +425,9 @@ describe('maintenanceService', () => {
     })
 
     it('returns zero stats when directory does not exist', async () => {
-      vi.spyOn(fs.promises, 'stat').mockRejectedValue(new Error('ENOENT'))
+      mockStat(async () => {
+        throw new Error('ENOENT')
+      })
 
       const result = await service.getStats()
 

--- a/packages/api/src/mashup/__test__/mashup-configuration.entity.spec.ts
+++ b/packages/api/src/mashup/__test__/mashup-configuration.entity.spec.ts
@@ -1,5 +1,5 @@
-import type { Screen } from '../../screens/screens.entity'
 import { describe, expect, it } from 'vitest'
+import { makeScreen } from '../../test/fixtures'
 import { MashupConfiguration } from '../entities/mashup-configuration.entity'
 import { MashupSlot } from '../entities/mashup-slot.entity'
 
@@ -25,7 +25,7 @@ describe('mashupConfiguration entity', () => {
 
   it('should have screen relationship', () => {
     const config = new MashupConfiguration()
-    const mockScreen = { id: 'screen-1' } as Screen
+    const mockScreen = makeScreen({ id: 'screen-1' })
 
     config.screen = mockScreen
 

--- a/packages/api/src/mashup/__test__/mashup-renderer.service.spec.ts
+++ b/packages/api/src/mashup/__test__/mashup-renderer.service.spec.ts
@@ -1,56 +1,45 @@
 import type { ConfigService } from '@nestjs/config'
 import type { MockDeviceSensorsService } from '../../device-sensors/__test__/mockDeviceSensorsService'
-import type { Device } from '../../devices/devices.entity'
-import type { Plugin } from '../../plugins/entities/plugin.entity'
+import type { DeviceSensorsService } from '../../device-sensors/device-sensors.service'
 import type { PluginDataFetcherService } from '../../plugins/services/plugin-data-fetcher.service'
 import type { PluginRendererService } from '../../plugins/services/plugin-renderer.service'
 import type { PluginTransformService } from '../../plugins/services/plugin-transform.service'
+import type { MockPluginDataFetcherService, MockPluginRendererService, MockPluginTransformService } from '../../test/mockPluginCollaborators'
 import type { MashupConfiguration } from '../entities/mashup-configuration.entity'
-import type { MashupSlot } from '../entities/mashup-slot.entity'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createMockDeviceSensorsService, primeMockDeviceSensorsService } from '../../device-sensors/__test__/mockDeviceSensorsService'
 import { PluginTemplateContextService } from '../../plugins/services/plugin-template-context.service'
+import { makeDevice, makeMashupConfiguration, makeMashupSlot, makePlugin, makePluginDataSource, makePluginTemplate } from '../../test/fixtures'
+import { createMockPluginDataFetcherService, createMockPluginRendererService, createMockPluginTransformService } from '../../test/mockPluginCollaborators'
+import { asService } from '../../test/mockService'
 import { MashupRendererService } from '../services/mashup-renderer.service'
 
 describe('mashupRendererService', () => {
   let service: MashupRendererService
-  let pluginDataFetcher: PluginDataFetcherService
-  let pluginRenderer: PluginRendererService
-  let pluginTransformer: PluginTransformService
-  let configService: ConfigService
+  let pluginDataFetcher: MockPluginDataFetcherService
+  let pluginRenderer: MockPluginRendererService
+  let pluginTransformer: MockPluginTransformService
+  let configService: { get: ReturnType<typeof vi.fn> }
   let deviceSensors: MockDeviceSensorsService
 
   beforeEach(() => {
-    pluginDataFetcher = {
-      fetchData: vi.fn(),
-      fetchOrLiteral: vi.fn((source: any, ctx: any) =>
-        source.mode === 'literal'
-          ? Promise.resolve(source.literalValue ?? null)
-          : pluginDataFetcher.fetchData(source.method, source.url ?? '', source.headers, source.body, ctx),
-      ),
-    } as any
-
-    pluginRenderer = {
-      render: vi.fn(),
-    } as any
-
-    pluginTransformer = {
-      transform: vi.fn(),
-    } as any
+    pluginDataFetcher = createMockPluginDataFetcherService()
+    pluginRenderer = createMockPluginRendererService()
+    pluginTransformer = createMockPluginTransformService()
 
     configService = {
       get: vi.fn().mockReturnValue('http://api'),
-    } as any
+    }
 
     deviceSensors = createMockDeviceSensorsService()
     primeMockDeviceSensorsService(deviceSensors)
 
     service = new MashupRendererService(
-      pluginDataFetcher,
-      pluginRenderer,
-      pluginTransformer,
-      configService,
-      deviceSensors as any,
+      asService<PluginDataFetcherService>(pluginDataFetcher),
+      asService<PluginRendererService>(pluginRenderer),
+      asService<PluginTransformService>(pluginTransformer),
+      asService<ConfigService>(configService),
+      asService<DeviceSensorsService>(deviceSensors),
       new PluginTemplateContextService(),
     )
 
@@ -59,40 +48,38 @@ describe('mashupRendererService', () => {
   })
 
   it('should render mashup with all plugins successful', async () => {
-    const device = { id: 'device-1', width: 800, height: 480 } as Device
+    const device = makeDevice({ id: 'device-1', width: 800, height: 480 })
 
-    const slots: MashupSlot[] = [
-      {
-        id: 'slot-1',
-        position: 'top-left',
-        size: 'view--quadrant',
-        order: 0,
-        plugin: {
-          id: 'plugin-1',
-          name: 'Weather',
-          dataSources: [{ name: 'source', method: 'GET', url: 'http://api/weather' }],
-          templates: [{ layout: 'full', liquidMarkup: '<div>Weather: {{temp}}</div>' }],
-        } as Plugin,
-      } as MashupSlot,
-      {
-        id: 'slot-2',
-        position: 'top-right',
-        size: 'view--quadrant',
-        order: 1,
-        plugin: {
-          id: 'plugin-2',
-          name: 'Calendar',
-          dataSources: [{ name: 'source', method: 'GET', url: 'http://api/calendar' }],
-          templates: [{ layout: 'full', liquidMarkup: '<div>Events: {{count}}</div>' }],
-        } as Plugin,
-      } as MashupSlot,
-    ]
-
-    const config: MashupConfiguration = {
+    const config: MashupConfiguration = makeMashupConfiguration({
       id: 'config-1',
       layout: '1Lx1R',
-      slots,
-    } as MashupConfiguration
+      slots: [
+        makeMashupSlot({
+          id: 'slot-1',
+          position: 'top-left',
+          size: 'view--quadrant',
+          order: 0,
+          plugin: makePlugin({
+            id: 'plugin-1',
+            name: 'Weather',
+            dataSources: [makePluginDataSource({ name: 'source', method: 'GET', url: 'http://api/weather' })],
+            templates: [makePluginTemplate({ layout: 'full', liquidMarkup: '<div>Weather: {{temp}}</div>' })],
+          }),
+        }),
+        makeMashupSlot({
+          id: 'slot-2',
+          position: 'top-right',
+          size: 'view--quadrant',
+          order: 1,
+          plugin: makePlugin({
+            id: 'plugin-2',
+            name: 'Calendar',
+            dataSources: [makePluginDataSource({ name: 'source', method: 'GET', url: 'http://api/calendar' })],
+            templates: [makePluginTemplate({ layout: 'full', liquidMarkup: '<div>Events: {{count}}</div>' })],
+          }),
+        }),
+      ],
+    })
 
     pluginDataFetcher.fetchData = vi.fn().mockResolvedValue({ temp: '72F', count: 5 })
     pluginRenderer.render = vi.fn()
@@ -110,40 +97,38 @@ describe('mashupRendererService', () => {
   })
 
   it('gives a failing data source an error marker instead of aborting its slot render (ADR-0005)', async () => {
-    const device = { id: 'device-1', width: 800, height: 480 } as Device
+    const device = makeDevice({ id: 'device-1', width: 800, height: 480 })
 
-    const slots: MashupSlot[] = [
-      {
-        id: 'slot-1',
-        position: 'left',
-        size: 'view--half_vertical',
-        order: 0,
-        plugin: {
-          id: 'plugin-1',
-          name: 'Working Plugin',
-          dataSources: [{ name: 'source', method: 'GET', url: 'http://api/working' }],
-          templates: [{ layout: 'full', liquidMarkup: '<div>Success</div>' }],
-        } as Plugin,
-      } as MashupSlot,
-      {
-        id: 'slot-2',
-        position: 'right',
-        size: 'view--half_vertical',
-        order: 1,
-        plugin: {
-          id: 'plugin-2',
-          name: 'Failing Plugin',
-          dataSources: [{ name: 'source', method: 'GET', url: 'http://api/failing' }],
-          templates: [{ layout: 'full', liquidMarkup: '<div>{{ source.error }}</div>' }],
-        } as Plugin,
-      } as MashupSlot,
-    ]
-
-    const config: MashupConfiguration = {
+    const config: MashupConfiguration = makeMashupConfiguration({
       id: 'config-1',
       layout: '1Lx1R',
-      slots,
-    } as MashupConfiguration
+      slots: [
+        makeMashupSlot({
+          id: 'slot-1',
+          position: 'left',
+          size: 'view--half_vertical',
+          order: 0,
+          plugin: makePlugin({
+            id: 'plugin-1',
+            name: 'Working Plugin',
+            dataSources: [makePluginDataSource({ name: 'source', method: 'GET', url: 'http://api/working' })],
+            templates: [makePluginTemplate({ layout: 'full', liquidMarkup: '<div>Success</div>' })],
+          }),
+        }),
+        makeMashupSlot({
+          id: 'slot-2',
+          position: 'right',
+          size: 'view--half_vertical',
+          order: 1,
+          plugin: makePlugin({
+            id: 'plugin-2',
+            name: 'Failing Plugin',
+            dataSources: [makePluginDataSource({ name: 'source', method: 'GET', url: 'http://api/failing' })],
+            templates: [makePluginTemplate({ layout: 'full', liquidMarkup: '<div>{{ source.error }}</div>' })],
+          }),
+        }),
+      ],
+    })
 
     pluginDataFetcher.fetchData = vi.fn()
       .mockResolvedValueOnce({ data: 'success' })
@@ -164,28 +149,26 @@ describe('mashupRendererService', () => {
   })
 
   it('falls back to the error placeholder when a slot has no data sources at all', async () => {
-    const device = { id: 'device-1', width: 800, height: 480 } as Device
+    const device = makeDevice({ id: 'device-1', width: 800, height: 480 })
 
-    const slots: MashupSlot[] = [
-      {
-        id: 'slot-1',
-        position: 'left',
-        size: 'view--half_vertical',
-        order: 0,
-        plugin: {
-          id: 'plugin-1',
-          name: 'Draft Plugin',
-          dataSources: [],
-          templates: [{ layout: 'full', liquidMarkup: '<div>Never rendered</div>' }],
-        } as unknown as Plugin,
-      } as MashupSlot,
-    ]
-
-    const config: MashupConfiguration = {
+    const config: MashupConfiguration = makeMashupConfiguration({
       id: 'config-1',
       layout: '1Lx1R',
-      slots,
-    } as MashupConfiguration
+      slots: [
+        makeMashupSlot({
+          id: 'slot-1',
+          position: 'left',
+          size: 'view--half_vertical',
+          order: 0,
+          plugin: makePlugin({
+            id: 'plugin-1',
+            name: 'Draft Plugin',
+            dataSources: [],
+            templates: [makePluginTemplate({ layout: 'full', liquidMarkup: '<div>Never rendered</div>' })],
+          }),
+        }),
+      ],
+    })
 
     const result = await service.renderMashup(config, device)
 
@@ -194,25 +177,25 @@ describe('mashupRendererService', () => {
   })
 
   it('should build correct HTML structure for 2x2 layout', async () => {
-    const device = { id: 'device-1', width: 800, height: 480 } as Device
+    const device = makeDevice({ id: 'device-1', width: 800, height: 480 })
 
-    const slots: MashupSlot[] = [
-      { position: 'top-left', size: 'view--quadrant', order: 0, plugin: { name: 'P1' } } as MashupSlot,
-      { position: 'top-right', size: 'view--quadrant', order: 1, plugin: { name: 'P2' } } as MashupSlot,
-      { position: 'bottom-left', size: 'view--quadrant', order: 2, plugin: { name: 'P3' } } as MashupSlot,
-      { position: 'bottom-right', size: 'view--quadrant', order: 3, plugin: { name: 'P4' } } as MashupSlot,
+    const slots = [
+      makeMashupSlot({ position: 'top-left', size: 'view--quadrant', order: 0, plugin: makePlugin({ name: 'P1' }) }),
+      makeMashupSlot({ position: 'top-right', size: 'view--quadrant', order: 1, plugin: makePlugin({ name: 'P2' }) }),
+      makeMashupSlot({ position: 'bottom-left', size: 'view--quadrant', order: 2, plugin: makePlugin({ name: 'P3' }) }),
+      makeMashupSlot({ position: 'bottom-right', size: 'view--quadrant', order: 3, plugin: makePlugin({ name: 'P4' }) }),
     ]
 
     for (const slot of slots) {
-      (slot.plugin as any).dataSources = [{ name: 'source', method: 'GET', url: 'http://api' }];
-      (slot.plugin as any).templates = [{ layout: 'full', liquidMarkup: '<div>Test</div>' }]
+      slot.plugin.dataSources = [makePluginDataSource({ name: 'source', method: 'GET', url: 'http://api' })]
+      slot.plugin.templates = [makePluginTemplate({ layout: 'full', liquidMarkup: '<div>Test</div>' })]
     }
 
-    const config: MashupConfiguration = {
+    const config: MashupConfiguration = makeMashupConfiguration({
       id: 'config-1',
       layout: '2x2',
       slots,
-    } as MashupConfiguration
+    })
 
     pluginDataFetcher.fetchData = vi.fn().mockResolvedValue({})
     pluginRenderer.render = vi.fn().mockResolvedValue('<div>Test</div>')
@@ -225,25 +208,23 @@ describe('mashupRendererService', () => {
   })
 
   it('returns device-independent body markup without a document shell', async () => {
-    const device = { id: 'device-1', width: 800, height: 480 } as Device
+    const device = makeDevice({ id: 'device-1', width: 800, height: 480 })
 
-    const slots: MashupSlot[] = [
-      {
-        position: 'top',
-        size: 'view--half_horizontal',
-        order: 0,
-        plugin: {
-          name: 'Test',
-          dataSources: [{ name: 'source', method: 'GET', url: 'http://api' }],
-          templates: [{ layout: 'full', liquidMarkup: '<div>Test</div>' }],
-        } as Plugin,
-      } as MashupSlot,
-    ]
-
-    const config: MashupConfiguration = {
+    const config: MashupConfiguration = makeMashupConfiguration({
       layout: '1Tx1B',
-      slots,
-    } as any
+      slots: [
+        makeMashupSlot({
+          position: 'top',
+          size: 'view--half_horizontal',
+          order: 0,
+          plugin: makePlugin({
+            name: 'Test',
+            dataSources: [makePluginDataSource({ name: 'source', method: 'GET', url: 'http://api' })],
+            templates: [makePluginTemplate({ layout: 'full', liquidMarkup: '<div>Test</div>' })],
+          }),
+        }),
+      ],
+    })
 
     pluginDataFetcher.fetchData = vi.fn().mockResolvedValue({})
     pluginRenderer.render = vi.fn().mockResolvedValue('<div>Test</div>')

--- a/packages/api/src/mashup/__test__/mashup-slot.entity.spec.ts
+++ b/packages/api/src/mashup/__test__/mashup-slot.entity.spec.ts
@@ -1,5 +1,5 @@
-import type { Plugin } from '../../plugins/entities/plugin.entity'
 import { describe, expect, it } from 'vitest'
+import { makePlugin } from '../../test/fixtures'
 import { MashupConfiguration } from '../entities/mashup-configuration.entity'
 import { MashupSlot } from '../entities/mashup-slot.entity'
 
@@ -29,7 +29,7 @@ describe('mashupSlot entity', () => {
 
   it('should have plugin relationship', () => {
     const slot = new MashupSlot()
-    const mockPlugin = { id: 'plugin-1', name: 'Weather' } as Plugin
+    const mockPlugin = makePlugin({ id: 'plugin-1', name: 'Weather' })
 
     slot.plugin = mockPlugin
 

--- a/packages/api/src/mashup/__test__/mashup.controller.spec.ts
+++ b/packages/api/src/mashup/__test__/mashup.controller.spec.ts
@@ -3,11 +3,12 @@ import type { UpdateMashupDto } from '../dto/update-mashup.dto'
 import type { MashupService } from '../mashup.service'
 import { BadRequestException, NotFoundException } from '@nestjs/common'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { asService } from '../../test/mockService'
 import { MashupController } from '../mashup.controller'
 
 describe('mashupController', () => {
   let controller: MashupController
-  let mockService: MashupService
+  let mockService: { create: ReturnType<typeof vi.fn>, update: ReturnType<typeof vi.fn>, delete: ReturnType<typeof vi.fn>, getConfiguration: ReturnType<typeof vi.fn>, getLayouts: ReturnType<typeof vi.fn> }
 
   beforeEach(() => {
     mockService = {
@@ -16,9 +17,9 @@ describe('mashupController', () => {
       delete: vi.fn(),
       getConfiguration: vi.fn(),
       getLayouts: vi.fn(),
-    } as any
+    }
 
-    controller = new MashupController(mockService)
+    controller = new MashupController(asService<MashupService>(mockService))
   })
 
   describe('create', () => {

--- a/packages/api/src/mashup/__test__/mashup.integration.spec.ts
+++ b/packages/api/src/mashup/__test__/mashup.integration.spec.ts
@@ -1,16 +1,19 @@
 import type { TestingModule } from '@nestjs/testing'
-import type { Repository } from 'typeorm'
 import type { PluginTemplate } from '../../plugins/entities/plugin-template.entity'
+import type { Plugin } from '../../plugins/entities/plugin.entity'
+import type { Screen } from '../../screens/screens.entity'
 import { ConfigService } from '@nestjs/config'
 import { Test } from '@nestjs/testing'
 import { getRepositoryToken } from '@nestjs/typeorm'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { Device } from '../../devices/devices.entity'
-import { Plugin } from '../../plugins/entities/plugin.entity'
+import { Plugin as PluginEntity } from '../../plugins/entities/plugin.entity'
 import { PluginDataFetcherService } from '../../plugins/services/plugin-data-fetcher.service'
 import { PluginRendererService } from '../../plugins/services/plugin-renderer.service'
 import { PluginTransformService } from '../../plugins/services/plugin-transform.service'
-import { Screen } from '../../screens/screens.entity'
+import { Screen as ScreenEntity } from '../../screens/screens.entity'
+import { makeDevice, makeMashupConfiguration, makeMashupSlot, makePlugin, makePluginTemplate, makeScreen } from '../../test/fixtures'
+import { createMockRepository, whereId } from '../../test/mockRepository'
 import { MashupConfiguration } from '../entities/mashup-configuration.entity'
 import { MashupSlot } from '../entities/mashup-slot.entity'
 import { MashupService } from '../mashup.service'
@@ -18,119 +21,77 @@ import { MashupRendererService } from '../services/mashup-renderer.service'
 
 describe('mashup Integration Tests', () => {
   let mashupService: MashupService
-  let deviceRepo: Repository<Device>
-  let screenRepo: Repository<Screen>
-  let pluginRepo: Repository<Plugin>
-  let mashupConfigRepo: Repository<MashupConfiguration>
-  let mashupSlotRepo: Repository<MashupSlot>
+  let deviceRepo: ReturnType<typeof createMockRepository<Device>>
+  let screenRepo: ReturnType<typeof createMockRepository<Screen>>
+  let pluginRepo: ReturnType<typeof createMockRepository<Plugin>>
+  let mashupConfigRepo: ReturnType<typeof createMockRepository<MashupConfiguration>>
+  let mashupSlotRepo: ReturnType<typeof createMockRepository<MashupSlot>>
 
   beforeEach(async () => {
-    const mockDevice = {
-      id: 'device-1',
-      name: 'Test Device',
-      width: 800,
-      height: 480,
-    }
+    const mockDevice = makeDevice({ id: 'device-1', name: 'Test Device', width: 800, height: 480 })
 
-    const mockPlugins = [
+    const mockPlugins: Array<Plugin & { template: PluginTemplate }> = [
       {
-        id: 'plugin-1',
-        name: 'Weather Plugin',
-        template: {
-          html: '<div class="plugin-weather">{{weather}}</div>',
-        } as unknown as PluginTemplate,
+        ...makePlugin({ id: 'plugin-1', name: 'Weather Plugin' }),
+        template: makePluginTemplate({ liquidMarkup: '<div class="plugin-weather">{{weather}}</div>' }),
       },
       {
-        id: 'plugin-2',
-        name: 'Calendar Plugin',
-        template: {
-          html: '<div class="plugin-calendar">{{events}}</div>',
-        } as unknown as PluginTemplate,
+        ...makePlugin({ id: 'plugin-2', name: 'Calendar Plugin' }),
+        template: makePluginTemplate({ liquidMarkup: '<div class="plugin-calendar">{{events}}</div>' }),
       },
     ]
 
-    deviceRepo = {
-      findOne: vi.fn().mockResolvedValue(mockDevice),
-    } as any
+    deviceRepo = createMockRepository<Device>()
+    deviceRepo.findOne.mockResolvedValue(mockDevice)
 
-    pluginRepo = {
-      findOne: vi.fn((opts) => {
-        const id = opts.where.id
-        return Promise.resolve(mockPlugins.find(p => p.id === id) || null)
-      }),
-      find: vi.fn().mockResolvedValue(mockPlugins),
-    } as any
+    pluginRepo = createMockRepository<Plugin>()
+    pluginRepo.findOne.mockImplementation(async options =>
+      mockPlugins.find(p => p.id === whereId(options)) ?? null)
+    pluginRepo.find.mockResolvedValue(mockPlugins)
 
-    screenRepo = {
-      create: vi.fn((data) => {
-        return { ...data, id: 'screen-1', isActive: false }
-      }),
-      save: vi.fn((screen) => {
-        return Promise.resolve(screen)
-      }),
-      update: vi.fn().mockResolvedValue(undefined),
-      findOne: vi.fn((opts) => {
-        if (opts.where.id === 'screen-1') {
-          return Promise.resolve({
-            id: 'screen-1',
-            type: 'mashup',
-            filename: 'Test Mashup',
-            device: mockDevice,
-            mashupConfiguration: {
-              id: 'config-1',
-              layout: '1Lx1R',
-              slots: [
-                {
-                  id: 'slot-1',
-                  position: 'L',
-                  size: '50',
-                  order: 0,
-                  plugin: mockPlugins[0],
-                },
-                {
-                  id: 'slot-2',
-                  position: 'R',
-                  size: '50',
-                  order: 1,
-                  plugin: mockPlugins[1],
-                },
-              ],
-            },
-          })
-        }
-        return Promise.resolve(null)
-      }),
-    } as any
+    screenRepo = createMockRepository<Screen>()
+    screenRepo.create.mockImplementation(data => makeScreen({ ...(data as Partial<Screen>), id: 'screen-1', isActive: false }))
+    screenRepo.save.mockImplementation(async screen => screen)
+    screenRepo.update.mockResolvedValue({ raw: [], generatedMaps: [] })
+    screenRepo.findOne.mockImplementation(async (options) => {
+      if (whereId(options) === 'screen-1') {
+        return makeScreen({
+          id: 'screen-1',
+          type: 'mashup',
+          filename: 'Test Mashup',
+          device: mockDevice,
+          mashupConfiguration: makeMashupConfiguration({
+            id: 'config-1',
+            layout: '1Lx1R',
+            slots: [
+              makeMashupSlot({ id: 'slot-1', position: 'L', size: '50', order: 0, plugin: mockPlugins[0] }),
+              makeMashupSlot({ id: 'slot-2', position: 'R', size: '50', order: 1, plugin: mockPlugins[1] }),
+            ],
+          }),
+        })
+      }
+      return null
+    })
 
-    mashupConfigRepo = {
-      create: vi.fn((data) => {
-        return { ...data, id: 'config-1' }
-      }),
-      save: vi.fn((config) => {
-        return Promise.resolve(config)
-      }),
-      findOne: vi.fn().mockResolvedValue(null),
-    } as any
+    mashupConfigRepo = createMockRepository<MashupConfiguration>()
+    mashupConfigRepo.create.mockImplementation(data => makeMashupConfiguration({ ...(data as Partial<MashupConfiguration>), id: 'config-1' }))
+    mashupConfigRepo.save.mockImplementation(async config => config)
+    mashupConfigRepo.findOne.mockResolvedValue(null)
 
-    mashupSlotRepo = {
-      create: vi.fn((data) => {
-        return { ...data, id: `slot-${Math.random()}` }
-      }),
-      save: vi.fn((slot) => {
-        return Promise.resolve(slot)
-      }),
-      find: vi.fn().mockResolvedValue([]),
-      remove: vi.fn().mockResolvedValue(undefined),
-    } as any
+    mashupSlotRepo = createMockRepository<MashupSlot>()
+    mashupSlotRepo.create.mockImplementation(data => makeMashupSlot({ ...(data as Partial<MashupSlot>), id: `slot-${Math.random()}` }))
+    mashupSlotRepo.save.mockImplementation(async slot => slot)
+    mashupSlotRepo.find.mockResolvedValue([])
+    mashupSlotRepo.remove.mockResolvedValue([])
 
     const mockPluginRenderer = {
-      render: vi.fn((plugin) => {
-        if (plugin.id === 'plugin-1') {
+      render: vi.fn((plugin: Plugin) => {
+        if (plugin.id === 'plugin-1')
           return Promise.resolve('<div class="plugin-weather">Sunny 72°F</div>')
-        }
-        if (plugin.id === 'plugin-2') {
+
+        if (plugin.id === 'plugin-2')
           return Promise.resolve('<div class="plugin-calendar">Meeting at 2pm</div>')
-        }
+
         return Promise.resolve('<div>Unknown</div>')
       }),
     }
@@ -151,11 +112,11 @@ describe('mashup Integration Tests', () => {
           useValue: deviceRepo,
         },
         {
-          provide: getRepositoryToken(Screen),
+          provide: getRepositoryToken(ScreenEntity),
           useValue: screenRepo,
         },
         {
-          provide: getRepositoryToken(Plugin),
+          provide: getRepositoryToken(PluginEntity),
           useValue: pluginRepo,
         },
         {
@@ -201,13 +162,13 @@ describe('mashup Integration Tests', () => {
 
   it.skip('should render mashup HTML with plugin content', async () => {
     const mockPluginRenderer = {
-      render: vi.fn((plugin) => {
-        if (plugin.id === 'plugin-1') {
+      render: vi.fn((plugin: Plugin) => {
+        if (plugin.id === 'plugin-1')
           return Promise.resolve('<div class="plugin-weather">Sunny 72°F</div>')
-        }
-        if (plugin.id === 'plugin-2') {
+
+        if (plugin.id === 'plugin-2')
           return Promise.resolve('<div class="plugin-calendar">Meeting at 2pm</div>')
-        }
+
         return Promise.resolve('<div>Unknown</div>')
       }),
     }
@@ -242,43 +203,36 @@ describe('mashup Integration Tests', () => {
 
     const renderer = module.get<MashupRendererService>(MashupRendererService)
 
-    const mockMashupConfig = {
+    const mockMashupConfig = makeMashupConfiguration({
       id: 'config-1',
       layout: '1Lx1R',
       slots: [
-        {
+        makeMashupSlot({
           id: 'slot-1',
           position: 'L',
           size: '50',
           order: 0,
-          plugin: {
+          plugin: makePlugin({
             id: 'plugin-1',
             name: 'Weather Plugin',
-            dataSource: { type: 'static', config: {} },
-            templates: [{ html: '<div>test</div>' }],
-          } as unknown as Plugin,
-        },
-        {
+            templates: [makePluginTemplate({ liquidMarkup: '<div>test</div>' })],
+          }),
+        }),
+        makeMashupSlot({
           id: 'slot-2',
           position: 'R',
           size: '50',
           order: 1,
-          plugin: {
+          plugin: makePlugin({
             id: 'plugin-2',
             name: 'Calendar Plugin',
-            dataSource: { type: 'static', config: {} },
-            templates: [{ html: '<div>test</div>' }],
-          } as unknown as Plugin,
-        },
+            templates: [makePluginTemplate({ liquidMarkup: '<div>test</div>' })],
+          }),
+        }),
       ],
-    } as MashupConfiguration
+    })
 
-    const mockDevice = {
-      id: 'device-1',
-      name: 'Test Device',
-      width: 800,
-      height: 480,
-    } as Device
+    const mockDevice = makeDevice({ id: 'device-1', name: 'Test Device', width: 800, height: 480 })
 
     const html = await renderer.renderMashup(mockMashupConfig, mockDevice)
 
@@ -292,10 +246,10 @@ describe('mashup Integration Tests', () => {
 
   it.skip('should handle plugin rendering errors gracefully in mashup', async () => {
     const mockPluginRenderer = {
-      render: vi.fn((plugin) => {
-        if (plugin.id === 'plugin-1') {
+      render: vi.fn((plugin: Plugin) => {
+        if (plugin.id === 'plugin-1')
           return Promise.reject(new Error('Plugin render failed'))
-        }
+
         return Promise.resolve('<div class="plugin-calendar">Meeting at 2pm</div>')
       }),
     }
@@ -330,38 +284,16 @@ describe('mashup Integration Tests', () => {
 
     const renderer = module.get<MashupRendererService>(MashupRendererService)
 
-    const mockMashupConfig = {
+    const mockMashupConfig = makeMashupConfiguration({
       id: 'config-1',
       layout: '1Lx1R',
       slots: [
-        {
-          id: 'slot-1',
-          position: 'L',
-          size: '50',
-          order: 0,
-          plugin: {
-            id: 'plugin-1',
-            name: 'Weather Plugin',
-          } as Plugin,
-        },
-        {
-          id: 'slot-2',
-          position: 'R',
-          size: '50',
-          order: 1,
-          plugin: {
-            id: 'plugin-2',
-            name: 'Calendar Plugin',
-          } as Plugin,
-        },
+        makeMashupSlot({ id: 'slot-1', position: 'L', size: '50', order: 0, plugin: makePlugin({ id: 'plugin-1', name: 'Weather Plugin' }) }),
+        makeMashupSlot({ id: 'slot-2', position: 'R', size: '50', order: 1, plugin: makePlugin({ id: 'plugin-2', name: 'Calendar Plugin' }) }),
       ],
-    } as MashupConfiguration
+    })
 
-    const mockDevice = {
-      id: 'device-1',
-      width: 800,
-      height: 480,
-    } as Device
+    const mockDevice = makeDevice({ id: 'device-1', width: 800, height: 480 })
 
     const html = await renderer.renderMashup(mockMashupConfig, mockDevice)
 
@@ -371,22 +303,22 @@ describe('mashup Integration Tests', () => {
   })
 
   it('should update an existing mashup and clear old slots', async () => {
-    const existingScreen = {
+    const existingScreen = makeScreen({
       id: 'screen-1',
-      type: 'mashup' as const,
+      type: 'mashup',
       filename: 'Old Mashup',
-      device: { id: 'device-1' },
-      mashupConfiguration: {
+      device: makeDevice({ id: 'device-1' }),
+      mashupConfiguration: makeMashupConfiguration({
         id: 'config-1',
         slots: [
-          { id: 'old-slot-1', plugin: { id: 'plugin-1' } },
-          { id: 'old-slot-2', plugin: { id: 'plugin-2' } },
+          makeMashupSlot({ id: 'old-slot-1', plugin: makePlugin({ id: 'plugin-1' }) }),
+          makeMashupSlot({ id: 'old-slot-2', plugin: makePlugin({ id: 'plugin-2' }) }),
         ],
-      },
-    }
+      }),
+    })
 
-    screenRepo.findOne = vi.fn().mockResolvedValue(existingScreen)
-    mashupConfigRepo.findOne = vi.fn().mockResolvedValue(existingScreen.mashupConfiguration)
+    screenRepo.findOne.mockResolvedValue(existingScreen)
+    mashupConfigRepo.findOne.mockResolvedValue(existingScreen.mashupConfiguration ?? null)
 
     const dto = {
       filename: 'Updated Mashup',
@@ -398,22 +330,20 @@ describe('mashup Integration Tests', () => {
 
     expect(result).toBeDefined()
     expect(result.filename).toBe('Updated Mashup')
-    expect(mashupSlotRepo.remove).toHaveBeenCalledWith(existingScreen.mashupConfiguration.slots)
+    expect(mashupSlotRepo.remove).toHaveBeenCalledWith(existingScreen.mashupConfiguration?.slots)
     expect(mashupSlotRepo.save).toHaveBeenCalled()
   })
 
   it('should delete mashup and cascade to configuration and slots', async () => {
-    const existingScreen = {
+    const existingScreen = makeScreen({
       id: 'screen-1',
-      type: 'mashup' as const,
-      device: { id: 'device-1' },
-      mashupConfiguration: {
-        id: 'config-1',
-      },
-    }
+      type: 'mashup',
+      device: makeDevice({ id: 'device-1' }),
+      mashupConfiguration: makeMashupConfiguration({ id: 'config-1' }),
+    })
 
-    screenRepo.findOne = vi.fn().mockResolvedValue(existingScreen)
-    screenRepo.remove = vi.fn().mockResolvedValue(undefined)
+    screenRepo.findOne.mockResolvedValue(existingScreen)
+    screenRepo.remove.mockResolvedValue([])
 
     await mashupService.delete('screen-1')
 

--- a/packages/api/src/mashup/__test__/mashup.service.spec.ts
+++ b/packages/api/src/mashup/__test__/mashup.service.spec.ts
@@ -6,46 +6,33 @@ import type { UpdateMashupDto } from '../dto/update-mashup.dto'
 import type { MashupConfiguration } from '../entities/mashup-configuration.entity'
 import type { MashupSlot } from '../entities/mashup-slot.entity'
 import { BadRequestException, NotFoundException } from '@nestjs/common'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { makeDevice, makeMashupConfiguration, makeMashupSlot, makePlugin, makeScreen } from '../../test/fixtures'
+import { asRepository, createMockRepository, whereId } from '../../test/mockRepository'
 import { MashupService } from '../mashup.service'
-
-function createMockRepo() {
-  return {
-    find: vi.fn(),
-    findOne: vi.fn(),
-    findOneBy: vi.fn(),
-    create: vi.fn(),
-    save: vi.fn(),
-    update: vi.fn(),
-    remove: vi.fn(),
-    delete: vi.fn(),
-  }
-}
 
 describe('mashupService', () => {
   let service: MashupService
-  let screenRepo: ReturnType<typeof createMockRepo>
-  let deviceRepo: ReturnType<typeof createMockRepo>
-  let mashupConfigRepo: ReturnType<typeof createMockRepo>
-  let mashupSlotRepo: ReturnType<typeof createMockRepo>
-  let pluginRepo: ReturnType<typeof createMockRepo>
+  let screenRepo: ReturnType<typeof createMockRepository<Screen>>
+  let deviceRepo: ReturnType<typeof createMockRepository<Device>>
+  let mashupConfigRepo: ReturnType<typeof createMockRepository<MashupConfiguration>>
+  let mashupSlotRepo: ReturnType<typeof createMockRepository<MashupSlot>>
+  let pluginRepo: ReturnType<typeof createMockRepository<Plugin>>
 
   beforeEach(() => {
-    screenRepo = createMockRepo()
-    deviceRepo = createMockRepo()
-    mashupConfigRepo = createMockRepo()
-    mashupSlotRepo = createMockRepo()
-    pluginRepo = createMockRepo()
+    screenRepo = createMockRepository<Screen>()
+    deviceRepo = createMockRepository<Device>()
+    mashupConfigRepo = createMockRepository<MashupConfiguration>()
+    mashupSlotRepo = createMockRepository<MashupSlot>()
+    pluginRepo = createMockRepository<Plugin>()
 
     service = new MashupService(
-      screenRepo as any,
-      deviceRepo as any,
-      mashupConfigRepo as any,
-      mashupSlotRepo as any,
-      pluginRepo as any,
+      asRepository(screenRepo),
+      asRepository(deviceRepo),
+      asRepository(mashupConfigRepo),
+      asRepository(mashupSlotRepo),
+      asRepository(pluginRepo),
     )
-
-    vi.resetAllMocks()
   })
 
   describe('create', () => {
@@ -57,29 +44,28 @@ describe('mashupService', () => {
         pluginIds: ['plugin-1', 'plugin-2', 'plugin-3', 'plugin-4'],
       }
 
-      const device = { id: 'device-1' } as Device
+      const device = makeDevice({ id: 'device-1' })
       const plugins = [
-        { id: 'plugin-1' } as Plugin,
-        { id: 'plugin-2' } as Plugin,
-        { id: 'plugin-3' } as Plugin,
-        { id: 'plugin-4' } as Plugin,
+        makePlugin({ id: 'plugin-1' }),
+        makePlugin({ id: 'plugin-2' }),
+        makePlugin({ id: 'plugin-3' }),
+        makePlugin({ id: 'plugin-4' }),
       ]
 
       deviceRepo.findOne.mockResolvedValue(device)
-      pluginRepo.findOne.mockImplementation(({ where }) => {
-        return Promise.resolve(plugins.find(p => p.id === where.id))
-      })
+      pluginRepo.findOne.mockImplementation(async options =>
+        plugins.find(p => p.id === whereId(options)) ?? null)
 
-      const screen = { id: 'screen-1', type: 'mashup', filename: dto.filename, device, order: 1, isActive: false } as Screen
+      const screen = makeScreen({ id: 'screen-1', type: 'mashup', filename: dto.filename, device, order: 1, isActive: false })
       screenRepo.create.mockReturnValue(screen)
       screenRepo.save.mockResolvedValue(screen)
-      screenRepo.update.mockResolvedValue(undefined)
+      screenRepo.update.mockResolvedValue({ raw: [], generatedMaps: [] })
 
-      const config = { id: 'config-1', screen, layout: dto.layout, slots: [] } as unknown as MashupConfiguration
+      const config = makeMashupConfiguration({ id: 'config-1', screen, layout: dto.layout, slots: [] })
       mashupConfigRepo.create.mockReturnValue(config)
       mashupConfigRepo.save.mockResolvedValue(config)
 
-      const slot = { id: 'slot-1' } as MashupSlot
+      const slot = makeMashupSlot({ id: 'slot-1' })
       mashupSlotRepo.create.mockReturnValue(slot)
       mashupSlotRepo.save.mockResolvedValue(slot)
 
@@ -115,7 +101,7 @@ describe('mashupService', () => {
         pluginIds: ['p1', 'p2'], // only 2 plugins, but 2x2 needs 4
       }
 
-      const device = { id: 'device-1' } as Device
+      const device = makeDevice({ id: 'device-1' })
       deviceRepo.findOne.mockResolvedValue(device)
 
       await expect(service.create(dto)).rejects.toThrow(BadRequestException)
@@ -130,13 +116,14 @@ describe('mashupService', () => {
         pluginIds: ['p1', 'p2', 'p3', 'nonexistent'],
       }
 
-      const device = { id: 'device-1' } as Device
+      const device = makeDevice({ id: 'device-1' })
       deviceRepo.findOne.mockResolvedValue(device)
 
-      pluginRepo.findOne.mockImplementation(({ where }) => {
-        if (where.id === 'nonexistent')
-          return Promise.resolve(null)
-        return Promise.resolve({ id: where.id } as Plugin)
+      pluginRepo.findOne.mockImplementation(async (options) => {
+        const id = whereId(options)
+        if (id === 'nonexistent')
+          return null
+        return makePlugin({ id })
       })
 
       await expect(service.create(dto)).rejects.toThrow(NotFoundException)
@@ -151,7 +138,7 @@ describe('mashupService', () => {
         pluginIds: ['p1', 'p2', 'p3', 'p1'], // duplicate p1
       }
 
-      const device = { id: 'device-1' } as Device
+      const device = makeDevice({ id: 'device-1' })
       deviceRepo.findOne.mockResolvedValue(device)
 
       await expect(service.create(dto)).rejects.toThrow(BadRequestException)
@@ -167,22 +154,20 @@ describe('mashupService', () => {
         pluginIds: ['p1', 'p2'],
       }
 
-      const screen = { id: 'screen-1', type: 'mashup', filename: 'Old Name' } as Screen
+      const screen = makeScreen({ id: 'screen-1', type: 'mashup', filename: 'Old Name' })
       screenRepo.findOne.mockResolvedValue(screen)
-      screenRepo.save.mockResolvedValue({ ...screen, filename: dto.filename })
+      screenRepo.save.mockResolvedValue({ ...screen, filename: dto.filename ?? screen.filename })
 
-      const oldSlots = [{ id: 'old-slot-1' }, { id: 'old-slot-2' }] as MashupSlot[]
-      const config = { id: 'config-1', screen, layout: '2x2', slots: oldSlots } as MashupConfiguration
+      const oldSlots = [makeMashupSlot({ id: 'old-slot-1' }), makeMashupSlot({ id: 'old-slot-2' })]
+      const config = makeMashupConfiguration({ id: 'config-1', screen, layout: '2x2', slots: oldSlots })
       mashupConfigRepo.findOne.mockResolvedValue(config)
-      mashupConfigRepo.save.mockResolvedValue({ ...config, layout: dto.layout })
+      mashupConfigRepo.save.mockResolvedValue({ ...config, layout: dto.layout ?? config.layout })
 
-      mashupSlotRepo.remove.mockResolvedValue(undefined)
+      mashupSlotRepo.remove.mockResolvedValue([])
 
-      pluginRepo.findOne.mockImplementation(({ where }) => {
-        return Promise.resolve({ id: where.id } as Plugin)
-      })
+      pluginRepo.findOne.mockImplementation(async options => makePlugin({ id: whereId(options) }))
 
-      const slot = { id: 'slot-1' } as MashupSlot
+      const slot = makeMashupSlot({ id: 'slot-1' })
       mashupSlotRepo.create.mockReturnValue(slot)
       mashupSlotRepo.save.mockResolvedValue(slot)
 
@@ -202,14 +187,14 @@ describe('mashupService', () => {
 
   describe('delete', () => {
     it('should delete a mashup and its configuration', async () => {
-      const screen = { id: 'screen-1', type: 'mashup' } as Screen
+      const screen = makeScreen({ id: 'screen-1', type: 'mashup' })
       screenRepo.findOne.mockResolvedValue(screen)
 
-      const config = { id: 'config-1', screen } as MashupConfiguration
+      const config = makeMashupConfiguration({ id: 'config-1', screen })
       mashupConfigRepo.findOne.mockResolvedValue(config)
 
-      mashupConfigRepo.remove.mockResolvedValue(undefined)
-      screenRepo.remove.mockResolvedValue(undefined)
+      mashupConfigRepo.remove.mockResolvedValue(config)
+      screenRepo.remove.mockResolvedValue(screen)
 
       await expect(service.delete('screen-1')).resolves.toBeUndefined()
       expect(mashupConfigRepo.remove).toHaveBeenCalledWith(config)
@@ -225,14 +210,14 @@ describe('mashupService', () => {
 
   describe('getConfiguration', () => {
     it('should return mashup configuration with slots and plugins', async () => {
-      const config = {
+      const config = makeMashupConfiguration({
         id: 'config-1',
         layout: '2x2',
         slots: [
-          { id: 'slot-1', plugin: { id: 'p1', name: 'Plugin 1' } },
-          { id: 'slot-2', plugin: { id: 'p2', name: 'Plugin 2' } },
+          makeMashupSlot({ id: 'slot-1', plugin: makePlugin({ id: 'p1', name: 'Plugin 1' }) }),
+          makeMashupSlot({ id: 'slot-2', plugin: makePlugin({ id: 'p2', name: 'Plugin 2' }) }),
         ],
-      } as MashupConfiguration
+      })
 
       mashupConfigRepo.findOne.mockResolvedValue(config)
 

--- a/packages/api/src/plugins/__test__/plugin-data-fetcher.service.spec.ts
+++ b/packages/api/src/plugins/__test__/plugin-data-fetcher.service.spec.ts
@@ -1,7 +1,11 @@
+import type { ConfigService } from '@nestjs/config'
+import type { PluginRendererService } from '../services/plugin-renderer.service'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { jsonResponse, stubFetch } from '../../test/fetch'
+import { asService } from '../../test/mockService'
 import { PluginDataFetcherService } from '../services/plugin-data-fetcher.service'
 
-globalThis.fetch = vi.fn()
+const mockFetch = stubFetch()
 
 describe('pluginDataFetcherService', () => {
   let service: PluginDataFetcherService
@@ -9,21 +13,18 @@ describe('pluginDataFetcherService', () => {
   const mockConfigService = { get: vi.fn().mockReturnValue(false) }
 
   beforeEach(() => {
-    service = new PluginDataFetcherService(mockRenderer as any, mockConfigService as any)
+    service = new PluginDataFetcherService(asService<PluginRendererService>(mockRenderer), asService<ConfigService>(mockConfigService))
     vi.clearAllMocks()
     mockConfigService.get.mockReturnValue(false)
   })
 
   it('fetches data from a GET endpoint', async () => {
     const mockData = { temperature: 25, condition: 'sunny' }
-    ;(globalThis.fetch as any).mockResolvedValue({
-      ok: true,
-      json: async () => mockData,
-    })
+    mockFetch.mockResolvedValue(jsonResponse(mockData))
 
     const result = await service.fetchData('GET', 'https://api.weather.com/data')
 
-    expect(globalThis.fetch).toHaveBeenCalledWith('https://api.weather.com/data', {
+    expect(mockFetch).toHaveBeenCalledWith('https://api.weather.com/data', {
       method: 'GET',
       headers: {},
     })
@@ -33,14 +34,11 @@ describe('pluginDataFetcherService', () => {
   it('fetches data from a POST endpoint with body', async () => {
     const mockData = { success: true }
     const body = { location: 'Tokyo', units: 'metric' }
-    ;(globalThis.fetch as any).mockResolvedValue({
-      ok: true,
-      json: async () => mockData,
-    })
+    mockFetch.mockResolvedValue(jsonResponse(mockData))
 
     const result = await service.fetchData('POST', 'https://api.example.com/webhook', {}, body)
 
-    expect(globalThis.fetch).toHaveBeenCalledWith('https://api.example.com/webhook', {
+    expect(mockFetch).toHaveBeenCalledWith('https://api.example.com/webhook', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
@@ -51,25 +49,18 @@ describe('pluginDataFetcherService', () => {
   it('includes custom headers in request', async () => {
     const mockData = { data: 'test' }
     const headers = { 'Authorization': 'Bearer token123', 'X-Custom': 'value' }
-    ;(globalThis.fetch as any).mockResolvedValue({
-      ok: true,
-      json: async () => mockData,
-    })
+    mockFetch.mockResolvedValue(jsonResponse(mockData))
 
     await service.fetchData('GET', 'https://api.example.com', headers)
 
-    expect(globalThis.fetch).toHaveBeenCalledWith('https://api.example.com', {
+    expect(mockFetch).toHaveBeenCalledWith('https://api.example.com', {
       method: 'GET',
       headers,
     })
   })
 
   it('throws error when fetch fails', async () => {
-    ;(globalThis.fetch as any).mockResolvedValue({
-      ok: false,
-      status: 404,
-      statusText: 'Not Found',
-    })
+    mockFetch.mockResolvedValue(jsonResponse(null, { ok: false, status: 404 }))
 
     await expect(
       service.fetchData('GET', 'https://api.example.com/notfound'),
@@ -77,7 +68,7 @@ describe('pluginDataFetcherService', () => {
   })
 
   it('throws error when network fails', async () => {
-    ;(globalThis.fetch as any).mockRejectedValue(new Error('Network error'))
+    mockFetch.mockRejectedValue(new Error('Network error'))
 
     await expect(
       service.fetchData('GET', 'https://api.example.com'),
@@ -90,10 +81,7 @@ describe('pluginDataFetcherService', () => {
       array: [1, 2, 3],
       string: 'test',
     }
-    ;(globalThis.fetch as any).mockResolvedValue({
-      ok: true,
-      json: async () => complexData,
-    })
+    mockFetch.mockResolvedValue(jsonResponse(complexData))
 
     const result = await service.fetchData('GET', 'https://api.example.com')
     expect(result).toEqual(complexData)

--- a/packages/api/src/plugins/__test__/plugin-data-source.entity.spec.ts
+++ b/packages/api/src/plugins/__test__/plugin-data-source.entity.spec.ts
@@ -1,10 +1,10 @@
-import type { Plugin } from '../entities/plugin.entity'
 import { describe, expect, it } from 'vitest'
+import { makePlugin } from '../../test/fixtures'
 import { PluginDataSource } from '../entities/plugin-data-source.entity'
 
 describe('pluginDataSource entity', () => {
   it('creates a data source with required fields', () => {
-    const plugin = { id: 'plugin-1' } as Plugin
+    const plugin = makePlugin({ id: 'plugin-1' })
 
     const dataSource = new PluginDataSource()
     dataSource.id = 'ds-1'
@@ -21,7 +21,7 @@ describe('pluginDataSource entity', () => {
   })
 
   it('belongs to a Plugin via a many-to-one relation, so several can share one plugin', () => {
-    const plugin = { id: 'plugin-1' } as Plugin
+    const plugin = makePlugin({ id: 'plugin-1' })
 
     const weather = new PluginDataSource()
     weather.name = 'weather'

--- a/packages/api/src/plugins/__test__/plugin-deletion-mashup.integration.spec.ts
+++ b/packages/api/src/plugins/__test__/plugin-deletion-mashup.integration.spec.ts
@@ -1,11 +1,12 @@
 import type { TestingModule } from '@nestjs/testing'
-import type { Repository } from 'typeorm'
 import { BadRequestException } from '@nestjs/common'
 import { Test } from '@nestjs/testing'
 import { getRepositoryToken } from '@nestjs/typeorm'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { MashupSlot } from '../../mashup/entities/mashup-slot.entity'
 import { Screen } from '../../screens/screens.entity'
+import { makeMashupConfiguration, makeMashupSlot, makePlugin, makeScreen } from '../../test/fixtures'
+import { createMockRepository } from '../../test/mockRepository'
 import { DevicePlugin } from '../entities/device-plugin.entity'
 import { PluginDataSource } from '../entities/plugin-data-source.entity'
 import { PluginField } from '../entities/plugin-field.entity'
@@ -19,41 +20,31 @@ import { PluginTransformService } from '../services/plugin-transform.service'
 
 describe('plugin Deletion with Mashup Warning Integration', () => {
   let pluginsService: PluginsService
-  let pluginRepo: Repository<Plugin>
-  let devicePluginRepo: Repository<DevicePlugin>
-  let mashupSlotRepo: Repository<MashupSlot>
+  let pluginRepo: ReturnType<typeof createMockRepository<Plugin>> & { manager: { getRepository: (entity: string) => unknown } }
+  let devicePluginRepo: ReturnType<typeof createMockRepository<DevicePlugin>>
+  let mashupSlotRepo: ReturnType<typeof createMockRepository<MashupSlot>>
 
   beforeEach(async () => {
-    const mockPlugin = {
-      id: 'plugin-1',
-      name: 'Weather Plugin',
-    }
+    const mockPlugin = makePlugin({ id: 'plugin-1', name: 'Weather Plugin' })
 
     const mockScheduler = {
       removeScheduledJob: vi.fn(),
     }
 
+    mashupSlotRepo = createMockRepository<MashupSlot>()
+
     pluginRepo = {
-      findOne: vi.fn().mockResolvedValue(mockPlugin),
-      findOneBy: vi.fn().mockResolvedValue(mockPlugin),
-      remove: vi.fn().mockResolvedValue(undefined),
+      ...createMockRepository<Plugin>(),
       manager: {
-        getRepository: vi.fn((entity: string) => {
-          if (entity === 'MashupSlot')
-            return mashupSlotRepo
-          return null
-        }),
+        getRepository: (entity: string) => entity === 'MashupSlot' ? mashupSlotRepo : null,
       },
-    } as any
+    }
+    pluginRepo.findOne.mockResolvedValue(mockPlugin)
+    pluginRepo.findOneBy.mockResolvedValue(mockPlugin)
+    pluginRepo.remove.mockResolvedValue(mockPlugin)
 
-    devicePluginRepo = {
-      find: vi.fn().mockResolvedValue([]),
-      remove: vi.fn().mockResolvedValue(undefined),
-    } as any
-
-    mashupSlotRepo = {
-      find: vi.fn(),
-    } as any
+    devicePluginRepo = createMockRepository<DevicePlugin>()
+    devicePluginRepo.find.mockResolvedValue([])
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -112,32 +103,26 @@ describe('plugin Deletion with Mashup Warning Integration', () => {
   })
 
   it.skip('should throw error when deleting plugin used in mashups without force flag', async () => {
-    mashupSlotRepo.find = vi.fn().mockResolvedValue([
-      {
+    mashupSlotRepo.find.mockResolvedValue([
+      makeMashupSlot({
         id: 'slot-1',
-        mashupConfiguration: {
-          screen: {
-            id: 'screen-1',
-            filename: 'Dashboard',
-          } as Screen,
-        },
-      },
+        mashupConfiguration: makeMashupConfiguration({
+          screen: makeScreen({ id: 'screen-1', filename: 'Dashboard' }),
+        }),
+      }),
     ])
 
     await expect(pluginsService.remove('plugin-1', false)).rejects.toThrow(BadRequestException)
   })
 
   it.skip('should allow deletion with force flag even when used in mashups', async () => {
-    mashupSlotRepo.find = vi.fn().mockResolvedValue([
-      {
+    mashupSlotRepo.find.mockResolvedValue([
+      makeMashupSlot({
         id: 'slot-1',
-        mashupConfiguration: {
-          screen: {
-            id: 'screen-1',
-            filename: 'Dashboard',
-          } as Screen,
-        },
-      },
+        mashupConfiguration: makeMashupConfiguration({
+          screen: makeScreen({ id: 'screen-1', filename: 'Dashboard' }),
+        }),
+      }),
     ])
 
     const result = await pluginsService.remove('plugin-1', true)
@@ -147,25 +132,19 @@ describe('plugin Deletion with Mashup Warning Integration', () => {
   })
 
   it('should return mashup usage information when checking plugin', async () => {
-    mashupSlotRepo.find = vi.fn().mockResolvedValue([
-      {
+    mashupSlotRepo.find.mockResolvedValue([
+      makeMashupSlot({
         id: 'slot-1',
-        mashupConfiguration: {
-          screen: {
-            id: 'screen-1',
-            filename: 'Dashboard',
-          } as Screen,
-        },
-      },
-      {
+        mashupConfiguration: makeMashupConfiguration({
+          screen: makeScreen({ id: 'screen-1', filename: 'Dashboard' }),
+        }),
+      }),
+      makeMashupSlot({
         id: 'slot-2',
-        mashupConfiguration: {
-          screen: {
-            id: 'screen-2',
-            filename: 'Weather Screen',
-          } as Screen,
-        },
-      },
+        mashupConfiguration: makeMashupConfiguration({
+          screen: makeScreen({ id: 'screen-2', filename: 'Weather Screen' }),
+        }),
+      }),
     ])
 
     const usage = await pluginsService.checkPluginUsage('plugin-1')
@@ -178,7 +157,7 @@ describe('plugin Deletion with Mashup Warning Integration', () => {
   })
 
   it.skip('should delete plugin when not used in any mashups', async () => {
-    mashupSlotRepo.find = vi.fn().mockResolvedValue([])
+    mashupSlotRepo.find.mockResolvedValue([])
 
     const result = await pluginsService.remove('plugin-1', false)
 

--- a/packages/api/src/plugins/__test__/plugin-exporter.service.spec.ts
+++ b/packages/api/src/plugins/__test__/plugin-exporter.service.spec.ts
@@ -1,9 +1,20 @@
-import type { Plugin } from '../entities/plugin.entity'
 import { Buffer } from 'node:buffer'
 import AdmZip from 'adm-zip'
 import * as yaml from 'js-yaml'
 import { beforeEach, describe, expect, it } from 'vitest'
+import { makePlugin, makePluginDataSource, makePluginField, makePluginTemplate } from '../../test/fixtures'
 import { PluginExporterService } from '../services/plugin-exporter.service'
+
+interface ExportedManifest {
+  name: string
+  description: string
+  custom_fields: Array<{ keyname: string, field_type: string, optional: boolean, description: string, default_value: string }>
+}
+
+interface ExportedSettings {
+  refresh_interval: number
+  data_sources?: Array<{ name: string, endpoint: string, method: string, headers?: Record<string, string>, body?: Record<string, unknown>, transform_js?: string }>
+}
 
 describe('pluginExporterService', () => {
   let service: PluginExporterService
@@ -13,28 +24,18 @@ describe('pluginExporterService', () => {
   })
 
   it('exports a basic plugin to ZIP', async () => {
-    const plugin = {
+    const plugin = makePlugin({
       name: 'Test Plugin',
       description: 'Test Description',
       refreshInterval: 15,
       dataSources: [
-        {
-          name: 'source',
-          url: 'https://api.example.com',
-          method: 'GET',
-          headers: {},
-          body: {},
-          order: 0,
-        },
+        makePluginDataSource({ name: 'source', url: 'https://api.example.com', method: 'GET', headers: {}, body: {}, order: 0 }),
       ],
       templates: [
-        {
-          layout: 'full',
-          liquidMarkup: '<div>{{ data }}</div>',
-        },
+        makePluginTemplate({ layout: 'full', liquidMarkup: '<div>{{ data }}</div>' }),
       ],
       fields: [],
-    } as unknown as Plugin
+    })
 
     const buffer = await service.exportToZip(plugin)
     expect(buffer).toBeInstanceOf(Buffer)
@@ -49,36 +50,29 @@ describe('pluginExporterService', () => {
   })
 
   it('includes manifest with custom fields', async () => {
-    const plugin = {
+    const plugin = makePlugin({
       name: 'Weather Plugin',
       description: 'Shows weather',
       refreshInterval: 30,
-      dataSources: [{
-        name: 'source',
-        url: 'https://api.weather.com',
-        method: 'GET',
-        headers: {},
-        body: {},
-        order: 0,
-      }],
-      templates: [{ layout: 'full', liquidMarkup: 'Test' }],
+      dataSources: [makePluginDataSource({ name: 'source', url: 'https://api.weather.com', method: 'GET', headers: {}, body: {}, order: 0 })],
+      templates: [makePluginTemplate({ layout: 'full', liquidMarkup: 'Test' })],
       fields: [
-        {
+        makePluginField({
           keyname: 'api_key',
           fieldType: 'password',
           name: 'API Key',
           description: 'Your API key',
           defaultValue: '',
           required: true,
-        },
+        }),
       ],
-    } as unknown as Plugin
+    })
 
     const buffer = await service.exportToZip(plugin)
     const zip = new AdmZip(buffer)
     const manifestEntry = zip.getEntry('.trmnlp.yml')!
     const manifestContent = manifestEntry.getData().toString('utf8')
-    const manifest = yaml.load(manifestContent) as any
+    const manifest = yaml.load(manifestContent) as ExportedManifest
 
     expect(manifest.name).toBe('Weather Plugin')
     expect(manifest.description).toBe('Shows weather')
@@ -89,56 +83,56 @@ describe('pluginExporterService', () => {
   })
 
   it('includes settings with a data_sources array', async () => {
-    const plugin = {
+    const plugin = makePlugin({
       name: 'Test',
       refreshInterval: 60,
-      dataSources: [{
+      dataSources: [makePluginDataSource({
         name: 'weather',
         url: 'https://api.example.com/data',
         method: 'POST',
         headers: { Authorization: 'Bearer token' },
         body: { key: 'value' },
         order: 0,
-      }],
-      templates: [{ layout: 'full', liquidMarkup: 'Test' }],
+      })],
+      templates: [makePluginTemplate({ layout: 'full', liquidMarkup: 'Test' })],
       fields: [],
-    } as unknown as Plugin
+    })
 
     const buffer = await service.exportToZip(plugin)
     const zip = new AdmZip(buffer)
     const settingsEntry = zip.getEntry('src/settings.yml')!
     const settingsContent = settingsEntry.getData().toString('utf8')
-    const settings = yaml.load(settingsContent) as any
+    const settings = yaml.load(settingsContent) as ExportedSettings
 
     expect(settings.refresh_interval).toBe(60)
     expect(settings.data_sources).toHaveLength(1)
-    expect(settings.data_sources[0].name).toBe('weather')
-    expect(settings.data_sources[0].endpoint).toBe('https://api.example.com/data')
-    expect(settings.data_sources[0].method).toBe('POST')
-    expect(settings.data_sources[0].headers.Authorization).toBe('Bearer token')
-    expect(settings.data_sources[0].body.key).toBe('value')
+    expect(settings.data_sources![0].name).toBe('weather')
+    expect(settings.data_sources![0].endpoint).toBe('https://api.example.com/data')
+    expect(settings.data_sources![0].method).toBe('POST')
+    expect(settings.data_sources![0].headers!.Authorization).toBe('Bearer token')
+    expect(settings.data_sources![0].body!.key).toBe('value')
   })
 
   it('exports multiple data sources in order, each with its own name', async () => {
-    const plugin = {
+    const plugin = makePlugin({
       name: 'Multi Source',
       refreshInterval: 15,
       dataSources: [
-        { name: 'air_quality', url: 'https://api.example.com/air', method: 'GET', order: 1 },
-        { name: 'weather', url: 'https://api.example.com/weather', method: 'GET', order: 0, transformJs: 'module.exports = (d) => d' },
+        makePluginDataSource({ name: 'air_quality', url: 'https://api.example.com/air', method: 'GET', order: 1 }),
+        makePluginDataSource({ name: 'weather', url: 'https://api.example.com/weather', method: 'GET', order: 0, transformJs: 'module.exports = (d) => d' }),
       ],
-      templates: [{ layout: 'full', liquidMarkup: 'Test' }],
+      templates: [makePluginTemplate({ layout: 'full', liquidMarkup: 'Test' })],
       fields: [],
-    } as unknown as Plugin
+    })
 
     const buffer = await service.exportToZip(plugin)
     const zip = new AdmZip(buffer)
-    const settings = yaml.load(zip.getEntry('src/settings.yml')!.getData().toString('utf8')) as any
+    const settings = yaml.load(zip.getEntry('src/settings.yml')!.getData().toString('utf8')) as ExportedSettings
 
     expect(settings.data_sources).toHaveLength(2)
-    expect(settings.data_sources[0].name).toBe('weather')
-    expect(settings.data_sources[0].transform_js).toBe('module.exports = (d) => d')
-    expect(settings.data_sources[1].name).toBe('air_quality')
+    expect(settings.data_sources![0].name).toBe('weather')
+    expect(settings.data_sources![0].transform_js).toBe('module.exports = (d) => d')
+    expect(settings.data_sources![1].name).toBe('air_quality')
   })
 
   it('exports a literal-mode data source as a mode/literal_value entry, not a broken endpoint', async () => {
@@ -169,24 +163,17 @@ describe('pluginExporterService', () => {
   })
 
   it('exports multiple templates with different layouts', async () => {
-    const plugin = {
+    const plugin = makePlugin({
       name: 'Multi Layout',
       refreshInterval: 15,
-      dataSources: [{
-        name: 'source',
-        url: 'https://api.example.com',
-        method: 'GET',
-        headers: {},
-        body: {},
-        order: 0,
-      }],
+      dataSources: [makePluginDataSource({ name: 'source', url: 'https://api.example.com', method: 'GET', headers: {}, body: {}, order: 0 })],
       templates: [
-        { layout: 'full', liquidMarkup: 'Full layout' },
-        { layout: 'half_horizontal', liquidMarkup: 'Half layout' },
-        { layout: 'quadrant', liquidMarkup: 'Quadrant layout' },
+        makePluginTemplate({ layout: 'full', liquidMarkup: 'Full layout' }),
+        makePluginTemplate({ layout: 'half_horizontal', liquidMarkup: 'Half layout' }),
+        makePluginTemplate({ layout: 'quadrant', liquidMarkup: 'Quadrant layout' }),
       ],
       fields: [],
-    } as unknown as Plugin
+    })
 
     const buffer = await service.exportToZip(plugin)
     const zip = new AdmZip(buffer)
@@ -200,12 +187,12 @@ describe('pluginExporterService', () => {
   })
 
   it('handles plugin without data source', async () => {
-    const plugin = {
+    const plugin = makePlugin({
       name: 'No Data Source',
       refreshInterval: 15,
-      templates: [{ layout: 'full', liquidMarkup: 'Static content' }],
+      templates: [makePluginTemplate({ layout: 'full', liquidMarkup: 'Static content' })],
       fields: [],
-    } as unknown as Plugin
+    })
 
     const buffer = await service.exportToZip(plugin)
     const zip = new AdmZip(buffer)
@@ -217,19 +204,12 @@ describe('pluginExporterService', () => {
   })
 
   it('handles plugin without templates', async () => {
-    const plugin = {
+    const plugin = makePlugin({
       name: 'No Templates',
       refreshInterval: 15,
-      dataSources: [{
-        name: 'source',
-        url: 'https://api.example.com',
-        method: 'GET',
-        headers: {},
-        body: {},
-        order: 0,
-      }],
+      dataSources: [makePluginDataSource({ name: 'source', url: 'https://api.example.com', method: 'GET', headers: {}, body: {}, order: 0 })],
       fields: [],
-    } as unknown as Plugin
+    })
 
     const buffer = await service.exportToZip(plugin)
     const zip = new AdmZip(buffer)
@@ -241,35 +221,35 @@ describe('pluginExporterService', () => {
   })
 
   it('handles empty or undefined descriptions and defaults', async () => {
-    const plugin = {
+    const plugin = makePlugin({
       name: 'Test',
       description: undefined,
       refreshInterval: 15,
-      dataSources: [{
+      dataSources: [makePluginDataSource({
         name: 'source',
         url: 'https://api.example.com',
         method: 'GET',
         headers: undefined,
         body: undefined,
         order: 0,
-      }],
-      templates: [{ layout: 'full', liquidMarkup: 'Test' }],
+      })],
+      templates: [makePluginTemplate({ layout: 'full', liquidMarkup: 'Test' })],
       fields: [
-        {
+        makePluginField({
           keyname: 'field1',
           fieldType: 'string',
           name: 'Field',
           description: undefined,
           defaultValue: undefined,
           required: false,
-        },
+        }),
       ],
-    } as unknown as Plugin
+    })
 
     const buffer = await service.exportToZip(plugin)
     const zip = new AdmZip(buffer)
     const manifestEntry = zip.getEntry('.trmnlp.yml')!
-    const manifest = yaml.load(manifestEntry.getData().toString('utf8')) as any
+    const manifest = yaml.load(manifestEntry.getData().toString('utf8')) as ExportedManifest
 
     expect(manifest.description).toBe('')
     expect(manifest.custom_fields[0].description).toBe('')

--- a/packages/api/src/plugins/__test__/plugin-exporter.service.spec.ts
+++ b/packages/api/src/plugins/__test__/plugin-exporter.service.spec.ts
@@ -13,7 +13,7 @@ interface ExportedManifest {
 
 interface ExportedSettings {
   refresh_interval: number
-  data_sources?: Array<{ name: string, endpoint: string, method: string, headers?: Record<string, string>, body?: Record<string, unknown>, transform_js?: string }>
+  data_sources?: Array<{ name: string, mode?: 'literal', endpoint?: string, method?: string, headers?: Record<string, string>, body?: Record<string, unknown>, transform_js?: string, literal_value?: unknown }>
 }
 
 describe('pluginExporterService', () => {
@@ -136,28 +136,28 @@ describe('pluginExporterService', () => {
   })
 
   it('exports a literal-mode data source as a mode/literal_value entry, not a broken endpoint', async () => {
-    const plugin = {
+    const plugin = makePlugin({
       name: 'Mixed',
       refreshInterval: 15,
       dataSources: [
-        { name: 'weather', mode: 'fetch', url: 'https://api.example.com/weather', method: 'GET', order: 0 },
-        { name: 'title', mode: 'literal', literalValue: { text: 'Hello' }, order: 1 },
+        makePluginDataSource({ name: 'weather', mode: 'fetch', url: 'https://api.example.com/weather', method: 'GET', order: 0 }),
+        makePluginDataSource({ name: 'title', mode: 'literal', literalValue: { text: 'Hello' }, order: 1 }),
       ],
-      templates: [{ layout: 'full', liquidMarkup: 'Test' }],
+      templates: [makePluginTemplate({ layout: 'full', liquidMarkup: 'Test' })],
       fields: [],
-    } as unknown as Plugin
+    })
 
     const buffer = await service.exportToZip(plugin)
     const zip = new AdmZip(buffer)
-    const settings = yaml.load(zip.getEntry('src/settings.yml')!.getData().toString('utf8')) as any
+    const settings = yaml.load(zip.getEntry('src/settings.yml')!.getData().toString('utf8')) as ExportedSettings
 
     expect(settings.data_sources).toHaveLength(2)
-    const literalEntry = settings.data_sources.find((s: any) => s.name === 'title')
+    const literalEntry = settings.data_sources!.find(s => s.name === 'title')!
     expect(literalEntry.mode).toBe('literal')
     expect(literalEntry.literal_value).toEqual({ text: 'Hello' })
     expect(literalEntry.endpoint).toBeUndefined()
 
-    const fetchEntry = settings.data_sources.find((s: any) => s.name === 'weather')
+    const fetchEntry = settings.data_sources!.find(s => s.name === 'weather')!
     expect(fetchEntry.endpoint).toBe('https://api.example.com/weather')
     expect(fetchEntry.mode).toBeUndefined()
   })

--- a/packages/api/src/plugins/__test__/plugin-field-value.entity.spec.ts
+++ b/packages/api/src/plugins/__test__/plugin-field-value.entity.spec.ts
@@ -1,14 +1,12 @@
-import type { Device } from '../../devices/devices.entity'
-import type { PluginField } from '../entities/plugin-field.entity'
-import type { Plugin } from '../entities/plugin.entity'
 import { describe, expect, it } from 'vitest'
+import { makeDevice, makePlugin, makePluginField } from '../../test/fixtures'
 import { PluginFieldValue } from '../entities/plugin-field-value.entity'
 
 describe('pluginFieldValue entity', () => {
   it('creates a field value with required fields', () => {
-    const plugin = { id: 'plugin-1' } as Plugin
-    const field = { id: 'field-1' } as PluginField
-    const device = { id: 'device-1' } as Device
+    const plugin = makePlugin({ id: 'plugin-1' })
+    const field = makePluginField({ id: 'field-1' })
+    const device = makeDevice({ id: 'device-1' })
 
     const fieldValue = new PluginFieldValue()
     fieldValue.id = 'value-1'
@@ -38,10 +36,10 @@ describe('pluginFieldValue entity', () => {
   })
 
   it('allows same field to have different values per device', () => {
-    const plugin = { id: 'plugin-1' } as Plugin
-    const field = { id: 'location' } as PluginField
-    const device1 = { id: 'device-1' } as Device
-    const device2 = { id: 'device-2' } as Device
+    const plugin = makePlugin({ id: 'plugin-1' })
+    const field = makePluginField({ id: 'location' })
+    const device1 = makeDevice({ id: 'device-1' })
+    const device2 = makeDevice({ id: 'device-2' })
 
     const value1 = new PluginFieldValue()
     value1.plugin = plugin

--- a/packages/api/src/plugins/__test__/plugin-field.entity.spec.ts
+++ b/packages/api/src/plugins/__test__/plugin-field.entity.spec.ts
@@ -1,10 +1,10 @@
-import type { Plugin } from '../entities/plugin.entity'
 import { describe, expect, it } from 'vitest'
+import { makePlugin } from '../../test/fixtures'
 import { PluginField } from '../entities/plugin-field.entity'
 
 describe('pluginField entity', () => {
   it('creates a field with required fields', () => {
-    const plugin = { id: 'plugin-1' } as Plugin
+    const plugin = makePlugin({ id: 'plugin-1' })
 
     const field = new PluginField()
     field.id = 'field-1'

--- a/packages/api/src/plugins/__test__/plugin-recipe-import.spec.ts
+++ b/packages/api/src/plugins/__test__/plugin-recipe-import.spec.ts
@@ -4,7 +4,7 @@ import * as yaml from 'js-yaml'
 import { describe, expect, it } from 'vitest'
 import { PluginImporterService } from '../services/plugin-importer.service'
 
-function buildFlatRecipeArchive(settings: Record<string, any>, files: Record<string, string> = { 'full.liquid': '<div>{{ source.title }}</div>' }): Buffer {
+function buildFlatRecipeArchive(settings: Record<string, unknown>, files: Record<string, string> = { 'full.liquid': '<div>{{ source.title }}</div>' }): Buffer {
   const zip = new AdmZip()
   zip.addFile('settings.yml', Buffer.from(yaml.dump(settings), 'utf8'))
   for (const [name, content] of Object.entries(files)) {

--- a/packages/api/src/plugins/__test__/plugin-render-cache.service.spec.ts
+++ b/packages/api/src/plugins/__test__/plugin-render-cache.service.spec.ts
@@ -1,34 +1,36 @@
-import type { Plugin } from '../entities/plugin.entity'
+import type { MashupSlot } from '../../mashup/entities/mashup-slot.entity'
+import type { Screen } from '../../screens/screens.entity'
 import type { PluginRendererService } from '../services/plugin-renderer.service'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { makeMashupConfiguration, makeMashupSlot, makePlugin, makePluginTemplate, makeScreen } from '../../test/fixtures'
+import { asRepository, createMockRepository } from '../../test/mockRepository'
+import { asService, injectPrivate } from '../../test/mockService'
 import { PluginRenderCacheService } from '../services/plugin-render-cache.service'
 
 describe('pluginRenderCacheService', () => {
   let service: PluginRenderCacheService
-  let mockRenderer: PluginRendererService
-  let mockScreenRepo: any
-  let mockMashupSlotRepo: any
+  let mockRenderer: { render: ReturnType<typeof vi.fn> }
+  let mockScreenRepo: ReturnType<typeof createMockRepository<Screen>> & { manager: { getRepository: ReturnType<typeof vi.fn> } }
+  let mockMashupSlotRepo: ReturnType<typeof createMockRepository<MashupSlot>>
 
-  const plugin = {
+  const plugin = makePlugin({
     id: 'plugin-1',
-    templates: [{ layout: 'full', liquidMarkup: '{{ data }}' }],
-  } as unknown as Plugin
+    templates: [makePluginTemplate({ layout: 'full', liquidMarkup: '{{ data }}' })],
+  })
 
   beforeEach(() => {
     mockRenderer = {
       render: vi.fn().mockResolvedValue('<div>rendered</div>'),
-    } as any
-
-    mockMashupSlotRepo = {
-      find: vi.fn().mockResolvedValue([]),
     }
 
-    mockScreenRepo = {
-      update: vi.fn(),
+    mockMashupSlotRepo = createMockRepository<MashupSlot>()
+    mockMashupSlotRepo.find.mockResolvedValue([])
+
+    mockScreenRepo = Object.assign(createMockRepository<Screen>(), {
       manager: { getRepository: vi.fn(() => mockMashupSlotRepo) },
-    }
+    })
 
-    service = new PluginRenderCacheService(mockRenderer, mockScreenRepo)
+    service = new PluginRenderCacheService(asService<PluginRendererService>(mockRenderer), asRepository(mockScreenRepo))
   })
 
   it('renders the primary template and caches it to every screen of the plugin', async () => {
@@ -42,18 +44,18 @@ describe('pluginRenderCacheService', () => {
   })
 
   it('does nothing when the plugin has no template', async () => {
-    await service.renderAndCache({ ...plugin, templates: [] } as unknown as Plugin, {})
+    await service.renderAndCache(makePlugin({ ...plugin, templates: [] }), {})
 
     expect(mockRenderer.render).not.toHaveBeenCalled()
     expect(mockScreenRepo.update).not.toHaveBeenCalled()
   })
 
   it('invalidates mashup caches when plugin updates', async () => {
-    mockMashupSlotRepo.find = vi.fn().mockResolvedValue([
-      { id: 'slot-1', mashupConfiguration: { screen: { id: 'screen-1' } } },
-      { id: 'slot-2', mashupConfiguration: { screen: { id: 'screen-2' } } },
+    mockMashupSlotRepo.find.mockResolvedValue([
+      makeMashupSlot({ id: 'slot-1', mashupConfiguration: makeMashupConfiguration({ screen: makeScreen({ id: 'screen-1' }) }) }),
+      makeMashupSlot({ id: 'slot-2', mashupConfiguration: makeMashupConfiguration({ screen: makeScreen({ id: 'screen-2' }) }) }),
     ])
-    ;(service as any).mashupSlotRepository = mockMashupSlotRepo
+    injectPrivate(service, 'mashupSlotRepository', asRepository(mockMashupSlotRepo))
 
     await service.invalidateMashupCaches('plugin-1')
 
@@ -72,7 +74,7 @@ describe('pluginRenderCacheService', () => {
   })
 
   it('does not fail if mashupSlotRepository not available', async () => {
-    ;(service as any).mashupSlotRepository = null
+    injectPrivate(service, 'mashupSlotRepository', null)
 
     await expect(service.invalidateMashupCaches('plugin-1')).resolves.toBeUndefined()
     expect(mockScreenRepo.update).not.toHaveBeenCalled()

--- a/packages/api/src/plugins/__test__/plugin-scheduler.service.spec.ts
+++ b/packages/api/src/plugins/__test__/plugin-scheduler.service.spec.ts
@@ -1,7 +1,11 @@
+import type { MockPluginDataFetcherService } from '../../test/mockPluginCollaborators'
 import type { Plugin } from '../entities/plugin.entity'
 import type { PluginDataFetcherService } from '../services/plugin-data-fetcher.service'
 import type { PluginRenderCacheService } from '../services/plugin-render-cache.service'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { makePlugin, makePluginDataSource, makePluginTemplate } from '../../test/fixtures'
+import { createMockPluginDataFetcherService } from '../../test/mockPluginCollaborators'
+import { asService, callPrivate } from '../../test/mockService'
 import { PluginSchedulerService } from '../services/plugin-scheduler.service'
 import { PluginTemplateContextService } from '../services/plugin-template-context.service'
 
@@ -21,36 +25,32 @@ vi.mock('node-cron', () => ({
 
 describe('pluginSchedulerService', () => {
   let service: PluginSchedulerService
-  let mockDataFetcher: PluginDataFetcherService
-  let mockRenderCache: PluginRenderCacheService
+  let mockDataFetcher: MockPluginDataFetcherService
+  let mockRenderCache: { renderAndCache: ReturnType<typeof vi.fn> }
 
   beforeEach(() => {
     capturedCallback = undefined
 
-    mockDataFetcher = {
-      fetchData: vi.fn(),
-      fetchOrLiteral: vi.fn((source: any, ctx: any) =>
-        source.mode === 'literal'
-          ? Promise.resolve(source.literalValue ?? null)
-          : mockDataFetcher.fetchData(source.method, source.url ?? '', source.headers, source.body, ctx),
-      ),
-    } as any
+    mockDataFetcher = createMockPluginDataFetcherService()
 
     mockRenderCache = {
       renderAndCache: vi.fn(),
-    } as any
+    }
 
-    service = new PluginSchedulerService(mockDataFetcher, mockRenderCache, new PluginTemplateContextService())
+    service = new PluginSchedulerService(
+      asService<PluginDataFetcherService>(mockDataFetcher),
+      asService<PluginRenderCacheService>(mockRenderCache),
+      new PluginTemplateContextService(),
+    )
   })
 
   it('schedules a plugin with refresh interval', () => {
-    const plugin = {
+    const plugin = makePlugin({
       id: 'plugin-1',
       refreshInterval: 15,
-      isActive: true,
-      dataSources: [{ name: 'source', url: 'https://api.example.com', method: 'GET' }],
-      templates: [{ layout: 'full', liquidMarkup: '{{ data }}' }],
-    } as unknown as Plugin
+      dataSources: [makePluginDataSource({ name: 'source', url: 'https://api.example.com', method: 'GET' })],
+      templates: [makePluginTemplate({ layout: 'full', liquidMarkup: '{{ data }}' })],
+    })
 
     service.schedulePlugin(plugin)
 
@@ -58,11 +58,10 @@ describe('pluginSchedulerService', () => {
   })
 
   it('does not schedule inactive plugins', () => {
-    const plugin = {
+    const plugin = makePlugin({
       id: 'plugin-1',
-      isActive: false,
       refreshInterval: 15,
-    } as unknown as Plugin
+    })
 
     service.schedulePlugin(plugin)
 
@@ -70,13 +69,12 @@ describe('pluginSchedulerService', () => {
   })
 
   it('removes a scheduled job', () => {
-    const plugin = {
+    const plugin = makePlugin({
       id: 'plugin-1',
       refreshInterval: 15,
-      isActive: true,
-      dataSources: [{ name: 'source', url: 'https://api.example.com', method: 'GET' }],
-      templates: [{ layout: 'full', liquidMarkup: '{{ data }}' }],
-    } as unknown as Plugin
+      dataSources: [makePluginDataSource({ name: 'source', url: 'https://api.example.com', method: 'GET' })],
+      templates: [makePluginTemplate({ layout: 'full', liquidMarkup: '{{ data }}' })],
+    })
 
     service.schedulePlugin(plugin)
     expect(service.hasScheduledJob('plugin-1')).toBe(true)
@@ -86,28 +84,26 @@ describe('pluginSchedulerService', () => {
   })
 
   it('converts refresh interval to cron expression', () => {
-    expect((service as any).getCronExpression(1)).toBe('*/1 * * * *')
-    expect((service as any).getCronExpression(15)).toBe('*/15 * * * *')
-    expect((service as any).getCronExpression(30)).toBe('*/30 * * * *')
-    expect((service as any).getCronExpression(60)).toBe('0 * * * *')
+    expect(callPrivate<string>(service, 'getCronExpression', 1)).toBe('*/1 * * * *')
+    expect(callPrivate<string>(service, 'getCronExpression', 15)).toBe('*/15 * * * *')
+    expect(callPrivate<string>(service, 'getCronExpression', 30)).toBe('*/30 * * * *')
+    expect(callPrivate<string>(service, 'getCronExpression', 60)).toBe('0 * * * *')
   })
 
   it('schedules multiple plugins independently', () => {
-    const plugin1 = {
+    const plugin1 = makePlugin({
       id: 'plugin-1',
       refreshInterval: 15,
-      isActive: true,
-      dataSources: [{ name: 'source', url: 'https://api1.com', method: 'GET' }],
-      templates: [{ layout: 'full', liquidMarkup: 'Test 1' }],
-    } as unknown as Plugin
+      dataSources: [makePluginDataSource({ name: 'source', url: 'https://api1.com', method: 'GET' })],
+      templates: [makePluginTemplate({ layout: 'full', liquidMarkup: 'Test 1' })],
+    })
 
-    const plugin2 = {
+    const plugin2 = makePlugin({
       id: 'plugin-2',
       refreshInterval: 30,
-      isActive: true,
-      dataSources: [{ name: 'source', url: 'https://api2.com', method: 'GET' }],
-      templates: [{ layout: 'full', liquidMarkup: 'Test 2' }],
-    } as unknown as Plugin
+      dataSources: [makePluginDataSource({ name: 'source', url: 'https://api2.com', method: 'GET' })],
+      templates: [makePluginTemplate({ layout: 'full', liquidMarkup: 'Test 2' })],
+    })
 
     service.schedulePlugin(plugin1)
     service.schedulePlugin(plugin2)
@@ -117,13 +113,12 @@ describe('pluginSchedulerService', () => {
   })
 
   it('reschedules plugin after removal', () => {
-    const plugin = {
+    const plugin = makePlugin({
       id: 'plugin-1',
       refreshInterval: 15,
-      isActive: true,
-      dataSources: [{ name: 'source', url: 'https://api.com', method: 'GET' }],
-      templates: [{ layout: 'full', liquidMarkup: 'Test' }],
-    } as unknown as Plugin
+      dataSources: [makePluginDataSource({ name: 'source', url: 'https://api.com', method: 'GET' })],
+      templates: [makePluginTemplate({ layout: 'full', liquidMarkup: 'Test' })],
+    })
 
     service.schedulePlugin(plugin)
     expect(service.hasScheduledJob('plugin-1')).toBe(true)
@@ -136,12 +131,11 @@ describe('pluginSchedulerService', () => {
   })
 
   it('does not schedule if there are no data sources', () => {
-    const plugin = {
+    const plugin = makePlugin({
       id: 'plugin-1',
       refreshInterval: 15,
-      isActive: true,
-      templates: [{ layout: 'full', liquidMarkup: 'Test' }],
-    } as unknown as Plugin
+      templates: [makePluginTemplate({ layout: 'full', liquidMarkup: 'Test' })],
+    })
 
     service.schedulePlugin(plugin)
 
@@ -149,13 +143,12 @@ describe('pluginSchedulerService', () => {
   })
 
   it('does not schedule a draft plugin with zero data sources', () => {
-    const plugin = {
+    const plugin = makePlugin({
       id: 'plugin-1',
       refreshInterval: 15,
-      isActive: true,
       dataSources: [],
-      templates: [{ layout: 'full', liquidMarkup: 'Test' }],
-    } as unknown as Plugin
+      templates: [makePluginTemplate({ layout: 'full', liquidMarkup: 'Test' })],
+    })
 
     service.schedulePlugin(plugin)
 
@@ -163,12 +156,11 @@ describe('pluginSchedulerService', () => {
   })
 
   it('does not schedule if templates are missing', () => {
-    const plugin = {
+    const plugin = makePlugin({
       id: 'plugin-1',
       refreshInterval: 15,
-      isActive: true,
-      dataSources: [{ name: 'source', url: 'https://api.com', method: 'GET' }],
-    } as unknown as Plugin
+      dataSources: [makePluginDataSource({ name: 'source', url: 'https://api.com', method: 'GET' })],
+    })
 
     service.schedulePlugin(plugin)
 
@@ -176,12 +168,12 @@ describe('pluginSchedulerService', () => {
   })
 
   it('does not schedule Webhook-kind plugins', () => {
-    const plugin = {
+    const plugin = makePlugin({
       id: 'plugin-1',
       kind: 'Webhook',
       refreshInterval: 15,
-      templates: [{ layout: 'full', liquidMarkup: 'Test' }],
-    } as unknown as Plugin
+      templates: [makePluginTemplate({ layout: 'full', liquidMarkup: 'Test' })],
+    })
 
     service.schedulePlugin(plugin)
 
@@ -190,20 +182,19 @@ describe('pluginSchedulerService', () => {
 
   describe('scheduled tick', () => {
     it('fetches all data sources in parallel and renders them under their own names', async () => {
-      const plugin = {
+      const plugin: Plugin = makePlugin({
         id: 'plugin-1',
         name: 'Multi Source',
         refreshInterval: 15,
-        isActive: true,
         dataSources: [
-          { name: 'weather', url: 'https://api.example.com/weather', method: 'GET' },
-          { name: 'air_quality', url: 'https://api.example.com/air', method: 'GET' },
+          makePluginDataSource({ name: 'weather', url: 'https://api.example.com/weather', method: 'GET' }),
+          makePluginDataSource({ name: 'air_quality', url: 'https://api.example.com/air', method: 'GET' }),
         ],
-        templates: [{ layout: 'full', liquidMarkup: '{{ weather.temp }} / {{ air_quality.aqi }}' }],
-      } as unknown as Plugin
+        templates: [makePluginTemplate({ layout: 'full', liquidMarkup: '{{ weather.temp }} / {{ air_quality.aqi }}' })],
+      })
 
-      let resolveWeather: (value: any) => void
-      let resolveAirQuality: (value: any) => void
+      let resolveWeather: (value: unknown) => void
+      let resolveAirQuality: (value: unknown) => void
       const weatherPromise = new Promise((resolve) => {
         resolveWeather = resolve
       })
@@ -211,10 +202,9 @@ describe('pluginSchedulerService', () => {
         resolveAirQuality = resolve
       })
 
-      mockDataFetcher.fetchData = vi.fn((_method, url) => {
-        return url.includes('weather') ? weatherPromise : airQualityPromise
-      }) as any
-      mockRenderCache.renderAndCache = vi.fn().mockResolvedValue(undefined)
+      mockDataFetcher.fetchData.mockImplementation((_method: string, url: string) =>
+        url.includes('weather') ? weatherPromise : airQualityPromise)
+      mockRenderCache.renderAndCache.mockResolvedValue(undefined)
 
       service.schedulePlugin(plugin)
       const tickPromise = capturedCallback!()
@@ -313,24 +303,22 @@ describe('pluginSchedulerService', () => {
     })
 
     it('gives a failing data source an error marker and still renders the sources that succeeded', async () => {
-      const plugin = {
+      const plugin: Plugin = makePlugin({
         id: 'plugin-1',
         name: 'Partial Failure',
         refreshInterval: 15,
-        isActive: true,
         dataSources: [
-          { name: 'weather', url: 'https://api.example.com/weather', method: 'GET' },
-          { name: 'air_quality', url: 'https://api.example.com/air', method: 'GET' },
+          makePluginDataSource({ name: 'weather', url: 'https://api.example.com/weather', method: 'GET' }),
+          makePluginDataSource({ name: 'air_quality', url: 'https://api.example.com/air', method: 'GET' }),
         ],
-        templates: [{ layout: 'full', liquidMarkup: '{{ weather.temp }}' }],
-      } as unknown as Plugin
+        templates: [makePluginTemplate({ layout: 'full', liquidMarkup: '{{ weather.temp }}' })],
+      })
 
-      mockDataFetcher.fetchData = vi.fn((_method, url) => {
-        return url.includes('weather')
+      mockDataFetcher.fetchData.mockImplementation((_method: string, url: string) =>
+        url.includes('weather')
           ? Promise.resolve({ temp: 25 })
-          : Promise.reject(new Error('API timeout'))
-      }) as any
-      mockRenderCache.renderAndCache = vi.fn().mockResolvedValue(undefined)
+          : Promise.reject(new Error('API timeout')))
+      mockRenderCache.renderAndCache.mockResolvedValue(undefined)
 
       service.schedulePlugin(plugin)
       await capturedCallback!()

--- a/packages/api/src/plugins/__test__/plugin-scheduler.service.spec.ts
+++ b/packages/api/src/plugins/__test__/plugin-scheduler.service.spec.ts
@@ -223,16 +223,15 @@ describe('pluginSchedulerService', () => {
     })
 
     it('schedules a plugin with only literal-mode data sources and renders its stored value without calling the data fetcher', async () => {
-      const plugin = {
+      const plugin = makePlugin({
         id: 'plugin-1',
         name: 'Literal Only',
         refreshInterval: 15,
-        isActive: true,
         dataSources: [
-          { name: 'source', mode: 'literal', literalValue: { title: 'Hello' } },
+          makePluginDataSource({ name: 'source', mode: 'literal', literalValue: { title: 'Hello' } }),
         ],
-        templates: [{ layout: 'full', liquidMarkup: '{{ source.title }}' }],
-      } as unknown as Plugin
+        templates: [makePluginTemplate({ layout: 'full', liquidMarkup: '{{ source.title }}' })],
+      })
 
       mockRenderCache.renderAndCache = vi.fn().mockResolvedValue(undefined)
 
@@ -249,17 +248,16 @@ describe('pluginSchedulerService', () => {
     })
 
     it('renders a mixed plugin with one fetch and one literal source, without fetching the literal one', async () => {
-      const plugin = {
+      const plugin = makePlugin({
         id: 'plugin-1',
         name: 'Mixed',
         refreshInterval: 15,
-        isActive: true,
         dataSources: [
-          { name: 'weather', mode: 'fetch', url: 'https://api.example.com/weather', method: 'GET' },
-          { name: 'title', mode: 'literal', literalValue: 'Static Title' },
+          makePluginDataSource({ name: 'weather', mode: 'fetch', url: 'https://api.example.com/weather', method: 'GET' }),
+          makePluginDataSource({ name: 'title', mode: 'literal', literalValue: 'Static Title' }),
         ],
-        templates: [{ layout: 'full', liquidMarkup: '{{ title }} {{ weather.temp }}' }],
-      } as unknown as Plugin
+        templates: [makePluginTemplate({ layout: 'full', liquidMarkup: '{{ title }} {{ weather.temp }}' })],
+      })
 
       mockDataFetcher.fetchData = vi.fn().mockResolvedValue({ temp: 25 })
       mockRenderCache.renderAndCache = vi.fn().mockResolvedValue(undefined)
@@ -275,17 +273,16 @@ describe('pluginSchedulerService', () => {
     })
 
     it('gives a failing fetch-mode source an error marker while a literal-mode source alongside it still renders normally', async () => {
-      const plugin = {
+      const plugin = makePlugin({
         id: 'plugin-1',
         name: 'Mixed Partial Failure',
         refreshInterval: 15,
-        isActive: true,
         dataSources: [
-          { name: 'weather', mode: 'fetch', url: 'https://api.example.com/weather', method: 'GET' },
-          { name: 'title', mode: 'literal', literalValue: 'Static Title' },
+          makePluginDataSource({ name: 'weather', mode: 'fetch', url: 'https://api.example.com/weather', method: 'GET' }),
+          makePluginDataSource({ name: 'title', mode: 'literal', literalValue: 'Static Title' }),
         ],
-        templates: [{ layout: 'full', liquidMarkup: '{{ title }}' }],
-      } as unknown as Plugin
+        templates: [makePluginTemplate({ layout: 'full', liquidMarkup: '{{ title }}' })],
+      })
 
       mockDataFetcher.fetchData = vi.fn().mockRejectedValue(new Error('API timeout'))
       mockRenderCache.renderAndCache = vi.fn().mockResolvedValue(undefined)

--- a/packages/api/src/plugins/__test__/plugin-template-context.service.spec.ts
+++ b/packages/api/src/plugins/__test__/plugin-template-context.service.spec.ts
@@ -1,12 +1,11 @@
-import type { DeviceSensor } from '../../device-sensors/entities/device-sensor.entity'
-import type { Plugin } from '../entities/plugin.entity'
 import { beforeEach, describe, expect, it } from 'vitest'
+import { makeDeviceSensor, makePlugin } from '../../test/fixtures'
 import { PluginTemplateContextService } from '../services/plugin-template-context.service'
 
 describe('pluginTemplateContextService', () => {
   let service: PluginTemplateContextService
 
-  const plugin = { name: 'Weather' } as Plugin
+  const plugin = makePlugin({ name: 'Weather' })
 
   beforeEach(() => {
     service = new PluginTemplateContextService()
@@ -22,9 +21,9 @@ describe('pluginTemplateContextService', () => {
 
   it('shapes a sensors object keyed by kind for a device with readings across multiple kinds', () => {
     const sensors = [
-      { kind: 'temperature', value: 21.5, unit: 'C' },
-      { kind: 'humidity', value: 45, unit: '%' },
-    ] as DeviceSensor[]
+      makeDeviceSensor({ kind: 'temperature', value: 21.5, unit: 'C' }),
+      makeDeviceSensor({ kind: 'humidity', value: 45, unit: '%' }),
+    ]
 
     const context = service.build(plugin, sensors)
 
@@ -41,7 +40,7 @@ describe('pluginTemplateContextService', () => {
   })
 
   it('omits kinds the device has no current reading for', () => {
-    const sensors = [{ kind: 'pressure', value: 1013, unit: 'hPa' }] as DeviceSensor[]
+    const sensors = [makeDeviceSensor({ kind: 'pressure', value: 1013, unit: 'hPa' })]
 
     const context = service.build(plugin, sensors)
 

--- a/packages/api/src/plugins/__test__/plugin-template.entity.spec.ts
+++ b/packages/api/src/plugins/__test__/plugin-template.entity.spec.ts
@@ -1,10 +1,10 @@
-import type { Plugin } from '../entities/plugin.entity'
 import { describe, expect, it } from 'vitest'
+import { makePlugin } from '../../test/fixtures'
 import { PluginTemplate } from '../entities/plugin-template.entity'
 
 describe('pluginTemplate entity', () => {
   it('creates a template with required fields', () => {
-    const plugin = { id: 'plugin-1' } as Plugin
+    const plugin = makePlugin({ id: 'plugin-1' })
 
     const template = new PluginTemplate()
     template.id = 'template-1'

--- a/packages/api/src/plugins/__test__/plugin-transform.service.spec.ts
+++ b/packages/api/src/plugins/__test__/plugin-transform.service.spec.ts
@@ -15,7 +15,7 @@ describe('pluginTransformService', () => {
       };
     `
     const rawData = { value: 42 }
-    const result = service.transform(transformJs, rawData) as Record<string, any>
+    const result = service.transform(transformJs, rawData) as Record<string, unknown>
 
     expect(result.transformed).toBe(true)
     expect(result.original).toEqual({ value: 42 })
@@ -28,7 +28,7 @@ describe('pluginTransformService', () => {
       }
     `
     const rawData = { value: 10 }
-    const result = service.transform(transformJs, rawData) as Record<string, any>
+    const result = service.transform(transformJs, rawData) as Record<string, unknown>
 
     expect(result.doubled).toBe(20)
   })
@@ -55,7 +55,7 @@ describe('pluginTransformService', () => {
       };
     `
     const rawData = { items: [{ id: 1 }, { id: 2 }] }
-    const result = service.transform(transformJs, rawData) as Record<string, any>
+    const result = service.transform(transformJs, rawData) as { items: { processed: boolean }[] }
 
     expect(result.items).toHaveLength(2)
     expect(result.items[0].processed).toBe(true)
@@ -95,7 +95,7 @@ describe('pluginTransformService', () => {
       };
     `
     const rawData = { value: 42 }
-    const result = service.transform(transformJs, rawData) as Record<string, any>
+    const result = service.transform(transformJs, rawData) as Record<string, unknown>
 
     expect(result.logged).toBe(true)
   })

--- a/packages/api/src/plugins/__test__/plugin-variable-resolver.service.spec.ts
+++ b/packages/api/src/plugins/__test__/plugin-variable-resolver.service.spec.ts
@@ -1,5 +1,6 @@
 import type { PluginVariable } from '../entities/plugin-variable.entity'
 import { beforeEach, describe, expect, it } from 'vitest'
+import { makePluginVariable } from '../../test/fixtures'
 import { PluginVariableResolverService } from '../services/plugin-variable-resolver.service'
 
 describe('pluginVariableResolverService', () => {
@@ -10,8 +11,8 @@ describe('pluginVariableResolverService', () => {
   })
 
   const variables: PluginVariable[] = [
-    { key: 'API_KEY', value: 'secret-key-123' } as PluginVariable,
-    { key: 'ENDPOINT', value: 'https://api.example.com' } as PluginVariable,
+    makePluginVariable({ key: 'API_KEY', value: 'secret-key-123' }),
+    makePluginVariable({ key: 'ENDPOINT', value: 'https://api.example.com' }),
   ]
 
   describe('resolveVariables', () => {
@@ -53,8 +54,10 @@ describe('pluginVariableResolverService', () => {
     })
 
     it('returns text unchanged if text is null/undefined', () => {
-      expect(service.resolveVariables(null as any, variables)).toBe(null)
-      expect(service.resolveVariables(undefined as any, variables)).toBe(undefined)
+      // @ts-expect-error deliberately passing null to prove it's returned unchanged
+      expect(service.resolveVariables(null, variables)).toBe(null)
+      // @ts-expect-error deliberately passing undefined to prove it's returned unchanged
+      expect(service.resolveVariables(undefined, variables)).toBe(undefined)
     })
 
     it('resolves env vars when no plugin variables match', () => {
@@ -64,7 +67,7 @@ describe('pluginVariableResolverService', () => {
         // eslint-disable-next-line no-template-curly-in-string
         const text = 'Env: ${TEST_KUROSHIRO_VAR}'
         const variables: PluginVariable[] = [
-          { key: 'OTHER_VAR', value: 'other' } as PluginVariable,
+          makePluginVariable({ key: 'OTHER_VAR', value: 'other' }),
         ]
         const result = service.resolveVariables(text, variables)
         expect(result).toBe('Env: test-value')

--- a/packages/api/src/plugins/__test__/plugins.controller.spec.ts
+++ b/packages/api/src/plugins/__test__/plugins.controller.spec.ts
@@ -1,17 +1,33 @@
 import type { Response } from 'express'
-import type { Plugin } from '../entities/plugin.entity'
 import type { PluginsService } from '../plugins.service'
 import type { PluginExporterService } from '../services/plugin-exporter.service'
 import type { PluginImporterService } from '../services/plugin-importer.service'
 import { Buffer } from 'node:buffer'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { makePlugin } from '../../test/fixtures'
+import { asService } from '../../test/mockService'
 import { PluginsController } from '../plugins.controller'
 
 describe('pluginsController', () => {
   let controller: PluginsController
-  let mockService: PluginsService
-  let mockImporter: PluginImporterService
-  let mockExporter: PluginExporterService
+  let mockService: {
+    findAll: ReturnType<typeof vi.fn>
+    findById: ReturnType<typeof vi.fn>
+    findByDevice: ReturnType<typeof vi.fn>
+    create: ReturnType<typeof vi.fn>
+    update: ReturnType<typeof vi.fn>
+    remove: ReturnType<typeof vi.fn>
+    assignToDevice: ReturnType<typeof vi.fn>
+    unassignFromDevice: ReturnType<typeof vi.fn>
+    updateDeviceAssignment: ReturnType<typeof vi.fn>
+    preview: ReturnType<typeof vi.fn>
+  }
+  let mockImporter: {
+    importFromFile: ReturnType<typeof vi.fn>
+    importFromGithubUrl: ReturnType<typeof vi.fn>
+    importFromRecipe: ReturnType<typeof vi.fn>
+  }
+  let mockExporter: { exportToZip: ReturnType<typeof vi.fn> }
 
   beforeEach(() => {
     mockService = {
@@ -25,37 +41,36 @@ describe('pluginsController', () => {
       unassignFromDevice: vi.fn(),
       updateDeviceAssignment: vi.fn(),
       preview: vi.fn(),
-    } as any
+    }
 
     mockImporter = {
       importFromFile: vi.fn(),
       importFromGithubUrl: vi.fn(),
       importFromRecipe: vi.fn(),
-    } as any
+    }
 
     mockExporter = {
       exportToZip: vi.fn(),
-    } as any
+    }
 
-    controller = new PluginsController(mockService, mockImporter, mockExporter)
+    controller = new PluginsController(
+      asService<PluginsService>(mockService),
+      asService<PluginImporterService>(mockImporter),
+      asService<PluginExporterService>(mockExporter),
+    )
   })
 
-  const basePlugin = {
+  const basePlugin = makePlugin({
     id: '1',
     name: 'Weather Plugin',
     description: 'Shows weather',
     kind: 'Poll',
     refreshInterval: 15,
-    isActive: true,
-    order: 1,
-    device: { id: 'device-1' },
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  } as unknown as Plugin
+  })
 
   it('findAll returns all plugins', async () => {
     const plugins = [basePlugin]
-    ;(mockService.findAll as any).mockResolvedValue(plugins)
+    mockService.findAll.mockResolvedValue(plugins)
 
     const result = await controller.findAll()
 
@@ -64,7 +79,7 @@ describe('pluginsController', () => {
   })
 
   it('findById returns a plugin by id', async () => {
-    ;(mockService.findById as any).mockResolvedValue(basePlugin)
+    mockService.findById.mockResolvedValue(basePlugin)
 
     const result = await controller.findById('1')
 
@@ -74,7 +89,7 @@ describe('pluginsController', () => {
 
   it('findByDevice returns plugins for a device', async () => {
     const plugins = [basePlugin]
-    ;(mockService.findByDevice as any).mockResolvedValue(plugins)
+    mockService.findByDevice.mockResolvedValue(plugins)
 
     const result = await controller.findByDevice('device-1')
 
@@ -83,8 +98,8 @@ describe('pluginsController', () => {
   })
 
   it('create creates a new plugin', async () => {
-    const createDto = { name: 'Weather Plugin', deviceId: 'device-1', kind: 'Poll' as const }
-    ;(mockService.create as any).mockResolvedValue(basePlugin)
+    const createDto = { name: 'Weather Plugin', kind: 'Poll' as const }
+    mockService.create.mockResolvedValue(basePlugin)
 
     const result = await controller.create(createDto)
 
@@ -94,8 +109,8 @@ describe('pluginsController', () => {
 
   it('update updates a plugin', async () => {
     const updateDto = { name: 'Updated Weather' }
-    const updated = { ...basePlugin, name: 'Updated Weather' } as unknown as Plugin
-    ;(mockService.update as any).mockResolvedValue(updated)
+    const updated = { ...basePlugin, name: 'Updated Weather' }
+    mockService.update.mockResolvedValue(updated)
 
     const result = await controller.update('1', updateDto)
 
@@ -104,7 +119,7 @@ describe('pluginsController', () => {
   })
 
   it('remove deletes a plugin', async () => {
-    ;(mockService.remove as any).mockResolvedValue(true)
+    mockService.remove.mockResolvedValue(true)
 
     const result = await controller.remove('1')
 
@@ -118,9 +133,9 @@ describe('pluginsController', () => {
       template: '<div>{{ source }}</div>',
     }
     const previewResult = { html: '<div>test</div>', data: { source: { test: true } } }
-    ;(mockService.preview as any).mockResolvedValue(previewResult)
+    mockService.preview.mockResolvedValue(previewResult)
 
-    const result = await controller.preview(previewData as any)
+    const result = await controller.preview(previewData)
 
     expect(result).toBe(previewResult)
     expect(mockService.preview).toHaveBeenCalledWith(
@@ -131,14 +146,14 @@ describe('pluginsController', () => {
   })
 
   it('importPlugin imports from file without device assignment', async () => {
-    const file = { path: '/tmp/plugin.zip' } as Express.Multer.File
+    const file = asService<Express.Multer.File>({ path: '/tmp/plugin.zip' })
     const parsedPlugin = {
       name: 'Imported Plugin',
       dataSources: [{ name: 'source', url: 'https://api.com', method: 'GET', headers: {}, body: {} }],
     }
     const createdPlugin = { id: 'plugin-1', name: 'Imported Plugin' }
-    ;(mockImporter.importFromFile as any).mockResolvedValue(parsedPlugin)
-    ;(mockService.create as any).mockResolvedValue(createdPlugin)
+    mockImporter.importFromFile.mockResolvedValue(parsedPlugin)
+    mockService.create.mockResolvedValue(createdPlugin)
 
     const result = await controller.importPlugin(file)
 
@@ -150,7 +165,7 @@ describe('pluginsController', () => {
   })
 
   it('importPlugin imports from file with device assignment', async () => {
-    const file = { path: '/tmp/plugin.zip' } as Express.Multer.File
+    const file = asService<Express.Multer.File>({ path: '/tmp/plugin.zip' })
     const parsedPlugin = {
       name: 'Imported Plugin',
       dataSources: [{
@@ -163,9 +178,9 @@ describe('pluginsController', () => {
       }],
     }
     const createdPlugin = { id: 'plugin-1', name: 'Imported Plugin' }
-    ;(mockImporter.importFromFile as any).mockResolvedValue(parsedPlugin)
-    ;(mockService.create as any).mockResolvedValue(createdPlugin)
-    ;(mockService.assignToDevice as any).mockResolvedValue({})
+    mockImporter.importFromFile.mockResolvedValue(parsedPlugin)
+    mockService.create.mockResolvedValue(createdPlugin)
+    mockService.assignToDevice.mockResolvedValue({})
 
     const result = await controller.importPlugin(file, 'device-1')
 
@@ -178,7 +193,8 @@ describe('pluginsController', () => {
   })
 
   it('importPlugin throws error if no file uploaded', async () => {
-    await expect(controller.importPlugin(undefined as any)).rejects.toThrow('No file uploaded')
+    // @ts-expect-error file is intentionally omitted to prove the controller rejects a missing upload
+    await expect(controller.importPlugin(undefined)).rejects.toThrow('No file uploaded')
   })
 
   it('importFromGithub imports from GitHub URL without device assignment', async () => {
@@ -188,8 +204,8 @@ describe('pluginsController', () => {
       dataSources: [{ name: 'source', url: 'https://api.com', method: 'GET', headers: {}, body: {} }],
     }
     const createdPlugin = { id: 'plugin-2', name: 'GitHub Plugin' }
-    ;(mockImporter.importFromGithubUrl as any).mockResolvedValue(parsedPlugin)
-    ;(mockService.create as any).mockResolvedValue(createdPlugin)
+    mockImporter.importFromGithubUrl.mockResolvedValue(parsedPlugin)
+    mockService.create.mockResolvedValue(createdPlugin)
 
     const result = await controller.importFromGithub(body)
 
@@ -206,9 +222,9 @@ describe('pluginsController', () => {
       dataSources: [{ name: 'source', url: 'https://api.com', method: 'GET', headers: {}, body: {} }],
     }
     const createdPlugin = { id: 'plugin-2', name: 'GitHub Plugin' }
-    ;(mockImporter.importFromGithubUrl as any).mockResolvedValue(parsedPlugin)
-    ;(mockService.create as any).mockResolvedValue(createdPlugin)
-    ;(mockService.assignToDevice as any).mockResolvedValue({})
+    mockImporter.importFromGithubUrl.mockResolvedValue(parsedPlugin)
+    mockService.create.mockResolvedValue(createdPlugin)
+    mockService.assignToDevice.mockResolvedValue({})
 
     await controller.importFromGithub(body)
 
@@ -231,8 +247,8 @@ describe('pluginsController', () => {
       sourceRecipeId: '150460',
     }
     const createdPlugin = { id: 'plugin-3', name: 'Daily Weather' }
-    ;(mockImporter.importFromRecipe as any).mockResolvedValue(parsedPlugin)
-    ;(mockService.create as any).mockResolvedValue(createdPlugin)
+    mockImporter.importFromRecipe.mockResolvedValue(parsedPlugin)
+    mockService.create.mockResolvedValue(createdPlugin)
 
     const result = await controller.importFromRecipe(body)
 
@@ -251,9 +267,9 @@ describe('pluginsController', () => {
       sourceRecipeId: '150460',
     }
     const createdPlugin = { id: 'plugin-3', name: 'Daily Weather' }
-    ;(mockImporter.importFromRecipe as any).mockResolvedValue(parsedPlugin)
-    ;(mockService.create as any).mockResolvedValue(createdPlugin)
-    ;(mockService.assignToDevice as any).mockResolvedValue({})
+    mockImporter.importFromRecipe.mockResolvedValue(parsedPlugin)
+    mockService.create.mockResolvedValue(createdPlugin)
+    mockService.assignToDevice.mockResolvedValue({})
 
     const result = await controller.importFromRecipe(body)
 
@@ -272,13 +288,13 @@ describe('pluginsController', () => {
   it('exportPlugin exports plugin as ZIP', async () => {
     const plugin = { id: '1', name: 'Test Plugin' }
     const zipBuffer = Buffer.from('zip-content')
-    ;(mockService.findById as any).mockResolvedValue(plugin)
-    ;(mockExporter.exportToZip as any).mockResolvedValue(zipBuffer)
+    mockService.findById.mockResolvedValue(plugin)
+    mockExporter.exportToZip.mockResolvedValue(zipBuffer)
 
-    const res = {
+    const res = asService<Response>({
       setHeader: vi.fn(),
       send: vi.fn(),
-    } as unknown as Response
+    })
 
     await controller.exportPlugin('1', res)
 
@@ -290,12 +306,12 @@ describe('pluginsController', () => {
   })
 
   it('exportPlugin returns 404 if plugin not found', async () => {
-    ;(mockService.findById as any).mockResolvedValue(null)
+    mockService.findById.mockResolvedValue(null)
 
-    const res = {
+    const res = asService<Response>({
       status: vi.fn().mockReturnThis(),
       json: vi.fn(),
-    } as unknown as Response
+    })
 
     await controller.exportPlugin('1', res)
 
@@ -306,16 +322,16 @@ describe('pluginsController', () => {
   it('assignToDevice assigns plugin to device', async () => {
     const assignData = { deviceId: 'device-1', isActive: true, order: 0 }
     const devicePlugin = { id: 'dp-1' }
-    ;(mockService.assignToDevice as any).mockResolvedValue(devicePlugin)
+    mockService.assignToDevice.mockResolvedValue(devicePlugin)
 
-    const result = await controller.assignToDevice('plugin-1', assignData as any)
+    const result = await controller.assignToDevice('plugin-1', assignData)
 
     expect(result).toBe(devicePlugin)
     expect(mockService.assignToDevice).toHaveBeenCalledWith('plugin-1', assignData)
   })
 
   it('unassignFromDevice removes plugin from device', async () => {
-    ;(mockService.unassignFromDevice as any).mockResolvedValue(true)
+    mockService.unassignFromDevice.mockResolvedValue(true)
 
     const result = await controller.unassignFromDevice('plugin-1', 'device-1')
 
@@ -326,7 +342,7 @@ describe('pluginsController', () => {
   it('updateDeviceAssignment updates device assignment', async () => {
     const updates = { isActive: false }
     const devicePlugin = { id: 'dp-1', isActive: false }
-    ;(mockService.updateDeviceAssignment as any).mockResolvedValue(devicePlugin)
+    mockService.updateDeviceAssignment.mockResolvedValue(devicePlugin)
 
     const result = await controller.updateDeviceAssignment('dp-1', updates)
 

--- a/packages/api/src/plugins/__test__/plugins.service.spec.ts
+++ b/packages/api/src/plugins/__test__/plugins.service.spec.ts
@@ -845,7 +845,7 @@ describe('pluginsService', () => {
     it('update accepts a body that omits kind entirely, and leaves kind and other unset fields untouched', async () => {
       const stored = { ...basePlugin }
       pluginRepo.findOne.mockResolvedValue(stored)
-      pluginRepo.save.mockImplementation(async (plugin: any) => plugin)
+      pluginRepo.save.mockImplementation(plugin => Promise.resolve(makePlugin(plugin)))
 
       const result = await service.update('1', transform({ description: 'test only' }))
 
@@ -860,7 +860,7 @@ describe('pluginsService', () => {
     })
 
     it('update accepts a webhook-kind body that omits mergeStrategy entirely, and leaves it untouched', async () => {
-      const stored = {
+      const stored = makePlugin({
         id: '1',
         name: 'Sensor Feed',
         kind: 'Webhook',
@@ -868,9 +868,9 @@ describe('pluginsService', () => {
         webhookToken: 'token-abc',
         mergeStrategy: 'stream',
         streamLimit: 20,
-      } as unknown as Plugin
+      })
       pluginRepo.findOne.mockResolvedValue(stored)
-      pluginRepo.save.mockImplementation(async (plugin: any) => plugin)
+      pluginRepo.save.mockImplementation(plugin => Promise.resolve(makePlugin(plugin)))
 
       const result = await service.update('1', transform({ description: 'test only' }))
 

--- a/packages/api/src/plugins/__test__/plugins.service.spec.ts
+++ b/packages/api/src/plugins/__test__/plugins.service.spec.ts
@@ -255,6 +255,7 @@ describe('pluginsService', () => {
       dataSources: [
         {
           name: 'weather',
+          mode: 'fetch' as const,
           url: 'https://api.example.com',
           method: 'GET',
           headers: {},
@@ -294,18 +295,19 @@ describe('pluginsService', () => {
   it('create builds a literal-mode data source with its literalValue and no fetch fields', async () => {
     const pluginData = {
       name: 'Static Plugin',
+      kind: 'Poll' as const,
       dataSources: [
-        { name: 'title', mode: 'literal', literalValue: { text: 'Hello' } },
+        { name: 'title', mode: 'literal' as const, literalValue: { text: 'Hello' } },
       ],
     }
 
-    const savedPlugin = { ...basePlugin, id: '2' } as Plugin
+    const savedPlugin = { ...basePlugin, id: '2' }
     pluginRepo.save.mockResolvedValue(savedPlugin)
-    dataSourceRepo.create.mockReturnValue({})
-    dataSourceRepo.save.mockResolvedValue({})
+    dataSourceRepo.create.mockReturnValue(makePluginDataSource())
+    dataSourceRepo.save.mockResolvedValue(makePluginDataSource())
     pluginRepo.findOne.mockResolvedValue(savedPlugin)
 
-    await service.create(pluginData as any)
+    await service.create(pluginData)
 
     expect(dataSourceRepo.create).toHaveBeenCalledWith(expect.objectContaining({
       name: 'title',
@@ -318,29 +320,31 @@ describe('pluginsService', () => {
   it('create tolerates a literal-mode data source carrying method "GET", the entity column\'s non-nullable default rather than a real fetch field', async () => {
     const pluginData = {
       name: 'Round-tripped Static Plugin',
+      kind: 'Poll' as const,
       dataSources: [
-        { name: 'title', mode: 'literal', literalValue: { text: 'Hello' }, method: 'GET' },
+        { name: 'title', mode: 'literal' as const, literalValue: { text: 'Hello' }, method: 'GET' },
       ],
     }
 
-    const savedPlugin = { ...basePlugin, id: '2' } as Plugin
+    const savedPlugin = { ...basePlugin, id: '2' }
     pluginRepo.save.mockResolvedValue(savedPlugin)
-    dataSourceRepo.create.mockReturnValue({})
-    dataSourceRepo.save.mockResolvedValue({})
+    dataSourceRepo.create.mockReturnValue(makePluginDataSource())
+    dataSourceRepo.save.mockResolvedValue(makePluginDataSource())
     pluginRepo.findOne.mockResolvedValue(savedPlugin)
 
-    await expect(service.create(pluginData as any)).resolves.toBe(savedPlugin)
+    await expect(service.create(pluginData)).resolves.toBe(savedPlugin)
   })
 
   it('create rejects a literal-mode data source that also carries a URL', async () => {
     const pluginData = {
       name: 'Bad Static Plugin',
+      kind: 'Poll' as const,
       dataSources: [
-        { name: 'title', mode: 'literal', literalValue: { text: 'Hello' }, url: 'https://api.example.com' },
+        { name: 'title', mode: 'literal' as const, literalValue: { text: 'Hello' }, url: 'https://api.example.com' },
       ],
     }
 
-    await expect(service.create(pluginData as any)).rejects.toThrow('A literal-mode Data Source cannot have a URL')
+    await expect(service.create(pluginData)).rejects.toThrow('A literal-mode Data Source cannot have a URL')
     expect(pluginRepo.save).not.toHaveBeenCalled()
   })
 
@@ -420,7 +424,7 @@ describe('pluginsService', () => {
     pluginRepo.save.mockResolvedValue(pluginWithoutDataSources)
 
     await service.update('1', {
-      dataSources: [{ name: 'weather', url: 'https://new-api.com', method: 'GET', headers: {}, body: {} }],
+      dataSources: [{ name: 'weather', mode: 'fetch', url: 'https://new-api.com', method: 'GET', headers: {}, body: {} }],
     })
 
     expect(dataSourceRepo.create).toHaveBeenCalled()
@@ -439,7 +443,7 @@ describe('pluginsService', () => {
     pluginRepo.save.mockResolvedValue(pluginWithDataSources)
 
     const result = await service.update('1', {
-      dataSources: [{ name: 'weather', url: 'https://new-api.com', method: 'GET' }],
+      dataSources: [{ name: 'weather', mode: 'fetch', url: 'https://new-api.com', method: 'GET' }],
     })
 
     expect(dataSourceRepo.remove).toHaveBeenCalledWith(oldDataSources)
@@ -452,7 +456,7 @@ describe('pluginsService', () => {
     pluginRepo.findOne.mockResolvedValue({ ...basePlugin, dataSources: [], fields: [] })
 
     await expect(service.update('1', {
-      dataSources: [{ name: 'trmnl', url: 'https://api.com', method: 'GET' }],
+      dataSources: [{ name: 'trmnl', mode: 'fetch', url: 'https://api.com', method: 'GET' }],
     })).rejects.toThrow('reserved')
 
     expect(dataSourceRepo.save).not.toHaveBeenCalled()
@@ -463,8 +467,8 @@ describe('pluginsService', () => {
 
     await expect(service.update('1', {
       dataSources: [
-        { name: 'weather', url: 'https://api.com/1', method: 'GET' },
-        { name: 'weather', url: 'https://api.com/2', method: 'GET' },
+        { name: 'weather', mode: 'fetch', url: 'https://api.com/1', method: 'GET' },
+        { name: 'weather', mode: 'fetch', url: 'https://api.com/2', method: 'GET' },
       ],
     })).rejects.toThrow('more than one data source')
   })
@@ -477,7 +481,7 @@ describe('pluginsService', () => {
     })
 
     await expect(service.update('1', {
-      dataSources: [{ name: 'weather', url: 'https://api.com', method: 'GET' }],
+      dataSources: [{ name: 'weather', mode: 'fetch', url: 'https://api.com', method: 'GET' }],
     })).rejects.toThrow('collides')
   })
 
@@ -541,7 +545,7 @@ describe('pluginsService', () => {
     pluginRepo.save.mockResolvedValue(pluginWithDataSource)
 
     await service.update('1', {
-      dataSources: [{ name: 'weather', url: 'https://new-api.com', method: 'GET' }],
+      dataSources: [{ name: 'weather', mode: 'fetch', url: 'https://new-api.com', method: 'GET' }],
     })
 
     expect(mockScheduler.removeScheduledJob).toHaveBeenCalledWith('1')
@@ -564,7 +568,7 @@ describe('pluginsService', () => {
     await service.create({
       name: 'Plugin',
       kind: 'Poll',
-      dataSources: [{ name: 'weather', url: 'https://api.com', method: 'GET', headers: {}, body: {} }],
+      dataSources: [{ name: 'weather', mode: 'fetch', url: 'https://api.com', method: 'GET', headers: {}, body: {} }],
       templates: [{ layout: 'full', liquidMarkup: 'Template' }],
     })
 
@@ -608,7 +612,7 @@ describe('pluginsService', () => {
     await expect(service.create({
       name: 'Plugin',
       kind: 'Poll',
-      dataSources: [{ name: 'trmnl', url: 'https://api.com', method: 'GET' }],
+      dataSources: [{ name: 'trmnl', mode: 'fetch', url: 'https://api.com', method: 'GET' }],
     })).rejects.toThrow('reserved')
 
     expect(pluginRepo.save).not.toHaveBeenCalled()
@@ -620,7 +624,7 @@ describe('pluginsService', () => {
     await expect(service.create({
       name: 'Plugin',
       kind: 'Poll',
-      dataSources: [{ name: 'weather', url: 'https://api.com', method: 'GET' }],
+      dataSources: [{ name: 'weather', mode: 'fetch', url: 'https://api.com', method: 'GET' }],
       fields: [{ keyname: 'weather', fieldType: 'string', name: 'Weather' }],
     })).rejects.toThrow('collides')
   })
@@ -750,7 +754,7 @@ describe('pluginsService', () => {
         name: 'Sensor Feed',
         kind: 'Webhook',
         mergeStrategy: 'standard',
-        dataSources: [{ name: 'source', url: 'https://api.example.com' }],
+        dataSources: [{ name: 'source', mode: 'fetch', url: 'https://api.example.com' }],
       })).rejects.toThrow('A Webhook-kind Plugin cannot have Data Sources')
     })
 

--- a/packages/api/src/plugins/__test__/plugins.service.spec.ts
+++ b/packages/api/src/plugins/__test__/plugins.service.spec.ts
@@ -1,5 +1,9 @@
-import type { Repository } from 'typeorm'
+import type { Screen } from '../../screens/screens.entity'
+import type { MockPluginDataFetcherService, MockPluginRendererService, MockPluginTransformService } from '../../test/mockPluginCollaborators'
 import type { DevicePlugin } from '../entities/device-plugin.entity'
+import type { PluginDataSource } from '../entities/plugin-data-source.entity'
+import type { PluginField } from '../entities/plugin-field.entity'
+import type { PluginTemplate } from '../entities/plugin-template.entity'
 import type { Plugin } from '../entities/plugin.entity'
 import type { PluginDataFetcherService } from '../services/plugin-data-fetcher.service'
 import type { PluginRendererService } from '../services/plugin-renderer.service'
@@ -7,94 +11,64 @@ import type { PluginSchedulerService } from '../services/plugin-scheduler.servic
 import type { PluginTransformService } from '../services/plugin-transform.service'
 import { plainToInstance } from 'class-transformer'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { makeDevicePlugin, makePlugin, makePluginDataSource, makePluginField, makePluginTemplate, makeScreen } from '../../test/fixtures'
+import { createMockPluginDataFetcherService, createMockPluginRendererService, createMockPluginTransformService } from '../../test/mockPluginCollaborators'
+import { asRepository, createMockRepository } from '../../test/mockRepository'
+import { asService, injectPrivate } from '../../test/mockService'
 import { UpdatePluginDto } from '../dto/update-plugin.dto'
 import { PluginsService } from '../plugins.service'
 
-interface MockRepository {
-  find: ReturnType<typeof vi.fn>
-  findOne: ReturnType<typeof vi.fn>
-  findOneBy: ReturnType<typeof vi.fn>
-  create: ReturnType<typeof vi.fn>
-  save: ReturnType<typeof vi.fn>
-  remove: ReturnType<typeof vi.fn>
-  update: ReturnType<typeof vi.fn>
-  maximum: ReturnType<typeof vi.fn>
-  delete?: ReturnType<typeof vi.fn>
-}
-
-function createMockRepository(): MockRepository {
-  return {
-    find: vi.fn(),
-    findOne: vi.fn(),
-    findOneBy: vi.fn(),
-    create: vi.fn(),
-    save: vi.fn(),
-    remove: vi.fn(),
-    update: vi.fn(),
-    maximum: vi.fn(),
-  }
-}
-
 describe('pluginsService', () => {
   let service: PluginsService
-  let pluginRepo: MockRepository
-  let devicePluginRepo: MockRepository
-  let screenRepo: MockRepository
-  let dataSourceRepo: MockRepository
-  let templateRepo: MockRepository
-  let fieldRepo: MockRepository
-  let mockDataFetcher: PluginDataFetcherService
-  let mockRenderer: PluginRendererService
-  let mockScheduler: PluginSchedulerService
-  let mockTransformer: PluginTransformService
+  let pluginRepo: ReturnType<typeof createMockRepository<Plugin>>
+  let devicePluginRepo: ReturnType<typeof createMockRepository<DevicePlugin>>
+  let screenRepo: ReturnType<typeof createMockRepository<Screen>>
+  let dataSourceRepo: ReturnType<typeof createMockRepository<PluginDataSource>>
+  let templateRepo: ReturnType<typeof createMockRepository<PluginTemplate>>
+  let fieldRepo: ReturnType<typeof createMockRepository<PluginField>>
+  let mockDataFetcher: MockPluginDataFetcherService
+  let mockRenderer: MockPluginRendererService
+  let mockScheduler: { schedulePlugin: ReturnType<typeof vi.fn>, removeScheduledJob: ReturnType<typeof vi.fn>, hasScheduledJob: ReturnType<typeof vi.fn> }
+  let mockTransformer: MockPluginTransformService
 
   beforeEach(() => {
-    pluginRepo = createMockRepository()
-    devicePluginRepo = createMockRepository()
-    screenRepo = createMockRepository()
-    dataSourceRepo = createMockRepository()
-    templateRepo = createMockRepository()
-    fieldRepo = createMockRepository()
+    pluginRepo = createMockRepository<Plugin>()
+    devicePluginRepo = createMockRepository<DevicePlugin>()
+    screenRepo = createMockRepository<Screen>()
+    dataSourceRepo = createMockRepository<PluginDataSource>()
+    templateRepo = createMockRepository<PluginTemplate>()
+    fieldRepo = createMockRepository<PluginField>()
 
-    mockDataFetcher = {
-      fetchData: vi.fn(),
-      fetchOrLiteral: vi.fn((source: any, ctx: any) =>
-        source.mode === 'literal'
-          ? Promise.resolve(source.literalValue ?? null)
-          : mockDataFetcher.fetchData(source.method || 'GET', source.url || '', source.headers, source.body, ctx),
-      ),
-    } as any
-    mockRenderer = { render: vi.fn() } as any
+    mockDataFetcher = createMockPluginDataFetcherService()
+    mockRenderer = createMockPluginRendererService()
     mockScheduler = {
       schedulePlugin: vi.fn(),
       removeScheduledJob: vi.fn(),
       hasScheduledJob: vi.fn(),
-    } as any
-    mockTransformer = { transform: vi.fn() } as any
+    }
+    mockTransformer = createMockPluginTransformService()
 
     service = new PluginsService(
-      pluginRepo as unknown as Repository<Plugin>,
-      devicePluginRepo as unknown as Repository<DevicePlugin>,
-      screenRepo as unknown as Repository<any>,
-      dataSourceRepo as unknown as Repository<any>,
-      templateRepo as unknown as Repository<any>,
-      fieldRepo as unknown as Repository<any>,
-      mockDataFetcher,
-      mockRenderer,
-      mockScheduler,
-      mockTransformer,
+      asRepository(pluginRepo),
+      asRepository(devicePluginRepo),
+      asRepository(screenRepo),
+      asRepository(dataSourceRepo),
+      asRepository(templateRepo),
+      asRepository(fieldRepo),
+      asService<PluginDataFetcherService>(mockDataFetcher),
+      asService<PluginRendererService>(mockRenderer),
+      asService<PluginSchedulerService>(mockScheduler),
+      asService<PluginTransformService>(mockTransformer),
     )
   })
 
-  const basePlugin = {
+  const basePlugin: Plugin = makePlugin({
     id: '1',
     name: 'Weather Plugin',
     description: 'Shows weather',
     kind: 'Poll',
     refreshInterval: 15,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  } as unknown as Plugin
+  })
 
   it('findAll returns all plugins ordered by name', async () => {
     const plugins = [basePlugin]
@@ -118,12 +92,12 @@ describe('pluginsService', () => {
   })
 
   it('findByDevice returns plugins for a specific device', async () => {
-    const devicePlugins = [{
+    const devicePlugins = [makeDevicePlugin({
       id: 'dp-1',
       isActive: true,
       order: 1,
       plugin: basePlugin,
-    }]
+    })]
     devicePluginRepo.find.mockResolvedValue(devicePlugins)
     const result = await service.findByDevice('device-1')
     expect(devicePluginRepo.find).toHaveBeenCalledWith({
@@ -136,10 +110,10 @@ describe('pluginsService', () => {
   })
 
   it('create creates and saves a new plugin', async () => {
-    const pluginData = { name: 'Weather Plugin' }
+    const pluginData = { name: 'Weather Plugin', kind: 'Poll' as const }
     pluginRepo.save.mockResolvedValue(basePlugin)
     pluginRepo.findOne.mockResolvedValue(basePlugin)
-    const result = await service.create(pluginData as any)
+    const result = await service.create(pluginData)
     expect(pluginRepo.save).toHaveBeenCalled()
     expect(pluginRepo.findOne).toHaveBeenCalledWith({
       where: { id: '1' },
@@ -149,20 +123,20 @@ describe('pluginsService', () => {
   })
 
   it('create persists the source Recipe id when provided', async () => {
-    const pluginData = { name: 'Daily Weather', sourceRecipeId: '150460' }
+    const pluginData = { name: 'Daily Weather', kind: 'Poll' as const, sourceRecipeId: '150460' }
     pluginRepo.save.mockResolvedValue(basePlugin)
     pluginRepo.findOne.mockResolvedValue(basePlugin)
 
-    await service.create(pluginData as any)
+    await service.create(pluginData)
 
     expect(pluginRepo.save).toHaveBeenCalledWith(expect.objectContaining({ sourceRecipeId: '150460' }))
   })
 
   it('update updates and saves an existing plugin', async () => {
     pluginRepo.findOne.mockResolvedValue(basePlugin)
-    const updated = { ...basePlugin, name: 'Updated Weather' } as unknown as Plugin
+    const updated = { ...basePlugin, name: 'Updated Weather' }
     pluginRepo.save.mockResolvedValue(updated)
-    const result = await service.update('1', { name: 'Updated Weather' } as any)
+    const result = await service.update('1', { name: 'Updated Weather' })
     expect(pluginRepo.findOne).toHaveBeenCalledWith({
       where: { id: '1' },
       relations: { dataSources: true, templates: true, fields: true },
@@ -173,13 +147,13 @@ describe('pluginsService', () => {
 
   it('update returns null if plugin not found', async () => {
     pluginRepo.findOne.mockResolvedValue(null)
-    const result = await service.update('1', { name: 'Updated' } as any)
+    const result = await service.update('1', { name: 'Updated' })
     expect(result).toBeNull()
   })
 
   it('remove deletes a plugin and returns true', async () => {
     pluginRepo.findOneBy.mockResolvedValue(basePlugin)
-    pluginRepo.remove.mockResolvedValue(undefined)
+    pluginRepo.remove.mockResolvedValue(basePlugin)
     const result = await service.remove('1')
     expect(pluginRepo.findOneBy).toHaveBeenCalledWith({ id: '1' })
     expect(pluginRepo.remove).toHaveBeenCalledWith(basePlugin)
@@ -195,7 +169,7 @@ describe('pluginsService', () => {
 
   it('checkPluginUsage returns empty array when not used in mashups', async () => {
     const mashupSlotRepo = { find: vi.fn().mockResolvedValue([]) }
-    ;(service as any).mashupSlotRepository = mashupSlotRepo
+    injectPrivate(service, 'mashupSlotRepository', mashupSlotRepo)
 
     const result = await service.checkPluginUsage('plugin-1')
 
@@ -225,7 +199,7 @@ describe('pluginsService', () => {
         },
       ]),
     }
-    ;(service as any).mashupSlotRepository = mashupSlotRepo
+    injectPrivate(service, 'mashupSlotRepository', mashupSlotRepo)
 
     const result = await service.checkPluginUsage('plugin-1')
 
@@ -246,7 +220,7 @@ describe('pluginsService', () => {
         },
       ]),
     }
-    ;(service as any).mashupSlotRepository = mashupSlotRepo
+    injectPrivate(service, 'mashupSlotRepository', mashupSlotRepo)
 
     await expect(service.remove('1', false)).rejects.toThrow('Plugin is used in 1 mashup(s)')
     expect(pluginRepo.remove).not.toHaveBeenCalled()
@@ -254,7 +228,7 @@ describe('pluginsService', () => {
 
   it('remove with force=true deletes plugin even if used in mashups', async () => {
     pluginRepo.findOneBy.mockResolvedValue(basePlugin)
-    pluginRepo.remove.mockResolvedValue(undefined)
+    pluginRepo.remove.mockResolvedValue(basePlugin)
 
     const mashupSlotRepo = {
       find: vi.fn().mockResolvedValue([
@@ -265,7 +239,7 @@ describe('pluginsService', () => {
         },
       ]),
     }
-    ;(service as any).mashupSlotRepository = mashupSlotRepo
+    injectPrivate(service, 'mashupSlotRepository', mashupSlotRepo)
 
     const result = await service.remove('1', true)
 
@@ -277,6 +251,7 @@ describe('pluginsService', () => {
   it('create saves plugin with dataSources, templates, and fields', async () => {
     const pluginData = {
       name: 'Complete Plugin',
+      kind: 'Poll' as const,
       dataSources: [
         {
           name: 'weather',
@@ -295,17 +270,17 @@ describe('pluginsService', () => {
       ],
     }
 
-    const savedPlugin = { ...basePlugin, id: '2' } as Plugin
+    const savedPlugin = { ...basePlugin, id: '2' }
     pluginRepo.save.mockResolvedValue(savedPlugin)
-    dataSourceRepo.create.mockReturnValue({})
-    dataSourceRepo.save.mockResolvedValue({})
-    templateRepo.create.mockReturnValue({})
-    templateRepo.save.mockResolvedValue({})
-    fieldRepo.create.mockReturnValue({})
-    fieldRepo.save.mockResolvedValue({})
+    dataSourceRepo.create.mockReturnValue(makePluginDataSource())
+    dataSourceRepo.save.mockResolvedValue(makePluginDataSource())
+    templateRepo.create.mockReturnValue(makePluginTemplate())
+    templateRepo.save.mockResolvedValue(makePluginTemplate())
+    fieldRepo.create.mockReturnValue(makePluginField())
+    fieldRepo.save.mockResolvedValue(makePluginField())
     pluginRepo.findOne.mockResolvedValue(savedPlugin)
 
-    const result = await service.create(pluginData as any)
+    const result = await service.create(pluginData)
 
     expect(dataSourceRepo.create).toHaveBeenCalled()
     expect(dataSourceRepo.save).toHaveBeenCalled()
@@ -370,18 +345,18 @@ describe('pluginsService', () => {
   })
 
   it('assignToDevice creates device plugin and screen', async () => {
-    const devicePlugin = { id: 'dp-1', isActive: true, order: 0 }
+    const devicePlugin = makeDevicePlugin({ id: 'dp-1', isActive: true, order: 0 })
     devicePluginRepo.create.mockReturnValue(devicePlugin)
     devicePluginRepo.save.mockResolvedValue(devicePlugin)
     screenRepo.maximum.mockResolvedValue(5)
-    screenRepo.create.mockReturnValue({})
-    screenRepo.save.mockResolvedValue({})
+    screenRepo.create.mockReturnValue(makeScreen())
+    screenRepo.save.mockResolvedValue(makeScreen())
 
     const result = await service.assignToDevice('plugin-1', {
       deviceId: 'device-1',
       isActive: true,
       order: 1,
-    } as any)
+    })
 
     expect(devicePluginRepo.create).toHaveBeenCalled()
     expect(devicePluginRepo.save).toHaveBeenCalled()
@@ -391,9 +366,9 @@ describe('pluginsService', () => {
   })
 
   it('unassignFromDevice removes device plugin and screen', async () => {
-    const devicePlugin = { id: 'dp-1' }
+    const devicePlugin = makeDevicePlugin({ id: 'dp-1' })
     devicePluginRepo.findOne.mockResolvedValue(devicePlugin)
-    devicePluginRepo.remove.mockResolvedValue(undefined)
+    devicePluginRepo.remove.mockResolvedValue(devicePlugin)
     screenRepo.delete = vi.fn().mockResolvedValue(undefined)
 
     const result = await service.unassignFromDevice('plugin-1', 'device-1')
@@ -413,7 +388,7 @@ describe('pluginsService', () => {
   })
 
   it('updateDeviceAssignment updates device plugin and screen', async () => {
-    const devicePlugin = { id: 'dp-1', isActive: true }
+    const devicePlugin = makeDevicePlugin({ id: 'dp-1', isActive: true })
     const updated = { ...devicePlugin, isActive: false }
     devicePluginRepo.findOneBy.mockResolvedValue(devicePlugin)
     devicePluginRepo.save.mockResolvedValue(updated)
@@ -440,38 +415,37 @@ describe('pluginsService', () => {
   it('update creates new data sources if none exist', async () => {
     const pluginWithoutDataSources = { ...basePlugin, dataSources: [] }
     pluginRepo.findOne.mockResolvedValue(pluginWithoutDataSources)
-    dataSourceRepo.create.mockReturnValue({ id: 'ds-1' })
-    dataSourceRepo.save.mockResolvedValue({ id: 'ds-1' })
+    dataSourceRepo.create.mockReturnValue(makePluginDataSource({ id: 'ds-1' }))
+    dataSourceRepo.save.mockResolvedValue(makePluginDataSource({ id: 'ds-1' }))
     pluginRepo.save.mockResolvedValue(pluginWithoutDataSources)
 
     await service.update('1', {
       dataSources: [{ name: 'weather', url: 'https://new-api.com', method: 'GET', headers: {}, body: {} }],
-    } as any)
+    })
 
     expect(dataSourceRepo.create).toHaveBeenCalled()
     expect(dataSourceRepo.save).toHaveBeenCalled()
   })
 
   it('update removes existing data sources and creates the replacement set', async () => {
-    const oldDataSources = [{ id: 'ds-old', name: 'old' }]
+    const oldDataSources = [makePluginDataSource({ id: 'ds-old', name: 'old' })]
     const pluginWithDataSources = {
       ...basePlugin,
       dataSources: oldDataSources,
     }
     pluginRepo.findOne.mockResolvedValue(pluginWithDataSources)
-    dataSourceRepo.remove.mockResolvedValue(undefined)
-    dataSourceRepo.create.mockReturnValue({ id: 'ds-new' })
-    dataSourceRepo.save.mockResolvedValue({ id: 'ds-new' })
+    dataSourceRepo.create.mockReturnValue(makePluginDataSource({ id: 'ds-new' }))
+    dataSourceRepo.save.mockResolvedValue(makePluginDataSource({ id: 'ds-new' }))
     pluginRepo.save.mockResolvedValue(pluginWithDataSources)
 
     const result = await service.update('1', {
       dataSources: [{ name: 'weather', url: 'https://new-api.com', method: 'GET' }],
-    } as any)
+    })
 
     expect(dataSourceRepo.remove).toHaveBeenCalledWith(oldDataSources)
     expect(dataSourceRepo.create).toHaveBeenCalled()
     // The returned plugin reflects the new data sources, not the removed ones
-    expect(result?.dataSources).toEqual([{ id: 'ds-new' }])
+    expect(result?.dataSources).toEqual([makePluginDataSource({ id: 'ds-new' })])
   })
 
   it('update rejects a data source named "trmnl"', async () => {
@@ -479,7 +453,7 @@ describe('pluginsService', () => {
 
     await expect(service.update('1', {
       dataSources: [{ name: 'trmnl', url: 'https://api.com', method: 'GET' }],
-    } as any)).rejects.toThrow('reserved')
+    })).rejects.toThrow('reserved')
 
     expect(dataSourceRepo.save).not.toHaveBeenCalled()
   })
@@ -492,31 +466,31 @@ describe('pluginsService', () => {
         { name: 'weather', url: 'https://api.com/1', method: 'GET' },
         { name: 'weather', url: 'https://api.com/2', method: 'GET' },
       ],
-    } as any)).rejects.toThrow('more than one data source')
+    })).rejects.toThrow('more than one data source')
   })
 
   it('update rejects a data source name colliding with a plugin field keyname', async () => {
     pluginRepo.findOne.mockResolvedValue({
       ...basePlugin,
       dataSources: [],
-      fields: [{ id: 'field-1', keyname: 'weather' }],
+      fields: [makePluginField({ id: 'field-1', keyname: 'weather' })],
     })
 
     await expect(service.update('1', {
       dataSources: [{ name: 'weather', url: 'https://api.com', method: 'GET' }],
-    } as any)).rejects.toThrow('collides')
+    })).rejects.toThrow('collides')
   })
 
   it('update creates new template if none exists', async () => {
     const pluginWithoutTemplates = { ...basePlugin, templates: [] }
     pluginRepo.findOne.mockResolvedValue(pluginWithoutTemplates)
-    templateRepo.create.mockReturnValue({ id: 't-1' })
-    templateRepo.save.mockResolvedValue({ id: 't-1' })
+    templateRepo.create.mockReturnValue(makePluginTemplate({ id: 't-1' }))
+    templateRepo.save.mockResolvedValue(makePluginTemplate({ id: 't-1' }))
     pluginRepo.save.mockResolvedValue(pluginWithoutTemplates)
 
     await service.update('1', {
       templates: [{ layout: 'full', liquidMarkup: 'New template' }],
-    } as any)
+    })
 
     expect(templateRepo.create).toHaveBeenCalled()
     expect(templateRepo.save).toHaveBeenCalled()
@@ -525,17 +499,16 @@ describe('pluginsService', () => {
   it('update replaces existing fields', async () => {
     const pluginWithFields = {
       ...basePlugin,
-      fields: [{ id: 'field-1', keyname: 'old_field' }],
+      fields: [makePluginField({ id: 'field-1', keyname: 'old_field' })],
     }
     pluginRepo.findOne.mockResolvedValue(pluginWithFields)
-    fieldRepo.remove.mockResolvedValue(undefined)
-    fieldRepo.create.mockReturnValue({ id: 'field-2' })
-    fieldRepo.save.mockResolvedValue({ id: 'field-2' })
+    fieldRepo.create.mockReturnValue(makePluginField({ id: 'field-2' }))
+    fieldRepo.save.mockResolvedValue(makePluginField({ id: 'field-2' }))
     pluginRepo.save.mockResolvedValue(pluginWithFields)
 
     await service.update('1', {
       fields: [{ keyname: 'new_field', fieldType: 'string', name: 'New Field', required: false }],
-    } as any)
+    })
 
     expect(fieldRepo.remove).toHaveBeenCalledWith(pluginWithFields.fields)
     expect(fieldRepo.create).toHaveBeenCalled()
@@ -545,13 +518,12 @@ describe('pluginsService', () => {
   it('update removes fields when empty array provided', async () => {
     const pluginWithFields = {
       ...basePlugin,
-      fields: [{ id: 'field-1', keyname: 'old_field' }],
+      fields: [makePluginField({ id: 'field-1', keyname: 'old_field' })],
     }
     pluginRepo.findOne.mockResolvedValue(pluginWithFields)
-    fieldRepo.remove.mockResolvedValue(undefined)
     pluginRepo.save.mockResolvedValue(pluginWithFields)
 
-    await service.update('1', { fields: [] } as any)
+    await service.update('1', { fields: [] })
 
     expect(fieldRepo.remove).toHaveBeenCalledWith(pluginWithFields.fields)
     expect(fieldRepo.create).not.toHaveBeenCalled()
@@ -560,8 +532,8 @@ describe('pluginsService', () => {
   it('update reschedules plugin when dataSources or templates change', async () => {
     const pluginWithDataSource = {
       ...basePlugin,
-      dataSources: [{ id: 'ds-1', name: 'weather', url: 'https://api.com' }],
-      templates: [{ id: 't-1', layout: 'full' }],
+      dataSources: [makePluginDataSource({ id: 'ds-1', name: 'weather', url: 'https://api.com' })],
+      templates: [makePluginTemplate({ id: 't-1', layout: 'full' })],
     }
     pluginRepo.findOne.mockResolvedValueOnce(pluginWithDataSource)
     pluginRepo.findOne.mockResolvedValueOnce(pluginWithDataSource)
@@ -570,7 +542,7 @@ describe('pluginsService', () => {
 
     await service.update('1', {
       dataSources: [{ name: 'weather', url: 'https://new-api.com', method: 'GET' }],
-    } as any)
+    })
 
     expect(mockScheduler.removeScheduledJob).toHaveBeenCalledWith('1')
     expect(mockScheduler.schedulePlugin).toHaveBeenCalledWith(pluginWithDataSource)
@@ -579,21 +551,22 @@ describe('pluginsService', () => {
   it('create schedules plugin when it has data sources and templates', async () => {
     const createdPlugin = {
       ...basePlugin,
-      dataSources: [{ id: 'ds-1', name: 'weather' }],
-      templates: [{ id: 't-1' }],
+      dataSources: [makePluginDataSource({ id: 'ds-1', name: 'weather' })],
+      templates: [makePluginTemplate({ id: 't-1' })],
     }
     pluginRepo.save.mockResolvedValue(basePlugin)
-    dataSourceRepo.create.mockReturnValue({})
-    dataSourceRepo.save.mockResolvedValue({})
-    templateRepo.create.mockReturnValue({})
-    templateRepo.save.mockResolvedValue({})
+    dataSourceRepo.create.mockReturnValue(makePluginDataSource())
+    dataSourceRepo.save.mockResolvedValue(makePluginDataSource())
+    templateRepo.create.mockReturnValue(makePluginTemplate())
+    templateRepo.save.mockResolvedValue(makePluginTemplate())
     pluginRepo.findOne.mockResolvedValue(createdPlugin)
 
     await service.create({
       name: 'Plugin',
+      kind: 'Poll',
       dataSources: [{ name: 'weather', url: 'https://api.com', method: 'GET', headers: {}, body: {} }],
       templates: [{ layout: 'full', liquidMarkup: 'Template' }],
-    } as any)
+    })
 
     expect(mockScheduler.schedulePlugin).toHaveBeenCalledWith(createdPlugin)
   })
@@ -602,17 +575,18 @@ describe('pluginsService', () => {
     const createdPlugin = {
       ...basePlugin,
       dataSources: [],
-      templates: [{ id: 't-1' }],
+      templates: [makePluginTemplate({ id: 't-1' })],
     }
     pluginRepo.save.mockResolvedValue(basePlugin)
-    templateRepo.create.mockReturnValue({})
-    templateRepo.save.mockResolvedValue({})
+    templateRepo.create.mockReturnValue(makePluginTemplate())
+    templateRepo.save.mockResolvedValue(makePluginTemplate())
     pluginRepo.findOne.mockResolvedValue(createdPlugin)
 
     await service.create({
       name: 'Plugin',
+      kind: 'Poll',
       templates: [{ layout: 'full', liquidMarkup: 'Template' }],
-    } as any)
+    })
 
     expect(mockScheduler.schedulePlugin).not.toHaveBeenCalled()
   })
@@ -622,7 +596,7 @@ describe('pluginsService', () => {
     pluginRepo.save.mockResolvedValue(basePlugin)
     pluginRepo.findOne.mockResolvedValue(createdPlugin)
 
-    const result = await service.create({ name: 'Draft Plugin' } as any)
+    const result = await service.create({ name: 'Draft Plugin', kind: 'Poll' })
 
     expect(dataSourceRepo.create).not.toHaveBeenCalled()
     expect(result).toBe(createdPlugin)
@@ -633,8 +607,9 @@ describe('pluginsService', () => {
 
     await expect(service.create({
       name: 'Plugin',
+      kind: 'Poll',
       dataSources: [{ name: 'trmnl', url: 'https://api.com', method: 'GET' }],
-    } as any)).rejects.toThrow('reserved')
+    })).rejects.toThrow('reserved')
 
     expect(pluginRepo.save).not.toHaveBeenCalled()
   })
@@ -644,9 +619,10 @@ describe('pluginsService', () => {
 
     await expect(service.create({
       name: 'Plugin',
+      kind: 'Poll',
       dataSources: [{ name: 'weather', url: 'https://api.com', method: 'GET' }],
       fields: [{ keyname: 'weather', fieldType: 'string', name: 'Weather' }],
-    } as any)).rejects.toThrow('collides')
+    })).rejects.toThrow('collides')
   })
 
   it('preview fetches a single source and renders template under its name', async () => {
@@ -745,7 +721,7 @@ describe('pluginsService', () => {
   })
 
   describe('webhook-kind plugins', () => {
-    const webhookPlugin = {
+    const webhookPlugin: Plugin = makePlugin({
       id: '1',
       name: 'Sensor Feed',
       kind: 'Webhook',
@@ -753,13 +729,13 @@ describe('pluginsService', () => {
       webhookToken: 'token-abc',
       mergeStrategy: 'stream',
       streamLimit: 20,
-    } as unknown as Plugin
+    })
 
     it('create issues a webhook token and never schedules the plugin', async () => {
-      pluginRepo.save.mockImplementation(async (plugin: any) => ({ ...plugin, id: '1' }))
+      pluginRepo.save.mockImplementation(async plugin => makePlugin({ ...plugin, id: '1' }))
       pluginRepo.findOne.mockResolvedValue(webhookPlugin)
 
-      await service.create({ name: 'Sensor Feed', kind: 'Webhook', mergeStrategy: 'standard' } as any)
+      await service.create({ name: 'Sensor Feed', kind: 'Webhook', mergeStrategy: 'standard' })
 
       expect(pluginRepo.save).toHaveBeenCalledWith(expect.objectContaining({
         kind: 'Webhook',
@@ -775,13 +751,13 @@ describe('pluginsService', () => {
         kind: 'Webhook',
         mergeStrategy: 'standard',
         dataSources: [{ name: 'source', url: 'https://api.example.com' }],
-      } as any)).rejects.toThrow('A Webhook-kind Plugin cannot have Data Sources')
+      })).rejects.toThrow('A Webhook-kind Plugin cannot have Data Sources')
     })
 
     it('update rejects a change of kind', async () => {
       pluginRepo.findOne.mockResolvedValue({ ...webhookPlugin })
 
-      await expect(service.update('1', { kind: 'Poll' } as any)).rejects.toThrow(
+      await expect(service.update('1', { kind: 'Poll' })).rejects.toThrow(
         'A Plugin\'s Kind is fixed at creation and cannot be changed',
       )
     })
@@ -789,7 +765,8 @@ describe('pluginsService', () => {
     it('update rejects a nulled kind', async () => {
       pluginRepo.findOne.mockResolvedValue({ ...webhookPlugin })
 
-      await expect(service.update('1', { kind: null } as any)).rejects.toThrow(
+      // @ts-expect-error kind is intentionally invalid (null) to prove the service rejects it
+      await expect(service.update('1', { kind: null })).rejects.toThrow(
         'A Plugin\'s Kind is fixed at creation and cannot be changed',
       )
     })
@@ -797,7 +774,7 @@ describe('pluginsService', () => {
     it('update rejects an explicit stream limit alongside a non-stream merge strategy', async () => {
       pluginRepo.findOne.mockResolvedValue({ ...webhookPlugin })
 
-      await expect(service.update('1', { mergeStrategy: 'deep_merge', streamLimit: 20 } as any)).rejects.toThrow(
+      await expect(service.update('1', { mergeStrategy: 'deep_merge', streamLimit: 20 })).rejects.toThrow(
         'A Stream Limit is only valid for the stream Merge Strategy',
       )
     })
@@ -805,15 +782,15 @@ describe('pluginsService', () => {
     it('update accepts an unchanged kind', async () => {
       const stored = { ...webhookPlugin }
       pluginRepo.findOne.mockResolvedValue(stored)
-      pluginRepo.save.mockImplementation(async (plugin: any) => plugin)
+      pluginRepo.save.mockImplementation(async plugin => makePlugin(plugin))
 
-      await expect(service.update('1', { kind: 'Webhook', name: 'Renamed' } as any)).resolves.toMatchObject({ name: 'Renamed' })
+      await expect(service.update('1', { kind: 'Webhook', name: 'Renamed' })).resolves.toMatchObject({ name: 'Renamed' })
     })
 
     it('update rejects a merge strategy on a poll-kind plugin', async () => {
       pluginRepo.findOne.mockResolvedValue({ ...basePlugin })
 
-      await expect(service.update('1', { mergeStrategy: 'stream' } as any)).rejects.toThrow(
+      await expect(service.update('1', { mergeStrategy: 'stream' })).rejects.toThrow(
         'A Poll-kind Plugin cannot have a Merge Strategy',
       )
     })
@@ -821,9 +798,9 @@ describe('pluginsService', () => {
     it('update drops the stream limit when the merge strategy moves off stream', async () => {
       const stored = { ...webhookPlugin }
       pluginRepo.findOne.mockResolvedValue(stored)
-      pluginRepo.save.mockImplementation(async (plugin: any) => plugin)
+      pluginRepo.save.mockImplementation(async plugin => makePlugin(plugin))
 
-      const updated = await service.update('1', { mergeStrategy: 'deep_merge' } as any)
+      const updated = await service.update('1', { mergeStrategy: 'deep_merge' })
 
       expect(updated).toMatchObject({ mergeStrategy: 'deep_merge', streamLimit: null })
     })
@@ -831,7 +808,7 @@ describe('pluginsService', () => {
     it('update rejects a directly supplied webhook token', async () => {
       pluginRepo.findOne.mockResolvedValue({ ...webhookPlugin })
 
-      await expect(service.update('1', { webhookToken: 'stolen' } as any)).rejects.toThrow(
+      await expect(service.update('1', { webhookToken: 'stolen' })).rejects.toThrow(
         'The Webhook Token is issued by Kuroshiro and cannot be set directly',
       )
     })

--- a/packages/api/src/plugins/__test__/webhook-ingest.integration.spec.ts
+++ b/packages/api/src/plugins/__test__/webhook-ingest.integration.spec.ts
@@ -1,11 +1,14 @@
 import type { TestingModule } from '@nestjs/testing'
+import type { MashupSlot } from '../../mashup/entities/mashup-slot.entity'
+import type { Screen } from '../../screens/screens.entity'
 import type { Plugin } from '../entities/plugin.entity'
 import { UnprocessableEntityException } from '@nestjs/common'
 import { Test } from '@nestjs/testing'
 import { getRepositoryToken } from '@nestjs/typeorm'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { MashupSlot } from '../../mashup/entities/mashup-slot.entity'
-import { Screen } from '../../screens/screens.entity'
+import { MashupSlot as MashupSlotEntity } from '../../mashup/entities/mashup-slot.entity'
+import { Screen as ScreenEntity } from '../../screens/screens.entity'
+import { makeMashupConfiguration, makeMashupSlot, makePlugin, makePluginTemplate, makeScreen } from '../../test/fixtures'
 import { DevicePlugin } from '../entities/device-plugin.entity'
 import { PluginDataSource } from '../entities/plugin-data-source.entity'
 import { PluginField } from '../entities/plugin-field.entity'
@@ -19,11 +22,12 @@ import { PluginSchedulerService } from '../services/plugin-scheduler.service'
 import { PluginTransformService } from '../services/plugin-transform.service'
 import { WebhookIngestService } from '../services/webhook-ingest.service'
 
-function matches(entity: any, where: Record<string, any>): boolean {
+function matches(entity: unknown, where: Record<string, unknown>): boolean {
+  const record = entity as Record<string, unknown>
   return Object.entries(where).every(([key, value]) => {
     if (value && typeof value === 'object' && 'id' in value)
-      return entity[key]?.id === value.id
-    return entity[key] === value
+      return (record[key] as { id?: unknown } | undefined)?.id === (value as { id: unknown }).id
+    return record[key] === value
   })
 }
 
@@ -31,13 +35,13 @@ describe('webhook ingest integration', () => {
   let ingest: WebhookIngestService
   let pluginsService: PluginsService
   let plugin: Plugin
-  let screens: any[]
-  let mashupSlots: any[]
+  let screens: Screen[]
+  let mashupSlots: MashupSlot[]
 
   const template = { layout: 'full', liquidMarkup: 'readings: {{ readings.size }} status: {{ status }}' }
 
   beforeEach(async () => {
-    plugin = {
+    plugin = makePlugin({
       id: 'plugin-1',
       name: 'Sensor Feed',
       kind: 'Webhook',
@@ -46,34 +50,34 @@ describe('webhook ingest integration', () => {
       mergeStrategy: 'standard',
       streamLimit: null,
       webhookPayload: null,
-      templates: [template],
-    } as unknown as Plugin
+      templates: [makePluginTemplate(template)],
+    })
 
     screens = [
-      { id: 'screen-1', plugin: { id: 'plugin-1' }, cachedPluginOutput: 'stale' },
-      { id: 'mashup-screen-1', plugin: null, cachedPluginOutput: 'stale mashup' },
+      makeScreen({ id: 'screen-1', type: 'plugin', plugin: makePlugin({ id: 'plugin-1' }), cachedPluginOutput: 'stale' }),
+      makeScreen({ id: 'mashup-screen-1', type: 'mashup', cachedPluginOutput: 'stale mashup' }),
     ]
 
     mashupSlots = [
-      { id: 'slot-1', plugin: { id: 'plugin-1' }, mashupConfiguration: { screen: { id: 'mashup-screen-1' } } },
+      makeMashupSlot({ id: 'slot-1', plugin: makePlugin({ id: 'plugin-1' }), mashupConfiguration: makeMashupConfiguration({ screen: makeScreen({ id: 'mashup-screen-1' }) }) }),
     ]
 
     const mashupSlotRepo = {
-      find: vi.fn(async ({ where }: any) => mashupSlots.filter(slot => matches(slot, where))),
+      find: vi.fn(async ({ where }: { where: Record<string, unknown> }) => mashupSlots.filter(slot => matches(slot, where))),
     }
 
     const screenRepo = {
-      update: vi.fn(async (where: any, partial: any) => {
+      update: vi.fn(async (where: Record<string, unknown>, partial: Partial<Screen>) => {
         screens.filter(screen => matches(screen, where)).forEach(screen => Object.assign(screen, partial))
       }),
       manager: { getRepository: (name: string) => (name === 'MashupSlot' ? mashupSlotRepo : null) },
     }
 
     const pluginRepo = {
-      findOne: vi.fn(async ({ where }: any) => (matches(plugin, where) ? plugin : null)),
-      findOneBy: vi.fn(async (where: any) => (matches(plugin, where) ? plugin : null)),
-      save: vi.fn(async (entity: any) => entity),
-      update: vi.fn(async (id: string, partial: any) => {
+      findOne: vi.fn(async ({ where }: { where: Record<string, unknown> }) => (matches(plugin, where) ? plugin : null)),
+      findOneBy: vi.fn(async (where: Record<string, unknown>) => (matches(plugin, where) ? plugin : null)),
+      save: vi.fn(async (entity: Plugin) => entity),
+      update: vi.fn(async (id: string, partial: Partial<Plugin>) => {
         if (id === plugin.id)
           Object.assign(plugin, partial)
       }),
@@ -88,11 +92,11 @@ describe('webhook ingest integration', () => {
         PluginsService,
         { provide: getRepositoryToken(PluginEntity), useValue: pluginRepo },
         { provide: getRepositoryToken(DevicePlugin), useValue: {} },
-        { provide: getRepositoryToken(Screen), useValue: screenRepo },
+        { provide: getRepositoryToken(ScreenEntity), useValue: screenRepo },
         { provide: getRepositoryToken(PluginDataSource), useValue: {} },
         { provide: getRepositoryToken(PluginTemplate), useValue: {} },
         { provide: getRepositoryToken(PluginField), useValue: {} },
-        { provide: getRepositoryToken(MashupSlot), useValue: mashupSlotRepo },
+        { provide: getRepositoryToken(MashupSlotEntity), useValue: mashupSlotRepo },
         { provide: PluginDataFetcherService, useValue: {} },
         { provide: PluginTransformService, useValue: {} },
         { provide: PluginSchedulerService, useValue: { schedulePlugin: vi.fn(), removeScheduledJob: vi.fn() } },

--- a/packages/api/src/plugins/__test__/webhook-plugin.guard.spec.ts
+++ b/packages/api/src/plugins/__test__/webhook-plugin.guard.spec.ts
@@ -1,27 +1,34 @@
 import type { ExecutionContext } from '@nestjs/common'
+import type { Plugin } from '../entities/plugin.entity'
 import { UnauthorizedException } from '@nestjs/common'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { makePlugin } from '../../test/fixtures'
+import { asRepository, createMockRepository } from '../../test/mockRepository'
+import { asService } from '../../test/mockService'
 import { WebhookPluginGuard } from '../guards/webhook-plugin.guard'
 
 describe('webhookPluginGuard', () => {
   let guard: WebhookPluginGuard
-  let pluginRepo: any
-  let request: any
+  let pluginRepo: ReturnType<typeof createMockRepository<Plugin>>
+  let request: { params: { token?: string }, plugin?: Plugin }
 
-  const plugin = { id: 'plugin-1', kind: 'Webhook', webhookToken: 'token-abc' }
+  const plugin = makePlugin({ id: 'plugin-1', kind: 'Webhook', webhookToken: 'token-abc' })
 
   function contextFor(token?: string): ExecutionContext {
     request = { params: token === undefined ? {} : { token } }
-    return {
+    return asService<ExecutionContext>({
       switchToHttp: () => ({ getRequest: () => request }),
-    } as unknown as ExecutionContext
+    })
   }
 
   beforeEach(() => {
-    pluginRepo = {
-      findOne: vi.fn(async ({ where }: any) => (where.webhookToken === plugin.webhookToken ? plugin : null)),
-    }
-    guard = new WebhookPluginGuard(pluginRepo)
+    pluginRepo = createMockRepository<Plugin>()
+    pluginRepo.findOne.mockImplementation(async (options) => {
+      const where = options.where
+      const webhookToken = where && !Array.isArray(where) ? where.webhookToken : undefined
+      return webhookToken === plugin.webhookToken ? plugin : null
+    })
+    guard = new WebhookPluginGuard(asRepository(pluginRepo))
   })
 
   it('resolves the Plugin from its Webhook Token and attaches it to the request', async () => {

--- a/packages/api/src/plugins/dto/__test__/create-plugin.dto.spec.ts
+++ b/packages/api/src/plugins/dto/__test__/create-plugin.dto.spec.ts
@@ -11,7 +11,7 @@ function flattenConstraints(errors: ValidationError[]): string[] {
   ])
 }
 
-async function violations(payload: Record<string, any>): Promise<string[]> {
+async function violations(payload: Record<string, unknown>): Promise<string[]> {
   const errors = await validate(plainToInstance(CreatePluginDto, payload))
   return flattenConstraints(errors)
 }

--- a/packages/api/src/plugins/dto/__test__/update-plugin.dto.spec.ts
+++ b/packages/api/src/plugins/dto/__test__/update-plugin.dto.spec.ts
@@ -11,7 +11,7 @@ function flattenConstraints(errors: ValidationError[]): string[] {
   ])
 }
 
-async function violations(payload: Record<string, any>): Promise<string[]> {
+async function violations(payload: Record<string, unknown>): Promise<string[]> {
   const errors = await validate(plainToInstance(UpdatePluginDto, payload))
   return flattenConstraints(errors)
 }

--- a/packages/api/src/schedule/__test__/schedule-eligibility.spec.ts
+++ b/packages/api/src/schedule/__test__/schedule-eligibility.spec.ts
@@ -1,9 +1,10 @@
 import type { Schedule } from '../schedule.entity'
 import { describe, expect, it } from 'vitest'
+import { makeSchedule } from '../../test/fixtures'
 import { isScheduleEligible } from '../schedule-eligibility'
 
 function schedule(overrides: Partial<Schedule>): Schedule {
-  return { enabled: true, ...overrides } as Schedule
+  return makeSchedule(overrides)
 }
 
 // Moments are written without a zone so they parse as server-local time.
@@ -85,7 +86,12 @@ describe('isScheduleEligible', () => {
     })
 
     it('accepts dates stored as Date objects', () => {
-      const stored = schedule({ startDate: new Date('2026-12-01T00:00:00') as any, endDate: new Date('2026-12-25T00:00:00') as any })
+      const stored = schedule({
+        // @ts-expect-error Postgres can return date columns as Date objects despite the declared string type
+        startDate: new Date('2026-12-01T00:00:00'),
+        // @ts-expect-error Postgres can return date columns as Date objects despite the declared string type
+        endDate: new Date('2026-12-25T00:00:00'),
+      })
       expect(isScheduleEligible(stored, new Date('2026-12-13T12:00:00'))).toBe(true)
       expect(isScheduleEligible(stored, new Date('2026-12-26T12:00:00'))).toBe(false)
     })

--- a/packages/api/src/schedule/__test__/schedule.controller.spec.ts
+++ b/packages/api/src/schedule/__test__/schedule.controller.spec.ts
@@ -1,11 +1,12 @@
 import type { ScheduleService } from '../schedule.service'
 import { NotFoundException } from '@nestjs/common'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { asService } from '../../test/mockService'
 import { ScheduleController } from '../schedule.controller'
 
 describe('scheduleController', () => {
   let controller: ScheduleController
-  let mockService: ScheduleService
+  let mockService: { create: ReturnType<typeof vi.fn>, getByScreen: ReturnType<typeof vi.fn>, update: ReturnType<typeof vi.fn>, delete: ReturnType<typeof vi.fn> }
 
   beforeEach(() => {
     mockService = {
@@ -13,14 +14,14 @@ describe('scheduleController', () => {
       getByScreen: vi.fn(),
       update: vi.fn(),
       delete: vi.fn(),
-    } as any
+    }
 
-    controller = new ScheduleController(mockService)
+    controller = new ScheduleController(asService<ScheduleService>(mockService))
   })
 
   it('creates a schedule for the screen in the route', async () => {
     const schedule = { id: 'schedule-1' }
-    mockService.create = vi.fn().mockResolvedValue(schedule)
+    mockService.create.mockResolvedValue(schedule)
 
     const result = await controller.create('screen-1', { weekdays: [1] })
 
@@ -30,20 +31,20 @@ describe('scheduleController', () => {
 
   it('returns the screen\'s schedule', async () => {
     const schedule = { id: 'schedule-1' }
-    mockService.getByScreen = vi.fn().mockResolvedValue(schedule)
+    mockService.getByScreen.mockResolvedValue(schedule)
 
     await expect(controller.get('screen-1')).resolves.toBe(schedule)
   })
 
   it('surfaces a missing schedule as a NotFoundException', async () => {
-    mockService.getByScreen = vi.fn().mockRejectedValue(new NotFoundException('Schedule not found'))
+    mockService.getByScreen.mockRejectedValue(new NotFoundException('Schedule not found'))
 
     await expect(controller.get('screen-1')).rejects.toThrow(NotFoundException)
   })
 
   it('updates the schedule for the screen in the route', async () => {
     const schedule = { id: 'schedule-1', enabled: false }
-    mockService.update = vi.fn().mockResolvedValue(schedule)
+    mockService.update.mockResolvedValue(schedule)
 
     const result = await controller.update('screen-1', { enabled: false })
 
@@ -52,7 +53,7 @@ describe('scheduleController', () => {
   })
 
   it('deletes the schedule for the screen in the route', async () => {
-    mockService.delete = vi.fn().mockResolvedValue(undefined)
+    mockService.delete.mockResolvedValue(undefined)
 
     await controller.delete('screen-1')
 

--- a/packages/api/src/schedule/__test__/schedule.service.spec.ts
+++ b/packages/api/src/schedule/__test__/schedule.service.spec.ts
@@ -1,32 +1,23 @@
+import type { Screen } from '../../screens/screens.entity'
+import type { Schedule } from '../schedule.entity'
 import { BadRequestException, NotFoundException } from '@nestjs/common'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { makeSchedule, makeScreen } from '../../test/fixtures'
+import { asRepository, createMockRepository } from '../../test/mockRepository'
 import { ScheduleService } from '../schedule.service'
-
-function createMockRepo() {
-  return {
-    find: vi.fn(),
-    findOne: vi.fn(),
-    create: vi.fn(),
-    save: vi.fn(),
-    remove: vi.fn(),
-  }
-}
 
 describe('scheduleService', () => {
   let service: ScheduleService
-  let scheduleRepo: ReturnType<typeof createMockRepo>
-  let screenRepo: ReturnType<typeof createMockRepo>
+  let scheduleRepo: ReturnType<typeof createMockRepository<Schedule>>
+  let screenRepo: ReturnType<typeof createMockRepository<Screen>>
 
   beforeEach(() => {
-    scheduleRepo = createMockRepo()
-    screenRepo = createMockRepo()
-    service = new ScheduleService(scheduleRepo as any, screenRepo as any)
-    vi.resetAllMocks()
-    scheduleRepo.create.mockImplementation(schedule => schedule)
-    scheduleRepo.save.mockImplementation(schedule => Promise.resolve({ id: 'schedule-1', ...schedule }))
+    scheduleRepo = createMockRepository<Schedule>()
+    screenRepo = createMockRepository<Screen>()
+    service = new ScheduleService(asRepository(scheduleRepo), asRepository(screenRepo))
   })
 
-  const screen = { id: 'screen-1' }
+  const screen = makeScreen({ id: 'screen-1' })
 
   describe('create', () => {
     it('attaches a schedule carrying the requested day and time constraints', async () => {
@@ -77,7 +68,7 @@ describe('scheduleService', () => {
 
     it('refuses a second schedule on an already scheduled screen', async () => {
       screenRepo.findOne.mockResolvedValue(screen)
-      scheduleRepo.findOne.mockResolvedValue({ id: 'schedule-1' })
+      scheduleRepo.findOne.mockResolvedValue(makeSchedule({ id: 'schedule-1' }))
 
       await expect(service.create('screen-1', {})).rejects.toThrow(BadRequestException)
       expect(scheduleRepo.save).not.toHaveBeenCalled()
@@ -119,7 +110,7 @@ describe('scheduleService', () => {
 
   describe('getByScreen', () => {
     it('returns the screen\'s schedule', async () => {
-      const schedule = { id: 'schedule-1', enabled: true }
+      const schedule = makeSchedule({ id: 'schedule-1', enabled: true })
       scheduleRepo.findOne.mockResolvedValue(schedule)
 
       await expect(service.getByScreen('screen-1')).resolves.toBe(schedule)
@@ -134,7 +125,7 @@ describe('scheduleService', () => {
 
   describe('update', () => {
     it('disables a schedule without discarding its day and time rules', async () => {
-      scheduleRepo.findOne.mockResolvedValue({ id: 'schedule-1', enabled: true, weekdays: [1], startTime: '07:00', endTime: '09:00' })
+      scheduleRepo.findOne.mockResolvedValue(makeSchedule({ id: 'schedule-1', enabled: true, weekdays: [1], startTime: '07:00', endTime: '09:00' }))
 
       const result = await service.update('screen-1', { enabled: false })
 
@@ -142,7 +133,7 @@ describe('scheduleService', () => {
     })
 
     it('leaves omitted constraints untouched', async () => {
-      scheduleRepo.findOne.mockResolvedValue({ id: 'schedule-1', enabled: true, weekdays: [1], startDate: '2026-12-01', endDate: '2026-12-25' })
+      scheduleRepo.findOne.mockResolvedValue(makeSchedule({ id: 'schedule-1', enabled: true, weekdays: [1], startDate: '2026-12-01', endDate: '2026-12-25' }))
 
       const result = await service.update('screen-1', { weekdays: [2, 3] })
 
@@ -150,7 +141,7 @@ describe('scheduleService', () => {
     })
 
     it('clears a constraint that is sent as null', async () => {
-      scheduleRepo.findOne.mockResolvedValue({ id: 'schedule-1', enabled: true, startTime: '07:00', endTime: '09:00' })
+      scheduleRepo.findOne.mockResolvedValue(makeSchedule({ id: 'schedule-1', enabled: true, startTime: '07:00', endTime: '09:00' }))
 
       const result = await service.update('screen-1', { startTime: null, endTime: null })
 
@@ -158,7 +149,7 @@ describe('scheduleService', () => {
     })
 
     it('rejects an update that would leave half a time window behind', async () => {
-      scheduleRepo.findOne.mockResolvedValue({ id: 'schedule-1', enabled: true, startTime: '07:00', endTime: '09:00' })
+      scheduleRepo.findOne.mockResolvedValue(makeSchedule({ id: 'schedule-1', enabled: true, startTime: '07:00', endTime: '09:00' }))
 
       await expect(service.update('screen-1', { endTime: null })).rejects.toThrow(BadRequestException)
       expect(scheduleRepo.save).not.toHaveBeenCalled()
@@ -173,7 +164,7 @@ describe('scheduleService', () => {
 
   describe('delete', () => {
     it('removes the schedule so the screen becomes always eligible again', async () => {
-      const schedule = { id: 'schedule-1' }
+      const schedule = makeSchedule({ id: 'schedule-1' })
       scheduleRepo.findOne.mockResolvedValue(schedule)
 
       await service.delete('screen-1')

--- a/packages/api/src/screens/__test__/screens-type.spec.ts
+++ b/packages/api/src/screens/__test__/screens-type.spec.ts
@@ -1,5 +1,5 @@
-import type { MashupConfiguration } from '../../mashup/entities/mashup-configuration.entity'
 import { describe, expect, it } from 'vitest'
+import { makeMashupConfiguration } from '../../test/fixtures'
 import { Screen } from '../screens.entity'
 
 describe('screen entity with type field', () => {
@@ -29,7 +29,7 @@ describe('screen entity with type field', () => {
   it('should have mashupConfiguration relationship for mashup type', () => {
     const screen = new Screen()
     screen.type = 'mashup'
-    const mockConfig = { id: 'config-1', layout: '2x2' } as MashupConfiguration
+    const mockConfig = makeMashupConfiguration({ id: 'config-1', layout: '2x2' })
 
     screen.mashupConfiguration = mockConfig
 

--- a/packages/api/src/screens/__test__/screens.controller.spec.ts
+++ b/packages/api/src/screens/__test__/screens.controller.spec.ts
@@ -1,9 +1,11 @@
 import type { ConfigService } from '@nestjs/config'
 import type { CreateScreenDto } from '../dto/create-screen.dto'
-import type { Screen } from '../screens.entity'
 import type { ScreensService } from '../screens.service'
 import buffer from 'node:buffer'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { makeScreen } from '../../test/fixtures'
+import { makeMulterFile } from '../../test/fs'
+import { asService } from '../../test/mockService'
 import { ScreensController } from '../screens.controller'
 
 function createMockService() {
@@ -25,11 +27,11 @@ describe('screensController (unit)', () => {
   beforeEach(() => {
     service = createMockService()
     configService = { get: vi.fn() }
-    controller = new ScreensController(service as unknown as ScreensService, configService as unknown as ConfigService)
+    controller = new ScreensController(asService<ScreensService>(service), asService<ConfigService>(configService))
   })
 
   it('getAll returns all screens', async () => {
-    const screens = [{ id: '1' } as Screen]
+    const screens = [makeScreen({ id: '1' })]
     service.getAll.mockResolvedValue(screens)
     const result = await controller.getAll()
     expect(result).toBe(screens)
@@ -37,8 +39,8 @@ describe('screensController (unit)', () => {
 
   it('add creates a screen', async () => {
     const dto: CreateScreenDto = { filename: 'file', deviceId: 'dev', fetchManual: false }
-    const file = { buffer: buffer.Buffer.from('data') } as Express.Multer.File
-    const screen = { id: '1', filename: 'file' } as Screen
+    const file = makeMulterFile({ buffer: buffer.Buffer.from('data') })
+    const screen = makeScreen({ id: '1', filename: 'file' })
     service.add.mockResolvedValue(screen)
     configService.get.mockReturnValue(false)
     const result = await controller.add(dto, file)
@@ -47,7 +49,7 @@ describe('screensController (unit)', () => {
   })
 
   it('getByDevice returns screens for a device', async () => {
-    const screens = [{ id: '1' } as Screen]
+    const screens = [makeScreen({ id: '1' })]
     service.getByDevice.mockResolvedValue(screens)
     const result = await controller.getByDevice('dev')
     expect(service.getByDevice).toHaveBeenCalledWith('dev')
@@ -67,7 +69,7 @@ describe('screensController (unit)', () => {
   })
 
   it('reorder calls service with device id and screen ids', async () => {
-    const screens = [{ id: '2' } as Screen, { id: '1' } as Screen]
+    const screens = [makeScreen({ id: '2' }), makeScreen({ id: '1' })]
     service.reorder.mockResolvedValue(screens)
     const result = await controller.reorder('dev', { screenIds: ['2', '1'] })
     expect(service.reorder).toHaveBeenCalledWith('dev', ['2', '1'])

--- a/packages/api/src/screens/__test__/screens.service.spec.ts
+++ b/packages/api/src/screens/__test__/screens.service.spec.ts
@@ -1,12 +1,19 @@
-import type { MockDeviceModelsService } from '../../device-models/__test__/mockDeviceModelsService'
+import type { ConfigService } from '@nestjs/config'
+import type { MockInstance } from 'vitest'
+import type { DeviceModelsService } from '../../device-models/device-models.service'
 import type { Device } from '../../devices/devices.entity'
+import type { MockDeviceModelsService } from '../../test/mockDeviceModelsService'
 import type { CreateScreenDto } from '../dto/create-screen.dto'
 import type { Screen } from '../screens.entity'
 import buffer from 'node:buffer'
 import * as fs from 'node:fs'
 import { BadRequestException, NotFoundException } from '@nestjs/common'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { createMockDeviceModelsService, primeMockDeviceModelsService } from '../../device-models/__test__/mockDeviceModelsService'
+import { makeDevice, makeScreen } from '../../test/fixtures'
+import { makeMulterFile } from '../../test/fs'
+import { createMockDeviceModelsService, primeMockDeviceModelsService } from '../../test/mockDeviceModelsService'
+import { asRepository, createMockRepository, createMockTransactionalRepository } from '../../test/mockRepository'
+import { asService } from '../../test/mockService'
 import { ScreensService } from '../screens.service'
 
 const { fileExistsMock } = vi.hoisted(() => ({ fileExistsMock: vi.fn() }))
@@ -18,41 +25,23 @@ vi.mock('../../utils/imageUtils', () => ({
 
 vi.mock('../../utils/fileExists', () => ({ fileExists: fileExistsMock }))
 
-function createMockRepo() {
-  const repo: any = {
-    find: vi.fn(),
-    findOne: vi.fn(),
-    findOneBy: vi.fn(),
-    create: vi.fn(),
-    save: vi.fn(),
-    update: vi.fn(),
-    remove: vi.fn(),
-    delete: vi.fn(),
-  }
-  repo.manager = {
-    getRepository: vi.fn(() => repo),
-    transaction: vi.fn(async (cb: (manager: any) => Promise<void>) => cb(repo.manager)),
-  }
-  return repo
-}
-
 describe('screensService', () => {
   let service: ScreensService
-  let screensRepo: ReturnType<typeof createMockRepo>
-  let devicesRepo: ReturnType<typeof createMockRepo>
-  let unlinkMock: any
+  let screensRepo: ReturnType<typeof createMockTransactionalRepository<Screen>>
+  let devicesRepo: ReturnType<typeof createMockRepository<Device>>
+  let unlinkMock: MockInstance<typeof fs.promises.unlink>
   let deviceModels: MockDeviceModelsService
   const mockConfigService = { get: vi.fn().mockReturnValue(false) }
 
   beforeEach(() => {
-    screensRepo = createMockRepo()
-    devicesRepo = createMockRepo()
+    screensRepo = createMockTransactionalRepository<Screen>()
+    devicesRepo = createMockRepository<Device>()
     deviceModels = createMockDeviceModelsService()
     service = new ScreensService(
-      screensRepo as any,
-      devicesRepo as any,
-      mockConfigService as any,
-      deviceModels as any,
+      asRepository(screensRepo),
+      asRepository(devicesRepo),
+      asService<ConfigService>(mockConfigService),
+      asService<DeviceModelsService>(deviceModels),
     )
     vi.resetAllMocks()
     primeMockDeviceModelsService(deviceModels)
@@ -60,7 +49,7 @@ describe('screensService', () => {
   })
 
   it('getAll returns all screens', async () => {
-    const screens = [{ id: '1' } as Screen]
+    const screens = [makeScreen({ id: '1' })]
     screensRepo.find.mockResolvedValue(screens)
     const result = await service.getAll()
     expect(result).toBe(screens)
@@ -68,7 +57,7 @@ describe('screensService', () => {
 
   it('add throws if both file and externalLink are provided', async () => {
     const dto: CreateScreenDto = { filename: 'file', deviceId: 'dev', externalLink: 'url', fetchManual: false, html: '' }
-    await expect(service.add(dto, { buffer: buffer.Buffer.from('data') } as Express.Multer.File)).rejects.toThrow()
+    await expect(service.add(dto, makeMulterFile({ buffer: buffer.Buffer.from('data') }))).rejects.toThrow()
   })
 
   it('add throws if neither file nor externalLink is provided', async () => {
@@ -77,13 +66,12 @@ describe('screensService', () => {
   })
 
   it('add creates a screen with file', async () => {
-    const device = { id: 'dev', screens: [], width: 100, height: 100 } as unknown as Device
+    const device = makeDevice({ id: 'dev', width: 100, height: 100 })
     devicesRepo.findOne.mockResolvedValue(device)
-    const screen = { id: '1', filename: 'file', device, order: 1, isActive: false } as Screen
+    const screen = makeScreen({ id: '1', filename: 'file', device, order: 1, isActive: false })
     screensRepo.create.mockReturnValue(screen)
     screensRepo.save.mockResolvedValue(screen)
-    screensRepo.update.mockResolvedValue(undefined)
-    const file = { buffer: buffer.Buffer.from('data') } as Express.Multer.File
+    const file = makeMulterFile({ buffer: buffer.Buffer.from('data') })
     const writeFileMock = vi.spyOn(fs.promises, 'writeFile').mockResolvedValue(undefined)
     vi.spyOn(fs.promises, 'mkdir').mockResolvedValue(undefined)
     const result = await service.add({ filename: 'file', deviceId: 'dev', fetchManual: false, html: '' }, file)
@@ -95,24 +83,22 @@ describe('screensService', () => {
   })
 
   it('add creates a screen with html', async () => {
-    const device = { id: 'dev', screens: [], width: 100, height: 100 } as unknown as Device
+    const device = makeDevice({ id: 'dev', width: 100, height: 100 })
     devicesRepo.findOne.mockResolvedValue(device)
-    const screen = { id: '1', html: '<div>hi</div>', device, order: 1, isActive: false } as Screen
+    const screen = makeScreen({ id: '1', html: '<div>hi</div>', device, order: 1, isActive: false })
     screensRepo.create.mockReturnValue(screen)
     screensRepo.save.mockResolvedValue(screen)
-    screensRepo.update.mockResolvedValue(undefined)
     const result = await service.add({ filename: 'file', deviceId: 'dev', fetchManual: false, html: '<div>hi</div>' }, undefined)
     expect(result).toBe(screen)
     expect(screensRepo.create).toHaveBeenCalledWith(expect.objectContaining({ type: 'html' }))
   })
 
   it('add creates a screen with externalLink and fetchManual', async () => {
-    const device = { id: 'dev', screens: [], width: 100, height: 100 } as unknown as Device
+    const device = makeDevice({ id: 'dev', width: 100, height: 100 })
     devicesRepo.findOne.mockResolvedValue(device)
-    const screen = { id: '1', filename: 'file', device, order: 1, isActive: false } as Screen
+    const screen = makeScreen({ id: '1', filename: 'file', device, order: 1, isActive: false })
     screensRepo.create.mockReturnValue(screen)
     screensRepo.save.mockResolvedValue(screen)
-    screensRepo.update.mockResolvedValue(undefined)
     const dto: CreateScreenDto = {
       filename: 'file',
       deviceId: 'dev',
@@ -127,19 +113,17 @@ describe('screensService', () => {
   })
 
   it('getByDevice returns screens for a device', async () => {
-    const screens = [{ id: '1' } as Screen]
+    const screens = [makeScreen({ id: '1' })]
     screensRepo.find.mockResolvedValue(screens)
     const result = await service.getByDevice('dev')
     expect(result).toBe(screens)
   })
 
   it('delete removes a screen and reindexes', async () => {
-    const device = { id: 'dev' } as Device
-    const screen = { id: '1', device } as Screen
-    screensRepo.findOne.mockResolvedValue({ ...screen, device })
-    screensRepo.delete.mockResolvedValue(undefined)
-    screensRepo.find.mockResolvedValue([{ id: '2', order: 2, device } as Screen])
-    screensRepo.save.mockResolvedValue(undefined)
+    const device = makeDevice({ id: 'dev' })
+    const screen = makeScreen({ id: '1', device })
+    screensRepo.findOne.mockResolvedValue(screen)
+    screensRepo.find.mockResolvedValue([makeScreen({ id: '2', order: 2, device })])
     await expect(service.delete('1')).resolves.toBeUndefined()
     expect(screensRepo.delete).toHaveBeenCalledWith('1')
     expect(screensRepo.save).toHaveBeenCalled()
@@ -148,8 +132,8 @@ describe('screensService', () => {
   })
 
   it('updateExternalScreen refetches into the retained original and converts it', async () => {
-    const device = { id: 'dev', width: 100, height: 100 } as Device
-    const screen = { id: '1', device, externalLink: 'url', fetchManual: true } as Screen
+    const device = makeDevice({ id: 'dev', width: 100, height: 100 })
+    const screen = makeScreen({ id: '1', device, externalLink: 'url', fetchManual: true })
     screensRepo.findOne.mockResolvedValue(screen)
     await expect(service.updateExternalScreen('1')).resolves.toBeUndefined()
     const { downloadImage, convertToPng } = await import('../../utils/imageUtils.js')
@@ -158,16 +142,16 @@ describe('screensService', () => {
   })
 
   describe('reconvertImageScreens', () => {
-    const device = { id: 'dev' } as Device
+    const device = makeDevice({ id: 'dev' })
 
     it('reconverts uploads and cached external images from their original, or from the PNG when none is retained', async () => {
       screensRepo.find.mockResolvedValue([
-        { id: 'upload', type: 'file' },
-        { id: 'legacy', type: 'file' },
-        { id: 'cached', type: 'external', fetchManual: true },
-        { id: 'live', type: 'external', fetchManual: false },
-        { id: 'plugin', type: 'plugin' },
-        { id: 'markup', type: 'html' },
+        makeScreen({ id: 'upload', type: 'file', device }),
+        makeScreen({ id: 'legacy', type: 'file', device }),
+        makeScreen({ id: 'cached', type: 'external', device, fetchManual: true }),
+        makeScreen({ id: 'live', type: 'external', device, fetchManual: false }),
+        makeScreen({ id: 'plugin', type: 'plugin', device }),
+        makeScreen({ id: 'markup', type: 'html', device }),
       ])
       fileExistsMock.mockImplementation(async (p: string) => !p.endsWith('legacy.original'))
       const renameMock = vi.spyOn(fs.promises, 'rename').mockResolvedValue(undefined)
@@ -185,7 +169,7 @@ describe('screensService', () => {
     })
 
     it('keeps going when one screen fails to convert, cleaning up its temp file', async () => {
-      screensRepo.find.mockResolvedValue([{ id: 'a', type: 'file' }, { id: 'b', type: 'file' }])
+      screensRepo.find.mockResolvedValue([makeScreen({ id: 'a', type: 'file', device }), makeScreen({ id: 'b', type: 'file', device })])
       fileExistsMock.mockResolvedValue(true)
       vi.spyOn(fs.promises, 'rename').mockResolvedValue(undefined)
       const { convertToPng } = await import('../../utils/imageUtils.js')
@@ -207,14 +191,13 @@ describe('screensService', () => {
   })
 
   it('reorder reassigns order sequentially to match submitted array within a transaction', async () => {
-    const device = { id: 'dev' } as Device
+    const device = makeDevice({ id: 'dev' })
     devicesRepo.findOne.mockResolvedValue(device)
-    const screenA = { id: 'a', order: 1, device } as Screen
-    const screenB = { id: 'b', order: 2, device } as Screen
+    const screenA = makeScreen({ id: 'a', order: 1, device })
+    const screenB = makeScreen({ id: 'b', order: 2, device })
     screensRepo.find
       .mockResolvedValueOnce([screenA, screenB]) // fetch device screens
       .mockResolvedValueOnce([screenB, screenA]) // getByDevice after reorder
-    screensRepo.save.mockResolvedValue(undefined)
 
     const result = await service.reorder('dev', ['b', 'a'])
 
@@ -227,39 +210,39 @@ describe('screensService', () => {
   })
 
   it('reorder rejects payload with duplicate ids', async () => {
-    const device = { id: 'dev' } as Device
+    const device = makeDevice({ id: 'dev' })
     devicesRepo.findOne.mockResolvedValue(device)
-    const screenA = { id: 'a', order: 1, device } as Screen
-    const screenB = { id: 'b', order: 2, device } as Screen
+    const screenA = makeScreen({ id: 'a', order: 1, device })
+    const screenB = makeScreen({ id: 'b', order: 2, device })
     screensRepo.find.mockResolvedValue([screenA, screenB])
 
     await expect(service.reorder('dev', ['a', 'a'])).rejects.toThrow(BadRequestException)
   })
 
   it('reorder rejects payload missing a screen id', async () => {
-    const device = { id: 'dev' } as Device
+    const device = makeDevice({ id: 'dev' })
     devicesRepo.findOne.mockResolvedValue(device)
-    const screenA = { id: 'a', order: 1, device } as Screen
-    const screenB = { id: 'b', order: 2, device } as Screen
+    const screenA = makeScreen({ id: 'a', order: 1, device })
+    const screenB = makeScreen({ id: 'b', order: 2, device })
     screensRepo.find.mockResolvedValue([screenA, screenB])
 
     await expect(service.reorder('dev', ['a'])).rejects.toThrow(BadRequestException)
   })
 
   it('reorder rejects payload with a foreign screen id', async () => {
-    const device = { id: 'dev' } as Device
+    const device = makeDevice({ id: 'dev' })
     devicesRepo.findOne.mockResolvedValue(device)
-    const screenA = { id: 'a', order: 1, device } as Screen
-    const screenB = { id: 'b', order: 2, device } as Screen
+    const screenA = makeScreen({ id: 'a', order: 1, device })
+    const screenB = makeScreen({ id: 'b', order: 2, device })
     screensRepo.find.mockResolvedValue([screenA, screenB])
 
     await expect(service.reorder('dev', ['a', 'foreign-id'])).rejects.toThrow(BadRequestException)
   })
 
   it('reorder rejects payload with an extra screen id', async () => {
-    const device = { id: 'dev' } as Device
+    const device = makeDevice({ id: 'dev' })
     devicesRepo.findOne.mockResolvedValue(device)
-    const screenA = { id: 'a', order: 1, device } as Screen
+    const screenA = makeScreen({ id: 'a', order: 1, device })
     screensRepo.find.mockResolvedValue([screenA])
 
     await expect(service.reorder('dev', ['a', 'b'])).rejects.toThrow(BadRequestException)

--- a/packages/api/src/screens/dto/__test__/reorder-screens.dto.spec.ts
+++ b/packages/api/src/screens/dto/__test__/reorder-screens.dto.spec.ts
@@ -38,7 +38,8 @@ describe('reorder-screens dto', () => {
 
   it('fails validation when screenIds contains non-string entries', async () => {
     const dto = new ReorderScreensDto()
-    dto.screenIds = [1, 2] as unknown as string[]
+    // @ts-expect-error deliberately non-string entries to prove validation rejects them
+    dto.screenIds = [1, 2]
 
     const errors = await validate(dto)
 

--- a/packages/api/src/test/fetch.ts
+++ b/packages/api/src/test/fetch.ts
@@ -1,0 +1,13 @@
+import type { Mock } from 'vitest'
+import { vi } from 'vitest'
+
+export function stubFetch(): Mock<typeof fetch> {
+  const mock = vi.fn<typeof fetch>()
+  vi.stubGlobal('fetch', mock)
+  return mock
+}
+
+export function jsonResponse(body: unknown, init: { status?: number, ok?: boolean } = {}): Response {
+  const status = init.status ?? (init.ok === false ? 500 : 200)
+  return new Response(JSON.stringify(body), { status })
+}

--- a/packages/api/src/test/fixtures.ts
+++ b/packages/api/src/test/fixtures.ts
@@ -1,0 +1,231 @@
+import type { DeviceModel } from '../device-models/entities/device-model.entity'
+import type { Palette } from '../device-models/entities/palette.entity'
+import type { DeviceSensor } from '../device-sensors/entities/device-sensor.entity'
+import type { Device } from '../devices/devices.entity'
+import type { Firmware } from '../firmware/entities/firmware.entity'
+import type { LogEntry } from '../logs/logs.entity'
+import type { MashupConfiguration } from '../mashup/entities/mashup-configuration.entity'
+import type { MashupSlot } from '../mashup/entities/mashup-slot.entity'
+import type { DevicePlugin } from '../plugins/entities/device-plugin.entity'
+import type { PluginDataSource } from '../plugins/entities/plugin-data-source.entity'
+import type { PluginField } from '../plugins/entities/plugin-field.entity'
+import type { PluginTemplate } from '../plugins/entities/plugin-template.entity'
+import type { PluginVariable } from '../plugins/entities/plugin-variable.entity'
+import type { Plugin } from '../plugins/entities/plugin.entity'
+import type { Schedule } from '../schedule/schedule.entity'
+import type { Screen } from '../screens/screens.entity'
+
+const FIXED_DATE = new Date('2026-01-01T00:00:00.000Z')
+
+export function makeDevice(overrides: Partial<Device> = {}): Device {
+  return {
+    id: 'device-1',
+    name: 'Test Device',
+    friendlyId: 'ABC123',
+    mac: 'AA:BB:CC:DD:EE:FF',
+    apikey: 'test-api-key',
+    refreshRate: 300,
+    specialFunction: 'identify',
+    sleepModeEnabled: false,
+    sleepScreenEnabled: false,
+    resetDevice: false,
+    updateFirmware: false,
+    lastSeen: FIXED_DATE,
+    screens: [],
+    logs: [],
+    ...overrides,
+  }
+}
+
+export function makeScreen(overrides: Partial<Screen> = {}): Screen {
+  return {
+    id: 'screen-1',
+    type: 'file',
+    fetchManual: false,
+    isActive: false,
+    order: 0,
+    generatedAt: FIXED_DATE,
+    device: makeDevice(),
+    ...overrides,
+  }
+}
+
+export function makeLogEntry(overrides: Partial<LogEntry> = {}): LogEntry {
+  return {
+    id: 'log-1',
+    entry: 'test log entry',
+    date: FIXED_DATE,
+    logId: 1,
+    device: makeDevice(),
+    ...overrides,
+  }
+}
+
+export function makeDeviceSensor(overrides: Partial<DeviceSensor> = {}): DeviceSensor {
+  return {
+    id: 'sensor-1',
+    kind: 'temperature',
+    value: 21,
+    unit: 'C',
+    device: makeDevice(),
+    ...overrides,
+  }
+}
+
+export function makePalette(overrides: Partial<Palette> = {}): Palette {
+  return {
+    id: 'palette-1',
+    name: 'Test Palette',
+    kind: 'official',
+    grays: 2,
+    frameworkClass: 'screen--1bit',
+    deprecated: false,
+    ...overrides,
+  }
+}
+
+export function makeDeviceModel(overrides: Partial<DeviceModel> = {}): DeviceModel {
+  return {
+    name: 'og_plus',
+    label: 'TRMNL OG (2-bit)',
+    description: null,
+    width: 800,
+    height: 480,
+    colors: 4,
+    bitDepth: 2,
+    scaleFactor: 1,
+    rotation: 0,
+    offsetX: 0,
+    offsetY: 0,
+    mimeType: 'image/png',
+    kind: 'trmnl',
+    paletteIds: ['bw', 'gray-4'],
+    cssClasses: ['screen--og_plus', 'screen--md', 'screen--density-1x'],
+    cssVariables: { '--screen-w': '800px', '--screen-h': '480px' },
+    imageSizeLimit: 90000,
+    deprecated: false,
+    syncedAt: null,
+    ...overrides,
+  }
+}
+
+export function makePlugin(overrides: Partial<Plugin> = {}): Plugin {
+  return {
+    id: 'plugin-1',
+    name: 'Test Plugin',
+    kind: 'Poll',
+    refreshInterval: 15,
+    createdAt: FIXED_DATE,
+    updatedAt: FIXED_DATE,
+    dataSources: [],
+    templates: [],
+    fields: [],
+    variables: [],
+    ...overrides,
+  }
+}
+
+export function makeDevicePlugin(overrides: Partial<DevicePlugin> = {}): DevicePlugin {
+  return {
+    id: 'device-plugin-1',
+    isActive: true,
+    order: 0,
+    device: makeDevice(),
+    plugin: makePlugin(),
+    ...overrides,
+  }
+}
+
+export function makePluginDataSource(overrides: Partial<PluginDataSource> = {}): PluginDataSource {
+  return {
+    id: 'data-source-1',
+    name: 'Test Source',
+    mode: 'fetch',
+    method: 'GET',
+    url: 'https://example.com/data',
+    order: 0,
+    plugin: makePlugin(),
+    ...overrides,
+  }
+}
+
+export function makePluginTemplate(overrides: Partial<PluginTemplate> = {}): PluginTemplate {
+  return {
+    id: 'template-1',
+    layout: 'full',
+    liquidMarkup: '<div>{{ trmnl }}</div>',
+    plugin: makePlugin(),
+    ...overrides,
+  }
+}
+
+export function makePluginField(overrides: Partial<PluginField> = {}): PluginField {
+  return {
+    id: 'field-1',
+    keyname: 'test_field',
+    fieldType: 'string',
+    name: 'Test Field',
+    required: false,
+    order: 0,
+    plugin: makePlugin(),
+    ...overrides,
+  }
+}
+
+export function makePluginVariable(overrides: Partial<PluginVariable> = {}): PluginVariable {
+  return {
+    id: 'variable-1',
+    key: 'API_KEY',
+    value: 'secret',
+    isSecret: false,
+    plugin: makePlugin(),
+    ...overrides,
+  }
+}
+
+export function makeMashupConfiguration(overrides: Partial<MashupConfiguration> = {}): MashupConfiguration {
+  return {
+    id: 'mashup-config-1',
+    layout: '2x1',
+    screen: makeScreen(),
+    slots: [],
+    createdAt: FIXED_DATE,
+    updatedAt: FIXED_DATE,
+    ...overrides,
+  }
+}
+
+export function makeFirmware(overrides: Partial<Firmware> = {}): Firmware {
+  return {
+    id: 'firmware-1',
+    version: '1.0.0',
+    kind: 'official-synced',
+    checksum: 'checksum-1',
+    compatibleModels: [],
+    deprecated: false,
+    ...overrides,
+  }
+}
+
+export function makeSchedule(overrides: Partial<Schedule> = {}): Schedule {
+  return {
+    id: 'schedule-1',
+    enabled: true,
+    screen: makeScreen(),
+    createdAt: FIXED_DATE,
+    updatedAt: FIXED_DATE,
+    ...overrides,
+  }
+}
+
+export function makeMashupSlot(overrides: Partial<MashupSlot> = {}): MashupSlot {
+  return {
+    id: 'mashup-slot-1',
+    position: 'top',
+    size: '1x1',
+    plugin: makePlugin(),
+    mashupConfiguration: makeMashupConfiguration(),
+    order: 0,
+    ...overrides,
+  }
+}

--- a/packages/api/src/test/fs.ts
+++ b/packages/api/src/test/fs.ts
@@ -1,0 +1,43 @@
+import type { Dirent, Stats } from 'node:fs'
+import * as fs from 'node:fs'
+import { vi } from 'vitest'
+
+export function makeStats(overrides: Partial<Pick<Stats, 'size' | 'mtimeMs'>> & { directory?: boolean } = {}): Stats {
+  const { directory = false, size = 0, mtimeMs = Date.now() } = overrides
+  return {
+    isDirectory: () => directory,
+    isFile: () => !directory,
+    size,
+    mtimeMs,
+  } as Stats
+}
+
+export function makeDirent(name: string, directory = false): Dirent {
+  return {
+    name,
+    isDirectory: () => directory,
+    isFile: () => !directory,
+  } as Dirent
+}
+
+/** The one documented boundary cast: `fs.promises.stat`'s real signature is overloaded on encoding options, which a test stub never varies. */
+export function mockStat(impl: (path: string) => Promise<Stats>) {
+  return vi.spyOn(fs.promises, 'stat').mockImplementation(impl as unknown as typeof fs.promises.stat)
+}
+
+/** The one documented boundary cast: `fs.promises.readdir`'s real signature is overloaded on `withFileTypes`, which a test stub never varies. */
+export function mockReaddir(impl: (path: string) => Promise<string[] | Dirent[]>) {
+  return vi.spyOn(fs.promises, 'readdir').mockImplementation(impl as unknown as typeof fs.promises.readdir)
+}
+
+/** The one documented boundary cast: `Express.Multer.File` carries a dozen disk-storage/stream fields no spec in this codebase reads — only the ones a test provides are populated. */
+export function makeMulterFile(overrides: Partial<Express.Multer.File> = {}): Express.Multer.File {
+  return {
+    fieldname: 'file',
+    originalname: 'upload.bin',
+    encoding: '7bit',
+    mimetype: 'application/octet-stream',
+    size: 0,
+    ...overrides,
+  } as Express.Multer.File
+}

--- a/packages/api/src/test/mockDeviceModelsService.ts
+++ b/packages/api/src/test/mockDeviceModelsService.ts
@@ -1,5 +1,5 @@
-import type { DeviceModel } from '../entities/device-model.entity'
-import type { Palette } from '../entities/palette.entity'
+import type { DeviceModel } from '../device-models/entities/device-model.entity'
+import type { Palette } from '../device-models/entities/palette.entity'
 import { vi } from 'vitest'
 
 export const OG_PLUS: DeviceModel = {

--- a/packages/api/src/test/mockPluginCollaborators.ts
+++ b/packages/api/src/test/mockPluginCollaborators.ts
@@ -1,0 +1,32 @@
+import type { FetchableDataSource } from '../plugins/services/plugin-data-fetcher.service'
+import { vi } from 'vitest'
+
+/**
+ * `fetchOrLiteral` routes to `fetchData` for a fetch-mode source (this mock replicates
+ * that routing, matching `PluginDataFetcherService.fetchOrLiteral`'s real implementation)
+ * or resolves `literalValue` directly for a literal-mode one — mirrored here so a spec
+ * that only configures `fetchData` still works against the `fetchOrLiteral` call sites
+ * every render/schedule/preview path now goes through.
+ */
+export function createMockPluginDataFetcherService() {
+  const fetchData = vi.fn()
+  const fetchOrLiteral = vi.fn((source: FetchableDataSource, templateContext?: object) =>
+    source.mode === 'literal'
+      ? Promise.resolve(source.literalValue ?? null)
+      : fetchData(source.method || 'GET', source.url || '', source.headers, source.body, templateContext))
+  return { fetchData, fetchOrLiteral }
+}
+
+export type MockPluginDataFetcherService = ReturnType<typeof createMockPluginDataFetcherService>
+
+export function createMockPluginRendererService() {
+  return { render: vi.fn() }
+}
+
+export type MockPluginRendererService = ReturnType<typeof createMockPluginRendererService>
+
+export function createMockPluginTransformService() {
+  return { transform: vi.fn() }
+}
+
+export type MockPluginTransformService = ReturnType<typeof createMockPluginTransformService>

--- a/packages/api/src/test/mockPluginCollaborators.ts
+++ b/packages/api/src/test/mockPluginCollaborators.ts
@@ -9,12 +9,16 @@ import { vi } from 'vitest'
  * every render/schedule/preview path now goes through.
  */
 export function createMockPluginDataFetcherService() {
-  const fetchData = vi.fn()
-  const fetchOrLiteral = vi.fn((source: FetchableDataSource, templateContext?: object) =>
-    source.mode === 'literal'
-      ? Promise.resolve(source.literalValue ?? null)
-      : fetchData(source.method || 'GET', source.url || '', source.headers, source.body, templateContext))
-  return { fetchData, fetchOrLiteral }
+  const mock = {
+    fetchData: vi.fn(),
+    fetchOrLiteral: vi.fn((source: FetchableDataSource, templateContext?: object) =>
+      source.mode === 'literal'
+        ? Promise.resolve(source.literalValue ?? null)
+        // Looked up off `mock` (not captured as a local) so a spec that reassigns
+        // `mockDataFetcher.fetchData = vi.fn()...` after construction is still honored.
+        : mock.fetchData(source.method || 'GET', source.url || '', source.headers, source.body, templateContext)),
+  }
+  return mock
 }
 
 export type MockPluginDataFetcherService = ReturnType<typeof createMockPluginDataFetcherService>

--- a/packages/api/src/test/mockRepository.ts
+++ b/packages/api/src/test/mockRepository.ts
@@ -1,0 +1,74 @@
+import type { DeepPartial, DeleteResult, FindManyOptions, FindOneOptions, FindOptionsWhere, InsertResult, ObjectLiteral, QueryDeepPartialEntity, RemoveOptions, Repository, SaveOptions, UpdateResult } from 'typeorm'
+import type { Mock } from 'vitest'
+import { vi } from 'vitest'
+
+/**
+ * A deliberately simplified view of `Repository<T>`'s methods: TypeORM overloads `create`,
+ * `save`, and `remove` on single-entity vs. array arguments, which defeats `vi.fn()`'s
+ * generic inference and makes `.mockImplementation()` unusable against the real overload
+ * set. Every spec in this codebase mocks these against a single entity, so that's the only
+ * shape modeled here.
+ */
+export interface MockRepository<T extends ObjectLiteral> {
+  find: Mock<(options?: FindManyOptions<T>) => Promise<T[]>>
+  findOne: Mock<(options: FindOneOptions<T>) => Promise<T | null>>
+  findOneBy: Mock<(where: FindOptionsWhere<T> | FindOptionsWhere<T>[]) => Promise<T | null>>
+  findBy: Mock<(where: FindOptionsWhere<T> | FindOptionsWhere<T>[]) => Promise<T[]>>
+  create: Mock<(entityLike?: DeepPartial<T>) => T>
+  save: Mock<(entity: T, options?: SaveOptions) => Promise<T>>
+  update: Mock<(criteria: FindOptionsWhere<T> | string | string[], partialEntity: QueryDeepPartialEntity<T>) => Promise<UpdateResult>>
+  delete: Mock<(criteria: FindOptionsWhere<T> | string | string[]) => Promise<DeleteResult>>
+  remove: Mock<(entity: T | T[], options?: RemoveOptions) => Promise<T | T[]>>
+  insert: Mock<(entity: QueryDeepPartialEntity<T>) => Promise<InsertResult>>
+  upsert: Mock<(entityOrEntities: QueryDeepPartialEntity<T>[], conflictPathsOrOptions: string[]) => Promise<InsertResult>>
+  maximum: Mock<(columnName: keyof T & string, where?: FindOptionsWhere<T>) => Promise<number | null>>
+  count: Mock<(options?: FindManyOptions<T>) => Promise<number>>
+}
+
+export function createMockRepository<T extends ObjectLiteral>(): MockRepository<T> {
+  return {
+    find: vi.fn(),
+    findOne: vi.fn(),
+    findOneBy: vi.fn(),
+    findBy: vi.fn(),
+    create: vi.fn((input?: unknown) => input),
+    save: vi.fn(async (input: unknown) => input),
+    update: vi.fn(),
+    delete: vi.fn(),
+    remove: vi.fn(async (input: unknown) => input),
+    insert: vi.fn(),
+    upsert: vi.fn(),
+    maximum: vi.fn(),
+    count: vi.fn(),
+  } as unknown as MockRepository<T>
+}
+
+/** The one documented boundary cast: a `MockRepository<T>` is a structural subset of `Repository<T>`, sufficient for constructor injection in tests. */
+export function asRepository<T extends ObjectLiteral>(mock: MockRepository<T>): Repository<T> {
+  return mock as unknown as Repository<T>
+}
+
+/** Pulls the `id` out of a `{ where: { id } }` find-options object, for specs whose mock `findOne`/`find` filters by id. Returns `undefined` for an array/absent `where`, which no spec in this codebase currently passes. */
+export function whereId<T extends ObjectLiteral>(options: FindOneOptions<T> | FindManyOptions<T>): string | undefined {
+  const where = options.where
+  if (!where || Array.isArray(where))
+    return undefined
+  return (where as { id?: string }).id
+}
+
+/** A `MockRepository<T>` whose `.manager` supports the two `EntityManager` members this codebase's transactions actually use: getting a scoped repository, and running a callback "in" a transaction (here, just invoking it — there's no real DB to isolate). */
+export interface MockTransactionalRepository<T extends ObjectLiteral> extends MockRepository<T> {
+  manager: {
+    getRepository: Mock<(target?: unknown) => MockTransactionalRepository<T>>
+    transaction: Mock<(cb: (manager: MockTransactionalRepository<T>['manager']) => Promise<void>) => Promise<void>>
+  }
+}
+
+export function createMockTransactionalRepository<T extends ObjectLiteral>(): MockTransactionalRepository<T> {
+  const repo = createMockRepository<T>() as MockTransactionalRepository<T>
+  repo.manager = {
+    getRepository: vi.fn(() => repo),
+    transaction: vi.fn(async cb => cb(repo.manager)),
+  }
+  return repo
+}

--- a/packages/api/src/test/mockService.ts
+++ b/packages/api/src/test/mockService.ts
@@ -1,0 +1,30 @@
+/**
+ * The one documented boundary cast for a hand-built service mock: a plain object of
+ * `vi.fn()`s is never structurally identical to the real class (private fields, method
+ * overloads), so it needs an `unknown` hop to satisfy a constructor parameter typed as
+ * the real service. Prefer a dedicated `createMockXService()` in this directory when the
+ * same service is faked across multiple spec files; reach for this generic helper for a
+ * mock that's local to a single spec.
+ */
+export function asService<T>(mock: object): T {
+  return mock as unknown as T
+}
+
+/**
+ * Overwrites a private field on a constructed instance with a test double — the same
+ * `unknown` hop as {@link asService}, scoped to assignment instead of construction, for
+ * specs that swap out a service's internal collaborator after the fact rather than
+ * through its constructor.
+ */
+export function injectPrivate<T extends object, V>(instance: T, key: string, value: V): void {
+  (instance as unknown as Record<string, V>)[key] = value
+}
+
+/**
+ * Invokes a private method on a constructed instance — the same `unknown` hop as
+ * {@link asService}, scoped to a single call, for specs asserting on private helper
+ * logic (e.g. a cron-expression builder) that isn't worth exposing publicly.
+ */
+export function callPrivate<R>(instance: object, key: string, ...args: unknown[]): R {
+  return (instance as unknown as Record<string, (...args: unknown[]) => R>)[key](...args)
+}

--- a/packages/api/src/utils/__test__/imageUtils.geometry.integration.spec.ts
+++ b/packages/api/src/utils/__test__/imageUtils.geometry.integration.spec.ts
@@ -6,6 +6,8 @@ import path from 'node:path'
 import { promisify } from 'node:util'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { TRMNL_MODELS_SNAPSHOT } from '../../device-models/data/trmnl-snapshot'
+import { makeDeviceModel, makePalette } from '../../test/fixtures'
+import { asService } from '../../test/mockService'
 import { convertToPng } from '../imageUtils'
 
 const execFileAsync = promisify(execFile)
@@ -22,7 +24,7 @@ const snapshotGeometries = Array.from(
   new Map(
     TRMNL_MODELS_SNAPSHOT.map(m => [
       `${m.width}x${m.height}@${m.rotation}+${m.offset_x}+${m.offset_y}`,
-      { name: m.name, width: m.width, height: m.height, rotation: m.rotation, offsetX: m.offset_x, offsetY: m.offset_y } as any,
+      makeDeviceModel({ name: m.name, width: m.width, height: m.height, rotation: m.rotation, offsetX: m.offset_x, offsetY: m.offset_y }),
     ]),
   ).values(),
 )
@@ -39,22 +41,22 @@ function magickAvailable(): boolean {
 
 // amazon_kindle_2024 from the TRMNL snapshot: the one model with a non-zero
 // offset, and the case #751 found producing an undersized output.
-const KINDLE_MODEL = {
+const KINDLE_MODEL = makeDeviceModel({
   name: 'amazon_kindle_2024',
   width: 1400,
   height: 840,
   rotation: 90,
   offsetX: 75,
   offsetY: 25,
-} as any
+})
 
-const GRAY_256: any = { id: 'gray-256', grays: 256, colors: null, frameworkClass: 'screen--8bit' }
+const GRAY_256 = makePalette({ id: 'gray-256', grays: 256, colors: null, frameworkClass: 'screen--8bit' })
 
 describe.runIf(magickAvailable())('convertToPng (real magick)', () => {
   let tmpDir: string
   let inputPath: string
   let outputPath: string
-  const logger = { log: () => {}, error: () => {} } as unknown as Logger
+  const logger = asService<Logger>({ log: () => {}, error: () => {} })
 
   beforeAll(async () => {
     tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'kuroshiro-imageutils-'))

--- a/packages/api/src/utils/__test__/imageUtils.spec.ts
+++ b/packages/api/src/utils/__test__/imageUtils.spec.ts
@@ -1,11 +1,15 @@
 import type { Logger } from '@nestjs/common'
 import { Buffer } from 'node:buffer'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { makeDeviceModel, makePalette } from '../../test/fixtures'
+import { asService } from '../../test/mockService'
 import { convertToPng, downloadImage, paletteConversion } from '../imageUtils'
+
+type ExecFileCallback = (error: Error | null, stdout: string, stderr: string) => void
 
 const mockExecFile = vi.fn()
 const mockFd = {
-  read: vi.fn().mockImplementation((buf: any) => {
+  read: vi.fn().mockImplementation((buf: Buffer) => {
     buf[0] = 0xFF
     buf[1] = 0xD8
     buf[2] = 0xFF
@@ -23,7 +27,7 @@ const mockFs = vi.hoisted(() => ({
 }))
 
 vi.mock('node:child_process', () => ({
-  execFile: (file: string, args: string[], callback: (error: Error | null, stdout: string, stderr: string) => void) => {
+  execFile: (file: string, args: string[], callback: ExecFileCallback) => {
     mockExecFile(file, args, callback)
   },
 }))
@@ -38,12 +42,12 @@ describe('imageUtils', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    mockLogger = {
+    mockLogger = asService<Logger>({
       log: vi.fn(),
       error: vi.fn(),
-    } as unknown as Logger
+    })
     mockFs.promises.open.mockResolvedValue(mockFd)
-    mockFd.read.mockImplementation((buf: any) => {
+    mockFd.read.mockImplementation((buf: Buffer) => {
       buf[0] = 0xFF
       buf[1] = 0xD8
       buf[2] = 0xFF
@@ -56,15 +60,15 @@ describe('imageUtils', () => {
     vi.resetAllMocks()
   })
 
-  const OG_PLUS = { name: 'og_plus', width: 800, height: 480, rotation: 0, offsetX: 0, offsetY: 0 } as any
-  const GRAY_4 = { id: 'gray-4', grays: 4, colors: null, frameworkClass: 'screen--2bit' } as any
-  const BW = { id: 'bw', grays: 2, colors: null, frameworkClass: 'screen--1bit' } as any
-  const GRAY_16 = { id: 'gray-16', grays: 16, colors: null, frameworkClass: 'screen--4bit' } as any
-  const COLOR_6A = { id: 'color-6a', grays: 2, colors: ['#FF0000', '#00FF00', '#0000FF', '#FFFF00', '#000000', '#FFFFFF'], frameworkClass: 'screen--color-6a' } as any
-  const COLOR_24 = { id: 'color-24bit', grays: 2, colors: null, frameworkClass: 'screen--color-full' } as any
+  const OG_PLUS = makeDeviceModel({ name: 'og_plus', width: 800, height: 480, rotation: 0, offsetX: 0, offsetY: 0 })
+  const GRAY_4 = makePalette({ id: 'gray-4', grays: 4, colors: null, frameworkClass: 'screen--2bit' })
+  const BW = makePalette({ id: 'bw', grays: 2, colors: null, frameworkClass: 'screen--1bit' })
+  const GRAY_16 = makePalette({ id: 'gray-16', grays: 16, colors: null, frameworkClass: 'screen--4bit' })
+  const COLOR_6A = makePalette({ id: 'color-6a', grays: 2, colors: ['#FF0000', '#00FF00', '#0000FF', '#FFFF00', '#000000', '#FFFFFF'], frameworkClass: 'screen--color-6a' })
+  const COLOR_24 = makePalette({ id: 'color-24bit', grays: 2, colors: null, frameworkClass: 'screen--color-full' })
 
   function magickSucceeds() {
-    mockExecFile.mockImplementation((_file: string, _args: string[], callback: any) => {
+    mockExecFile.mockImplementation((_file: string, _args: string[], callback: ExecFileCallback) => {
       callback(null, '', '')
     })
   }
@@ -74,7 +78,7 @@ describe('imageUtils', () => {
       expect(paletteConversion(BW)).toEqual({ kind: 'gray', levels: 2, bitDepth: 1 })
       expect(paletteConversion(GRAY_4)).toEqual({ kind: 'gray', levels: 4, bitDepth: 2 })
       expect(paletteConversion(GRAY_16)).toEqual({ kind: 'gray', levels: 16, bitDepth: 4 })
-      expect(paletteConversion({ id: 'gray-256', grays: 256, colors: null, frameworkClass: 'screen--4bit' } as any)).toEqual({ kind: 'gray', levels: 256, bitDepth: 8 })
+      expect(paletteConversion(makePalette({ id: 'gray-256', grays: 256, colors: null, frameworkClass: 'screen--4bit' }))).toEqual({ kind: 'gray', levels: 256, bitDepth: 8 })
     })
 
     it('maps colour palettes to their colour list and full-colour palettes to untouched colour', () => {
@@ -175,7 +179,7 @@ describe('imageUtils', () => {
     it('fits to the model size, rotates, then shifts the offset back into a full-canvas frame', async () => {
       mockFs.existsSync.mockReturnValue(true)
       magickSucceeds()
-      const kindle = { ...OG_PLUS, name: 'kindle', width: 1400, height: 840, rotation: 90, offsetX: 75, offsetY: 25 }
+      const kindle = makeDeviceModel({ ...OG_PLUS, name: 'kindle', width: 1400, height: 840, rotation: 90, offsetX: 75, offsetY: 25 })
 
       await convertToPng('/input.jpg', '/output.png', { model: kindle, palette: GRAY_4 }, mockLogger)
 
@@ -202,7 +206,7 @@ describe('imageUtils', () => {
     it('keeps the offset frame at the unrotated model size when rotation does not swap dimensions', async () => {
       mockFs.existsSync.mockReturnValue(true)
       magickSucceeds()
-      const shifted = { ...OG_PLUS, name: 'shifted', width: 1400, height: 840, rotation: 180, offsetX: 10, offsetY: 5 }
+      const shifted = makeDeviceModel({ ...OG_PLUS, name: 'shifted', width: 1400, height: 840, rotation: 180, offsetX: 10, offsetY: 5 })
 
       await convertToPng('/input.jpg', '/output.png', { model: shifted, palette: GRAY_4 }, mockLogger)
 
@@ -212,7 +216,7 @@ describe('imageUtils', () => {
 
     it('handles ImageMagick errors during colormap creation', async () => {
       mockFs.existsSync.mockReturnValue(false)
-      mockExecFile.mockImplementation((_file: string, args: string[], callback: any) => {
+      mockExecFile.mockImplementation((_file: string, args: string[], callback: ExecFileCallback) => {
         if (args.some(a => a.includes('colormap'))) {
           callback(new Error('ImageMagick failed'), '', 'ImageMagick error')
         }
@@ -227,7 +231,7 @@ describe('imageUtils', () => {
 
     it('handles ImageMagick errors during conversion', async () => {
       mockFs.existsSync.mockReturnValue(true)
-      mockExecFile.mockImplementation((_file: string, _args: string[], callback: any) => {
+      mockExecFile.mockImplementation((_file: string, _args: string[], callback: ExecFileCallback) => {
         callback(new Error('Conversion failed'), '', 'conversion stderr')
       })
 
@@ -237,7 +241,7 @@ describe('imageUtils', () => {
     })
 
     it('rejects unknown image formats', async () => {
-      mockFd.read.mockImplementation((buf: any) => {
+      mockFd.read.mockImplementation((buf: Buffer) => {
         buf[0] = 0x00
         buf[1] = 0x01
         return Promise.resolve()

--- a/packages/ui/eslint.config.ts
+++ b/packages/ui/eslint.config.ts
@@ -7,10 +7,4 @@ export default antfu(
       'ts/no-explicit-any': 'error',
     },
   },
-  {
-    files: ['**/__test__/**', '**/__tests__/**', '**/*.spec.ts'],
-    rules: {
-      'ts/no-explicit-any': 'warn',
-    },
-  },
 )

--- a/packages/ui/src/components/AddScreenCard.vue
+++ b/packages/ui/src/components/AddScreenCard.vue
@@ -123,6 +123,8 @@ async function submitAddScreen() {
   }
 }
 const { isDemo } = useDemoInfo()
+
+defineExpose({ filename, externalLink, addScreenInputValid })
 </script>
 
 <template>

--- a/packages/ui/src/components/DeviceInformationCard.vue
+++ b/packages/ui/src/components/DeviceInformationCard.vue
@@ -357,6 +357,21 @@ async function saveDevice() {
   })
 }
 const nameEditing = ref(false)
+
+defineExpose({
+  selectedModelName,
+  selectedPaletteId,
+  selectedFirmwareId,
+  sleepStartTime,
+  sleepEndTime,
+  pendingSpecialFunction,
+  sleepWindowValid,
+  firmwareOptions,
+  saveDevice,
+  triggerSpecialFunction,
+  triggerReset,
+  triggerFirmwareUpdate,
+})
 </script>
 
 <template>

--- a/packages/ui/src/components/PluginDataSourcesEditor.vue
+++ b/packages/ui/src/components/PluginDataSourcesEditor.vue
@@ -115,6 +115,14 @@ function onModeChange(source: EditableDataSource) {
     source.literalValueJson = ''
   }
 }
+
+defineExpose({
+  dataSources,
+  addDataSource,
+  removeDataSource,
+  syncLiteralValue,
+  onModeChange,
+})
 </script>
 
 <template>

--- a/packages/ui/src/components/RenderTargetPicker.vue
+++ b/packages/ui/src/components/RenderTargetPicker.vue
@@ -32,6 +32,8 @@ watch(selectedModel, (model) => {
 watch([selectedModel, selectedPalette], ([model, palette]) => {
   target.value = renderTargetFor({ deviceModel: model, palette }, deviceModelsStore)
 }, { immediate: true })
+
+defineExpose({ selectedModelName, selectedPaletteId })
 </script>
 
 <template>

--- a/packages/ui/src/components/ScreenListCard.vue
+++ b/packages/ui/src/components/ScreenListCard.vue
@@ -126,6 +126,12 @@ function previewScreen(screen: Screen) {
 
   showScreenPreview.value = true
 }
+
+defineExpose({
+  showScreenPreview,
+  previewMode,
+  selectedPreviewScreen,
+})
 </script>
 
 <template>

--- a/packages/ui/src/components/__test__/AddScreenCard.spec.ts
+++ b/packages/ui/src/components/__test__/AddScreenCard.spec.ts
@@ -61,7 +61,7 @@ describe('addScreenCard', () => {
         plugins: [createPinia(), vuetify],
       },
     })
-    const vm = wrapper.vm as any
+    const vm = wrapper.vm
     vm.filename = 'shot'
     vm.externalLink = 'https://example.com/image.png'
     await wrapper.vm.$nextTick()

--- a/packages/ui/src/components/__test__/DeviceInformationCard.spec.ts
+++ b/packages/ui/src/components/__test__/DeviceInformationCard.spec.ts
@@ -147,7 +147,7 @@ describe('deviceInformationCard', () => {
   it('sends the selected model and palette when saving', async () => {
     mockDevice.current = baseDevice({ deviceModel: OG_PLUS, palette: GRAY_4, refreshRate: 300 })
     const wrapper = mountCard()
-    const vm = wrapper.vm as any
+    const vm = wrapper.vm
     vm.selectedModelName = 'v2'
     vm.selectedPaletteId = 'gray-16'
     await vm.saveDevice()
@@ -157,7 +157,7 @@ describe('deviceInformationCard', () => {
   it('never includes the one-shot specialFunction/resetDevice fields in a regular save', async () => {
     mockDevice.current = baseDevice({ specialFunction: 'identify', resetDevice: true, refreshRate: 300 })
     const wrapper = mountCard()
-    const vm = wrapper.vm as any
+    const vm = wrapper.vm
     await vm.saveDevice()
     expect(updateDevice.mock.calls[0][1]).not.toHaveProperty('specialFunction')
     expect(updateDevice.mock.calls[0][1]).not.toHaveProperty('resetDevice')
@@ -166,7 +166,7 @@ describe('deviceInformationCard', () => {
   it('drops a palette the newly selected model does not support', async () => {
     mockDevice.current = baseDevice({ deviceModel: V2, palette: GRAY_16, refreshRate: 300 })
     const wrapper = mountCard()
-    const vm = wrapper.vm as any
+    const vm = wrapper.vm
     vm.selectedModelName = 'og_plus'
     await wrapper.vm.$nextTick()
     expect(vm.selectedPaletteId).toBeNull()
@@ -179,14 +179,14 @@ describe('deviceInformationCard', () => {
     it('pre-selects the device\'s currently pending special function', () => {
       mockDevice.current = baseDevice({ specialFunction: 'identify' })
       const wrapper = mountCard()
-      const vm = wrapper.vm as any
+      const vm = wrapper.vm
       expect(vm.pendingSpecialFunction).toBe('identify')
     })
 
     it('sends only the selected special function, isolated from the rest of the form', async () => {
       mockDevice.current = baseDevice({ name: 'Unsaved rename in progress' })
       const wrapper = mountCard()
-      const vm = wrapper.vm as any
+      const vm = wrapper.vm
       vm.pendingSpecialFunction = 'sleep'
       await vm.triggerSpecialFunction()
       expect(updateDevice).toHaveBeenCalledWith('device1', { specialFunction: 'sleep' })
@@ -197,7 +197,7 @@ describe('deviceInformationCard', () => {
     it('sends only resetDevice, isolated from the rest of the form', async () => {
       mockDevice.current = baseDevice({ name: 'Unsaved rename in progress' })
       const wrapper = mountCard()
-      const vm = wrapper.vm as any
+      const vm = wrapper.vm
       await vm.triggerReset()
       expect(updateDevice).toHaveBeenCalledWith('device1', { resetDevice: true })
     })
@@ -207,14 +207,14 @@ describe('deviceInformationCard', () => {
     it('pre-selects the device\'s currently assigned target firmware', () => {
       mockDevice.current = baseDevice({ deviceModel: OG_PLUS, targetFirmware: OFFICIAL_FW })
       const wrapper = mountCard()
-      const vm = wrapper.vm as any
+      const vm = wrapper.vm
       expect(vm.selectedFirmwareId).toBe('fw-1')
     })
 
     it('does nothing when triggered without a selected firmware', async () => {
       mockDevice.current = baseDevice({ deviceModel: OG_PLUS })
       const wrapper = mountCard()
-      const vm = wrapper.vm as any
+      const vm = wrapper.vm
       await vm.triggerFirmwareUpdate()
       expect(updateDevice).not.toHaveBeenCalled()
     })
@@ -222,7 +222,7 @@ describe('deviceInformationCard', () => {
     it('assigns the firmware and flips the update flag in a single call', async () => {
       mockDevice.current = baseDevice({ deviceModel: OG_PLUS })
       const wrapper = mountCard()
-      const vm = wrapper.vm as any
+      const vm = wrapper.vm
       vm.selectedFirmwareId = 'fw-1'
       await vm.triggerFirmwareUpdate()
       expect(updateDevice).toHaveBeenCalledWith('device1', { targetFirmwareId: 'fw-1', updateFirmware: true })
@@ -232,9 +232,9 @@ describe('deviceInformationCard', () => {
       const deprecatedFw = { ...OFFICIAL_FW, deprecated: true }
       mockDevice.current = baseDevice({ deviceModel: OG_PLUS, targetFirmware: deprecatedFw })
       const wrapper = mountCard()
-      const vm = wrapper.vm as any
+      const vm = wrapper.vm
       expect(vm.selectedFirmwareId).toBe('fw-1')
-      expect(vm.firmwareOptions.some((opt: any) => opt.value === 'fw-1')).toBe(true)
+      expect(vm.firmwareOptions.some(opt => opt.value === 'fw-1')).toBe(true)
     })
 
     it('shows an update pending chip while the flag is set', async () => {
@@ -250,7 +250,7 @@ describe('deviceInformationCard', () => {
     it('pre-fills the configured sleep window as time inputs', () => {
       mockDevice.current = baseDevice({ deviceModel: OG_PLUS, sleepModeEnabled: true, sleepStartTime: 22 * 3600, sleepEndTime: 6 * 3600 })
       const wrapper = mountCard()
-      const vm = wrapper.vm as any
+      const vm = wrapper.vm
       expect(vm.sleepStartTime).toBe('22:00')
       expect(vm.sleepEndTime).toBe('06:00')
     })
@@ -258,7 +258,7 @@ describe('deviceInformationCard', () => {
     it('leaves the time inputs empty when no window is configured', () => {
       mockDevice.current = baseDevice({ deviceModel: OG_PLUS })
       const wrapper = mountCard()
-      const vm = wrapper.vm as any
+      const vm = wrapper.vm
       expect(vm.sleepStartTime).toBe('')
       expect(vm.sleepEndTime).toBe('')
     })
@@ -266,7 +266,7 @@ describe('deviceInformationCard', () => {
     it('sends the sleep window converted back to seconds-since-midnight when saving', async () => {
       mockDevice.current = baseDevice({ deviceModel: OG_PLUS, refreshRate: 300, sleepModeEnabled: true, sleepScreenEnabled: true })
       const wrapper = mountCard()
-      const vm = wrapper.vm as any
+      const vm = wrapper.vm
       vm.sleepStartTime = '22:00'
       vm.sleepEndTime = '06:00'
       await vm.saveDevice()
@@ -281,7 +281,7 @@ describe('deviceInformationCard', () => {
     it('rejects enabling sleep mode without a full window and does not save', async () => {
       mockDevice.current = baseDevice({ deviceModel: OG_PLUS, refreshRate: 300, sleepModeEnabled: true })
       const wrapper = mountCard()
-      const vm = wrapper.vm as any
+      const vm = wrapper.vm
       vm.sleepStartTime = ''
       vm.sleepEndTime = ''
       expect(vm.sleepWindowValid).toBe(false)
@@ -293,7 +293,7 @@ describe('deviceInformationCard', () => {
       mockDevice.current = baseDevice({ deviceModel: OG_PLUS })
       const wrapper = mountCard()
       await wrapper.find('.v-expansion-panel-title').trigger('click')
-      const vm = wrapper.vm as any
+      const vm = wrapper.vm
       vm.sleepStartTime = '22:00'
       vm.sleepEndTime = '06:00'
       await wrapper.vm.$nextTick()

--- a/packages/ui/src/components/__test__/DeviceLogsCard.spec.ts
+++ b/packages/ui/src/components/__test__/DeviceLogsCard.spec.ts
@@ -1,9 +1,11 @@
+import type { useLogStore } from '@/stores/logs'
 import type { LogEntry } from '@/types.ts'
 import { mount } from '@vue/test-utils'
 import { createPinia } from 'pinia'
 import rop from 'resize-observer-polyfill'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import vuetify from '../../plugins/vuetify'
+import { asStore } from '../../test/mockStore'
 import DeviceLogsCard from '../DeviceLogsCard.vue'
 
 globalThis.ResizeObserver = rop
@@ -20,7 +22,7 @@ globalThis.window.matchMedia = globalThis.window.matchMedia || function () {
 }
 
 // Use a local variable to control the mock return value
-let logStoreMock: any
+let logStoreMock: ReturnType<typeof useLogStore>
 vi.mock('@/stores/logs', () => ({
   useLogStore: () => logStoreMock,
 }))
@@ -33,12 +35,12 @@ vi.mock('@/stores/device', () => ({
 
 describe('deviceLogsCard', () => {
   beforeEach(() => {
-    logStoreMock = {
+    logStoreMock = asStore<ReturnType<typeof useLogStore>>({
       error: '',
       logEntries: [] as LogEntry[],
       loading: false,
       clearLogs: vi.fn(),
-    }
+    })
   })
 
   it('renders without error and shows empty state', () => {

--- a/packages/ui/src/components/__test__/PluginCard.spec.ts
+++ b/packages/ui/src/components/__test__/PluginCard.spec.ts
@@ -1,9 +1,11 @@
-import type { Plugin } from '@/types/plugin'
+import type { usePluginsStore } from '@/stores/plugins'
+import type { DeviceAssignment, Plugin } from '@/types/plugin'
 import { mount } from '@vue/test-utils'
 import { createPinia } from 'pinia'
 import rop from 'resize-observer-polyfill'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import vuetify from '../../plugins/vuetify'
+import { asStore } from '../../test/mockStore'
 import PluginCard from '../PluginCard.vue'
 
 globalThis.ResizeObserver = rop
@@ -29,7 +31,7 @@ Object.defineProperty(globalThis, 'visualViewport', {
   writable: true,
 })
 
-let pluginsStoreMock: any
+let pluginsStoreMock: ReturnType<typeof usePluginsStore>
 vi.mock('@/stores/plugins', () => ({
   usePluginsStore: () => pluginsStoreMock,
 }))
@@ -50,11 +52,11 @@ vi.mock('../PluginAssignDialog.vue', () => ({
 
 describe('pluginCard', () => {
   beforeEach(() => {
-    pluginsStoreMock = {
+    pluginsStoreMock = asStore<ReturnType<typeof usePluginsStore>>({
       deletePlugin: vi.fn(),
       updateDeviceAssignment: vi.fn(),
       fetchPluginsForDevice: vi.fn(),
-    }
+    })
     mockRouter.push.mockClear()
   })
 
@@ -93,9 +95,10 @@ describe('pluginCard', () => {
   })
 
   it('shows assigned device count when not on device page', () => {
+    const deviceAssignment = (id: string): DeviceAssignment => ({ id, isActive: true, order: 0, device: { id, name: `Device ${id}` } })
     const plugin = {
       ...basePlugin,
-      deviceAssignments: [{}, {}] as any,
+      deviceAssignments: [deviceAssignment('1'), deviceAssignment('2')],
     }
     const wrapper = mount(PluginCard, {
       props: { plugin },

--- a/packages/ui/src/components/__test__/PluginDataSourcesEditor.spec.ts
+++ b/packages/ui/src/components/__test__/PluginDataSourcesEditor.spec.ts
@@ -17,7 +17,7 @@ function mountEditor(dataSources: EditableDataSource[]) {
 describe('pluginDataSourcesEditor', () => {
   it('adds a new data source defaulting to fetch mode', async () => {
     const wrapper = mountEditor([])
-    const vm = wrapper.vm as any
+    const vm = wrapper.vm
 
     vm.addDataSource()
     await wrapper.vm.$nextTick()
@@ -31,7 +31,7 @@ describe('pluginDataSourcesEditor', () => {
   it('clears fetch fields when switching a source to literal mode', async () => {
     const source: EditableDataSource = { name: 'weather', mode: 'fetch', method: 'GET', url: 'https://api.example.com', headers: { A: 'b' }, headersJson: '{"A":"b"}' }
     const wrapper = mountEditor([source])
-    const vm = wrapper.vm as any
+    const vm = wrapper.vm
 
     vm.dataSources[0].mode = 'literal'
     vm.onModeChange(vm.dataSources[0])
@@ -46,7 +46,7 @@ describe('pluginDataSourcesEditor', () => {
   it('restores a default method and clears the literal value when switching a source back to fetch mode', async () => {
     const source: EditableDataSource = { name: 'title', mode: 'literal', literalValue: { text: 'Hi' }, literalValueJson: '{"text":"Hi"}' }
     const wrapper = mountEditor([source])
-    const vm = wrapper.vm as any
+    const vm = wrapper.vm
 
     vm.dataSources[0].mode = 'fetch'
     vm.onModeChange(vm.dataSources[0])
@@ -60,7 +60,7 @@ describe('pluginDataSourcesEditor', () => {
   it('parses literalValueJson into literalValue on sync', () => {
     const source: EditableDataSource = { name: 'title', mode: 'literal', literalValueJson: '' }
     const wrapper = mountEditor([source])
-    const vm = wrapper.vm as any
+    const vm = wrapper.vm
 
     vm.dataSources[0].literalValueJson = '{"text":"Hello"}'
     vm.syncLiteralValue(vm.dataSources[0])
@@ -71,7 +71,7 @@ describe('pluginDataSourcesEditor', () => {
   it('keeps the last valid literalValue while the JSON is being typed and invalid', () => {
     const source: EditableDataSource = { name: 'title', mode: 'literal', literalValue: { text: 'Hello' }, literalValueJson: '{"text":"Hello"}' }
     const wrapper = mountEditor([source])
-    const vm = wrapper.vm as any
+    const vm = wrapper.vm
 
     vm.dataSources[0].literalValueJson = '{"text": incomplete'
     vm.syncLiteralValue(vm.dataSources[0])
@@ -84,7 +84,7 @@ describe('pluginDataSourcesEditor', () => {
       { name: 'one', mode: 'fetch' },
       { name: 'two', mode: 'fetch' },
     ])
-    const vm = wrapper.vm as any
+    const vm = wrapper.vm
 
     vm.removeDataSource(0)
     await wrapper.vm.$nextTick()

--- a/packages/ui/src/components/__test__/RenderTargetPicker.spec.ts
+++ b/packages/ui/src/components/__test__/RenderTargetPicker.spec.ts
@@ -1,3 +1,5 @@
+import type { DeviceModel, Palette } from '@/types'
+import type { RenderTarget } from '@/utils/screenShell'
 import { mount } from '@vue/test-utils'
 import { createPinia } from 'pinia'
 import rop from 'resize-observer-polyfill'
@@ -6,24 +8,24 @@ import { defineComponent, ref } from 'vue'
 import vuetify from '../../plugins/vuetify'
 import RenderTargetPicker from '../RenderTargetPicker.vue'
 
-const OG = { name: 'og_plus', label: 'TRMNL OG', width: 800, height: 480, paletteIds: ['bw', 'gray-4'], cssClasses: [], cssVariables: {}, rotation: 0, deprecated: false }
-const V2 = { ...OG, name: 'v2', label: 'TRMNL X', width: 1872, height: 1404, paletteIds: ['gray-16', 'bw'] }
-const BW = { id: 'bw', name: 'bw', grays: 2, frameworkClass: 'screen--1bit', deprecated: false }
-const GRAY_4 = { id: 'gray-4', name: 'g4', grays: 4, frameworkClass: 'screen--2bit', deprecated: false }
-const GRAY_16 = { id: 'gray-16', name: 'g16', grays: 16, frameworkClass: 'screen--4bit', deprecated: false }
+const OG: DeviceModel = { name: 'og_plus', label: 'TRMNL OG', description: null, width: 800, height: 480, colors: 4, bitDepth: 2, scaleFactor: 1, rotation: 0, offsetX: 0, offsetY: 0, mimeType: 'image/png', kind: 'trmnl', paletteIds: ['bw', 'gray-4'], cssClasses: [], cssVariables: {}, deprecated: false }
+const V2: DeviceModel = { ...OG, name: 'v2', label: 'TRMNL X', width: 1872, height: 1404, paletteIds: ['gray-16', 'bw'] }
+const BW: Palette = { id: 'bw', name: 'bw', grays: 2, frameworkClass: 'screen--1bit', deprecated: false }
+const GRAY_4: Palette = { id: 'gray-4', name: 'g4', grays: 4, frameworkClass: 'screen--2bit', deprecated: false }
+const GRAY_16: Palette = { id: 'gray-16', name: 'g16', grays: 16, frameworkClass: 'screen--4bit', deprecated: false }
 
 vi.mock('@/stores/deviceModels', () => ({
   useDeviceModelsStore: () => ({
     ensureLoaded: vi.fn(),
     activeModels: [OG, V2],
     getByName: (name: string) => [OG, V2].find(m => m.name === name),
-    palettesFor: (model: any) => [BW, GRAY_4, GRAY_16].filter(p => model?.paletteIds.includes(p.id)),
+    palettesFor: (model: DeviceModel | null | undefined) => [BW, GRAY_4, GRAY_16].filter(p => model?.paletteIds.includes(p.id)),
   }),
 }))
 
 globalThis.ResizeObserver = rop
 
-function mountPicker(modelValue: any) {
+function mountPicker(modelValue: RenderTarget) {
   return mount(RenderTargetPicker, {
     props: { modelValue },
     global: { plugins: [createPinia(), vuetify] },
@@ -39,7 +41,7 @@ describe('renderTargetPicker', () => {
 
   it('re-emits with the new model and drops a palette it does not support', async () => {
     const wrapper = mountPicker({ model: OG, palette: GRAY_4 })
-    const vm = wrapper.vm as any
+    const vm = wrapper.vm
     vm.selectedPaletteId = 'gray-4'
     await wrapper.vm.$nextTick()
     vm.selectedModelName = 'v2'
@@ -58,7 +60,7 @@ describe('renderTargetPicker', () => {
 
   it('seeds its selection from an incoming modelValue, shown in the selects', () => {
     const wrapper = mountPicker({ model: V2, palette: GRAY_16 })
-    const vm = wrapper.vm as any
+    const vm = wrapper.vm
     expect(vm.selectedModelName).toBe('v2')
     expect(vm.selectedPaletteId).toBe('gray-16')
     expect(wrapper.get('[data-test-id="render-target-model"]').text()).toContain('TRMNL X')
@@ -69,7 +71,7 @@ describe('renderTargetPicker', () => {
     const Host = defineComponent({
       components: { RenderTargetPicker },
       setup() {
-        const target = ref({ model: OG, palette: GRAY_4 })
+        const target = ref<RenderTarget>({ model: OG, palette: GRAY_4 })
         const shown = ref(true)
         return { target, shown }
       },
@@ -79,21 +81,21 @@ describe('renderTargetPicker', () => {
     })
 
     const wrapper = mount(Host, { global: { plugins: [createPinia(), vuetify] } })
-    const picker = () => wrapper.findComponent(RenderTargetPicker).vm as any
+    const picker = () => wrapper.findComponent(RenderTargetPicker).vm
     picker().selectedModelName = 'v2'
     await wrapper.vm.$nextTick()
     await wrapper.vm.$nextTick()
-    const targetAfterEdit = (wrapper.vm as any).target
+    const targetAfterEdit = wrapper.vm.target
     expect(targetAfterEdit).toEqual({ model: V2, palette: GRAY_16 })
 
-    ;(wrapper.vm as any).shown = false
+    wrapper.vm.shown = false
     await wrapper.vm.$nextTick()
     expect(wrapper.findComponent(RenderTargetPicker).exists()).toBe(false)
 
-    ;(wrapper.vm as any).shown = true
+    wrapper.vm.shown = true
     await wrapper.vm.$nextTick()
 
-    expect((wrapper.vm as any).target).toEqual(targetAfterEdit)
+    expect(wrapper.vm.target).toEqual(targetAfterEdit)
     expect(picker().selectedModelName).toBe('v2')
     expect(picker().selectedPaletteId).toBe('gray-16')
   })

--- a/packages/ui/src/components/__test__/ScreenListCard.spec.ts
+++ b/packages/ui/src/components/__test__/ScreenListCard.spec.ts
@@ -1,8 +1,13 @@
+import type { Mocked } from 'vitest'
+import type { useScreensStore } from '@/stores/screens'
+import type { Screen } from '@/types'
 import { flushPromises, mount } from '@vue/test-utils'
 import { createPinia } from 'pinia'
 import rop from 'resize-observer-polyfill'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import vuetify from '../../plugins/vuetify'
+import { stubVisualViewport } from '../../test/browser'
+import { asStore } from '../../test/mockStore'
 import ScreenListCard from '../ScreenListCard.vue'
 
 globalThis.ResizeObserver = rop
@@ -18,20 +23,12 @@ globalThis.window.matchMedia = globalThis.window.matchMedia || function () {
   }
 }
 
-globalThis.visualViewport = globalThis.visualViewport || {
-  addEventListener: () => {},
-  removeEventListener: () => {},
-  width: 1024,
-  height: 768,
-  offsetLeft: 0,
-  offsetTop: 0,
-  pageLeft: 0,
-  pageTop: 0,
-  scale: 1,
-} as any
+globalThis.visualViewport = globalThis.visualViewport || stubVisualViewport()
+
+type ScreensStoreMock = Mocked<Pick<ReturnType<typeof useScreensStore>, 'screens' | 'deleteScreen' | 'updateExternalScreen' | 'reorderScreens'>>
 
 // Use a local variable to control the mock return value
-let screensStoreMock: any
+let screensStoreMock: ScreensStoreMock
 vi.mock('@/stores/screens', () => ({
   useScreensStore: () => screensStoreMock,
 }))
@@ -44,12 +41,12 @@ vi.mock('@/stores/device', () => ({
 
 describe('screenListCard', () => {
   beforeEach(() => {
-    screensStoreMock = {
+    screensStoreMock = asStore<ScreensStoreMock>({
       screens: [],
       deleteScreen: vi.fn(),
       updateExternalScreen: vi.fn(),
       reorderScreens: vi.fn(),
-    }
+    })
   })
 
   it('renders without error and shows empty state', () => {
@@ -130,9 +127,9 @@ describe('screenListCard', () => {
     await wrapper.vm.$nextTick()
     await wrapper.vm.$nextTick()
 
-    expect((wrapper.vm as any).showScreenPreview).toBe(true)
-    expect((wrapper.vm as any).previewMode).toBe('mashup')
-    expect((wrapper.vm as any).selectedPreviewScreen.cachedPluginOutput).toBe(cachedHtml)
+    expect(wrapper.vm.showScreenPreview).toBe(true)
+    expect(wrapper.vm.previewMode).toBe('mashup')
+    expect(wrapper.vm.selectedPreviewScreen?.cachedPluginOutput).toBe(cachedHtml)
 
     wrapper.unmount()
   })
@@ -155,8 +152,8 @@ describe('screenListCard', () => {
     await wrapper.vm.$nextTick()
     await wrapper.vm.$nextTick()
 
-    expect((wrapper.vm as any).showScreenPreview).toBe(true)
-    expect((wrapper.vm as any).previewMode).toBe('image')
+    expect(wrapper.vm.showScreenPreview).toBe(true)
+    expect(wrapper.vm.previewMode).toBe('image')
 
     const img = document.body.querySelector('img[alt="Screen preview"]')
     expect(img).not.toBeNull()
@@ -296,15 +293,15 @@ describe('screenListCard', () => {
     await wrapper.vm.$nextTick()
     await wrapper.vm.$nextTick()
 
-    expect((wrapper.vm as any).showScreenPreview).toBe(true)
-    expect((wrapper.vm as any).previewMode).toBe('mashup')
-    expect((wrapper.vm as any).selectedPreviewScreen.cachedPluginOutput).toBeNull()
+    expect(wrapper.vm.showScreenPreview).toBe(true)
+    expect(wrapper.vm.previewMode).toBe('mashup')
+    expect(wrapper.vm.selectedPreviewScreen?.cachedPluginOutput).toBeNull()
 
     wrapper.unmount()
   })
 
   describe('schedule column', () => {
-    function mountWithScreens(screens: any[]) {
+    function mountWithScreens(screens: Screen[]) {
       screensStoreMock.screens = screens
       return mount(ScreenListCard, {
         props: { deviceId: 'device1' },

--- a/packages/ui/src/components/__test__/ScreenPreviewCard.spec.ts
+++ b/packages/ui/src/components/__test__/ScreenPreviewCard.spec.ts
@@ -1,7 +1,9 @@
+import type { useScreensStore } from '@/stores/screens'
 import { mount } from '@vue/test-utils'
 import rop from 'resize-observer-polyfill'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import vuetify from '../../plugins/vuetify'
+import { asStore } from '../../test/mockStore'
 import ScreenPreviewCard from '../ScreenPreviewCard.vue'
 
 globalThis.ResizeObserver = rop
@@ -23,7 +25,7 @@ vi.mock('@/utils/formatDate', () => ({
 }))
 
 // Use a local variable to control the mock return value
-let screensStoreMock: any
+let screensStoreMock: ReturnType<typeof useScreensStore>
 vi.mock('@/stores/screens', () => ({
   useScreensStore: () => screensStoreMock,
 }))
@@ -36,7 +38,7 @@ vi.mock('@/stores/device', () => ({
 
 describe('screenPreviewCard', () => {
   beforeEach(() => {
-    screensStoreMock = {
+    screensStoreMock = asStore<ReturnType<typeof useScreensStore>>({
       fetchCurrentScreenForDevice: vi.fn(),
       screens: [],
       deleteScreen: vi.fn(),
@@ -47,7 +49,7 @@ describe('screenPreviewCard', () => {
         refresh_rate: 60,
         rendered_at: '2024-01-01T00:00:00Z',
       },
-    }
+    })
   })
 
   it('renders without error and shows image and date', () => {
@@ -67,7 +69,7 @@ describe('screenPreviewCard', () => {
   })
 
   it('renders non date if renderedAt is empty', () => {
-    screensStoreMock.currentScreen.rendered_at = undefined
+    screensStoreMock.currentScreen!.rendered_at = ''
     const wrapper = mount(ScreenPreviewCard, {
       props: { deviceId: 'device1' },
       global: {
@@ -82,7 +84,7 @@ describe('screenPreviewCard', () => {
   })
 
   it('renders default text on screen not available', () => {
-    screensStoreMock.currentScreen = undefined
+    screensStoreMock.currentScreen = null
     const wrapper = mount(ScreenPreviewCard, {
       props: { deviceId: 'device1' },
       global: {

--- a/packages/ui/src/components/__test__/ScreenScheduleDialog.spec.ts
+++ b/packages/ui/src/components/__test__/ScreenScheduleDialog.spec.ts
@@ -1,9 +1,13 @@
+import type { useScheduleStore } from '@/stores/schedule'
+import type { useScreensStore } from '@/stores/screens'
 import type { Screen } from '@/types'
 import { flushPromises, mount } from '@vue/test-utils'
 import { createPinia } from 'pinia'
 import rop from 'resize-observer-polyfill'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import vuetify from '../../plugins/vuetify'
+import { stubVisualViewport } from '../../test/browser'
+import { asStore } from '../../test/mockStore'
 import ScreenScheduleDialog from '../ScreenScheduleDialog.vue'
 
 globalThis.ResizeObserver = rop
@@ -19,29 +23,19 @@ globalThis.window.matchMedia = globalThis.window.matchMedia || function () {
   }
 }
 
-globalThis.visualViewport = globalThis.visualViewport || {
-  addEventListener: () => {},
-  removeEventListener: () => {},
-  width: 1024,
-  height: 768,
-  offsetLeft: 0,
-  offsetTop: 0,
-  pageLeft: 0,
-  pageTop: 0,
-  scale: 1,
-} as any
+globalThis.visualViewport = globalThis.visualViewport || stubVisualViewport()
 
-let scheduleStoreMock: any
+let scheduleStoreMock: ReturnType<typeof useScheduleStore>
 vi.mock('@/stores/schedule', () => ({
   useScheduleStore: () => scheduleStoreMock,
 }))
 
-let screensStoreMock: any
+let screensStoreMock: ReturnType<typeof useScreensStore>
 vi.mock('@/stores/screens', () => ({
   useScreensStore: () => screensStoreMock,
 }))
 
-const unscheduledScreen = { id: 'screen-1', filename: 'Bus times', isActive: false, device: 'device-1', fetchManual: false } as Screen
+const unscheduledScreen: Screen = { id: 'screen-1', filename: 'Bus times', isActive: false, device: 'device-1', fetchManual: false }
 
 function mountDialog(screen: Screen) {
   return mount(ScreenScheduleDialog, {
@@ -68,12 +62,12 @@ function clickButton(testId: string) {
 describe('screenScheduleDialog', () => {
   beforeEach(() => {
     document.body.innerHTML = ''
-    scheduleStoreMock = {
+    scheduleStoreMock = asStore<ReturnType<typeof useScheduleStore>>({
       create: vi.fn().mockResolvedValue({ id: 'schedule-1' }),
       update: vi.fn().mockResolvedValue({ id: 'schedule-1' }),
       remove: vi.fn().mockResolvedValue(undefined),
-    }
-    screensStoreMock = { fetchScreensForDevice: vi.fn().mockResolvedValue(undefined) }
+    })
+    screensStoreMock = asStore<ReturnType<typeof useScreensStore>>({ fetchScreensForDevice: vi.fn().mockResolvedValue(undefined) })
   })
 
   it('creates a schedule for a screen that has none', async () => {
@@ -97,7 +91,7 @@ describe('screenScheduleDialog', () => {
   })
 
   it('updates the existing schedule of an already scheduled screen', async () => {
-    const scheduled = { ...unscheduledScreen, schedule: { id: 'schedule-1', enabled: true, weekdays: [1, 2], startTime: '07:00:00', endTime: '09:00:00' } } as Screen
+    const scheduled: Screen = { ...unscheduledScreen, schedule: { id: 'schedule-1', enabled: true, weekdays: [1, 2], startTime: '07:00:00', endTime: '09:00:00' } }
     mountDialog(scheduled)
     await flushPromises()
 
@@ -118,7 +112,7 @@ describe('screenScheduleDialog', () => {
     expect(document.querySelector('[data-test-id="schedule-remove-btn"]')).toBeNull()
 
     document.body.innerHTML = ''
-    mountDialog({ ...unscheduledScreen, schedule: { id: 'schedule-1', enabled: true } } as Screen)
+    mountDialog({ ...unscheduledScreen, schedule: { id: 'schedule-1', enabled: true } })
     await flushPromises()
 
     await clickButton('schedule-remove-btn')

--- a/packages/ui/src/stores/__test__/deviceModels.spec.ts
+++ b/packages/ui/src/stores/__test__/deviceModels.spec.ts
@@ -1,5 +1,6 @@
 import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { jsonResponse, stubFetch } from '../../test/fetch'
 import { useDeviceModelsStore } from '../deviceModels'
 
 const OG_PLUS = { name: 'og_plus', label: 'TRMNL OG', width: 800, height: 480, paletteIds: ['bw', 'gray-4'], deprecated: false }
@@ -7,19 +8,17 @@ const OLD = { name: 'old', label: 'Old', width: 800, height: 480, paletteIds: ['
 const BW = { id: 'bw', name: 'Black & White (1-bit)', grays: 2 }
 const GRAY_4 = { id: 'gray-4', name: '4 Grays (2-bit)', grays: 4 }
 
-function jsonResponse(body: unknown, ok = true) {
-  return { ok, status: ok ? 200 : 503, statusText: ok ? 'OK' : 'Service Unavailable', json: async () => body }
-}
-
 describe('deviceModels store', () => {
+  let mockFetch: ReturnType<typeof stubFetch>
+
   beforeEach(() => {
     setActivePinia(createPinia())
-    globalThis.fetch = vi.fn()
+    mockFetch = stubFetch()
   })
 
   it('fetchAll loads models and palettes and exposes only active models', async () => {
-    ;(globalThis.fetch as any).mockImplementation(async (url: string) =>
-      url.endsWith('/palettes') ? jsonResponse([BW, GRAY_4]) : jsonResponse([OG_PLUS, OLD]))
+    mockFetch.mockImplementation(async url =>
+      String(url).endsWith('/palettes') ? jsonResponse([BW, GRAY_4]) : jsonResponse([OG_PLUS, OLD]))
     const store = useDeviceModelsStore()
     await store.fetchAll()
     expect(store.models).toHaveLength(2)
@@ -29,23 +28,25 @@ describe('deviceModels store', () => {
   })
 
   it('ensureLoaded only fetches on the first call once loaded', async () => {
-    ;(globalThis.fetch as any).mockResolvedValue(jsonResponse([]))
+    // A real `Response` body can only be read once — `fetchAll` reads both the
+    // models and palettes responses, so each `fetch()` call needs its own instance.
+    mockFetch.mockImplementation(async () => jsonResponse([]))
     const store = useDeviceModelsStore()
     await store.ensureLoaded()
     await store.ensureLoaded()
-    expect(globalThis.fetch).toHaveBeenCalledTimes(2)
+    expect(mockFetch).toHaveBeenCalledTimes(2)
   })
 
   it('ensureLoaded dedupes concurrent calls into a single fetchAll', async () => {
-    ;(globalThis.fetch as any).mockResolvedValue(jsonResponse([]))
+    mockFetch.mockImplementation(async () => jsonResponse([]))
     const store = useDeviceModelsStore()
     await Promise.all([store.ensureLoaded(), store.ensureLoaded(), store.ensureLoaded()])
-    expect(globalThis.fetch).toHaveBeenCalledTimes(2)
+    expect(mockFetch).toHaveBeenCalledTimes(2)
   })
 
   it('fetchAll records the status and statusText when a response is not ok', async () => {
-    ;(globalThis.fetch as any).mockImplementation(async (url: string) =>
-      url.endsWith('/palettes') ? jsonResponse([BW, GRAY_4]) : jsonResponse(null, false))
+    mockFetch.mockImplementation(async url =>
+      String(url).endsWith('/palettes') ? jsonResponse([BW, GRAY_4]) : jsonResponse(null, { status: 503, statusText: 'Service Unavailable' }))
     const store = useDeviceModelsStore()
     await store.fetchAll()
     expect(store.loaded).toBe(false)
@@ -54,20 +55,20 @@ describe('deviceModels store', () => {
 
   it('fetchAll clears a previous error on a later successful load', async () => {
     const store = useDeviceModelsStore()
-    ;(globalThis.fetch as any).mockResolvedValue(jsonResponse(null, false))
+    mockFetch.mockResolvedValue(jsonResponse(null, { status: 503, statusText: 'Service Unavailable' }))
     await store.fetchAll()
     expect(store.error).not.toBeNull()
 
-    ;(globalThis.fetch as any).mockImplementation(async (url: string) =>
-      url.endsWith('/palettes') ? jsonResponse([BW]) : jsonResponse([OG_PLUS]))
+    mockFetch.mockImplementation(async url =>
+      String(url).endsWith('/palettes') ? jsonResponse([BW]) : jsonResponse([OG_PLUS]))
     await store.fetchAll()
     expect(store.error).toBeNull()
     expect(store.loaded).toBe(true)
   })
 
   it('palettesFor returns the palettes a model allows, in the model order', async () => {
-    ;(globalThis.fetch as any).mockImplementation(async (url: string) =>
-      url.endsWith('/palettes') ? jsonResponse([GRAY_4, BW]) : jsonResponse([OG_PLUS]))
+    mockFetch.mockImplementation(async url =>
+      String(url).endsWith('/palettes') ? jsonResponse([GRAY_4, BW]) : jsonResponse([OG_PLUS]))
     const store = useDeviceModelsStore()
     await store.fetchAll()
     expect(store.palettesFor(store.getByName('og_plus'))).toEqual([BW, GRAY_4])
@@ -76,20 +77,20 @@ describe('deviceModels store', () => {
 
   it('sync posts to the sync endpoint and refreshes the lists', async () => {
     const result = { models: 1, palettes: 2, deprecatedModels: 0, deprecatedPalettes: 0, syncedAt: '2026-08-18T00:00:00.000Z' }
-    ;(globalThis.fetch as any).mockImplementation(async (url: string, init?: RequestInit) => {
+    mockFetch.mockImplementation(async (url, init) => {
       if (init?.method === 'POST')
         return jsonResponse(result)
-      return url.endsWith('/palettes') ? jsonResponse([BW]) : jsonResponse([OG_PLUS])
+      return String(url).endsWith('/palettes') ? jsonResponse([BW]) : jsonResponse([OG_PLUS])
     })
     const store = useDeviceModelsStore()
     await expect(store.sync()).resolves.toEqual(result)
-    expect(globalThis.fetch).toHaveBeenCalledWith('/api/device-models/sync', { method: 'POST' })
+    expect(mockFetch).toHaveBeenCalledWith('/api/device-models/sync', { method: 'POST' })
     expect(store.models).toEqual([OG_PLUS])
     expect(store.error).toBeNull()
   })
 
   it('sync records the server error message and returns null on failure', async () => {
-    ;(globalThis.fetch as any).mockResolvedValue(jsonResponse({ message: 'Could not sync device models from TRMNL: boom' }, false))
+    mockFetch.mockResolvedValue(jsonResponse({ message: 'Could not sync device models from TRMNL: boom' }, false))
     const store = useDeviceModelsStore()
     await expect(store.sync()).resolves.toBeNull()
     expect(store.error).toBe('Could not sync device models from TRMNL: boom')
@@ -97,7 +98,7 @@ describe('deviceModels store', () => {
   })
 
   it('fetchAll records a network failure instead of throwing', async () => {
-    ;(globalThis.fetch as any).mockRejectedValue(new TypeError('Failed to fetch'))
+    mockFetch.mockRejectedValue(new TypeError('Failed to fetch'))
     const store = useDeviceModelsStore()
     await expect(store.fetchAll()).resolves.toBeUndefined()
     expect(store.loaded).toBe(false)

--- a/packages/ui/src/stores/__test__/firmware.spec.ts
+++ b/packages/ui/src/stores/__test__/firmware.spec.ts
@@ -1,5 +1,6 @@
 import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { jsonResponse, stubFetch } from '../../test/fetch'
 import { useFirmwareStore } from '../firmware'
 
 const OFFICIAL = { id: 'fw-1', version: '1.5.6', kind: 'official-synced', compatibleModels: ['og_png', 'og_plus', 'og_bwry'], deprecated: false }
@@ -7,18 +8,16 @@ const CUSTOM_UNIVERSAL = { id: 'fw-2', version: '1.0.0', kind: 'custom', compati
 const CUSTOM_V2 = { id: 'fw-3', version: '2.0.0', kind: 'custom', compatibleModels: ['v2'], deprecated: false }
 const DEPRECATED = { id: 'fw-0', version: '1.5.5', kind: 'official-synced', compatibleModels: ['og_png'], deprecated: true }
 
-function jsonResponse(body: unknown, ok = true) {
-  return { ok, status: ok ? 200 : 503, statusText: ok ? 'OK' : 'Service Unavailable', json: async () => body }
-}
-
 describe('firmware store', () => {
+  let mockFetch: ReturnType<typeof stubFetch>
+
   beforeEach(() => {
     setActivePinia(createPinia())
-    globalThis.fetch = vi.fn()
+    mockFetch = stubFetch()
   })
 
   it('fetchAll loads firmware and exposes only active rows', async () => {
-    ;(globalThis.fetch as any).mockResolvedValue(jsonResponse([OFFICIAL, DEPRECATED]))
+    mockFetch.mockResolvedValue(jsonResponse([OFFICIAL, DEPRECATED]))
     const store = useFirmwareStore()
     await store.fetchAll()
     expect(store.firmware).toHaveLength(2)
@@ -27,14 +26,14 @@ describe('firmware store', () => {
   })
 
   it('ensureLoaded dedupes concurrent calls into a single fetchAll', async () => {
-    ;(globalThis.fetch as any).mockResolvedValue(jsonResponse([]))
+    mockFetch.mockResolvedValue(jsonResponse([]))
     const store = useFirmwareStore()
     await Promise.all([store.ensureLoaded(), store.ensureLoaded(), store.ensureLoaded()])
-    expect(globalThis.fetch).toHaveBeenCalledTimes(1)
+    expect(mockFetch).toHaveBeenCalledTimes(1)
   })
 
   it('fetchAll records the status and statusText when a response is not ok', async () => {
-    ;(globalThis.fetch as any).mockResolvedValue(jsonResponse(null, false))
+    mockFetch.mockResolvedValue(jsonResponse(null, { status: 503, statusText: 'Service Unavailable' }))
     const store = useFirmwareStore()
     await store.fetchAll()
     expect(store.loaded).toBe(false)
@@ -42,7 +41,7 @@ describe('firmware store', () => {
   })
 
   it('compatibleWith returns universal and model-matching firmware, excluding other models and deprecated rows', async () => {
-    ;(globalThis.fetch as any).mockResolvedValue(jsonResponse([OFFICIAL, CUSTOM_UNIVERSAL, CUSTOM_V2, DEPRECATED]))
+    mockFetch.mockResolvedValue(jsonResponse([OFFICIAL, CUSTOM_UNIVERSAL, CUSTOM_V2, DEPRECATED]))
     const store = useFirmwareStore()
     await store.fetchAll()
     expect(store.compatibleWith('og_plus')).toEqual([OFFICIAL, CUSTOM_UNIVERSAL])
@@ -51,7 +50,7 @@ describe('firmware store', () => {
   })
 
   it('getById finds a firmware row by id', async () => {
-    ;(globalThis.fetch as any).mockResolvedValue(jsonResponse([OFFICIAL]))
+    mockFetch.mockResolvedValue(jsonResponse([OFFICIAL]))
     const store = useFirmwareStore()
     await store.fetchAll()
     expect(store.getById('fw-1')).toEqual(OFFICIAL)
@@ -60,16 +59,16 @@ describe('firmware store', () => {
 
   it('sync posts to the sync endpoint and refreshes the list', async () => {
     const result = { inserted: true, version: '1.5.7' }
-    ;(globalThis.fetch as any).mockImplementation(async (url: string, init?: RequestInit) =>
+    mockFetch.mockImplementation(async (_url, init) =>
       init?.method === 'POST' ? jsonResponse(result) : jsonResponse([OFFICIAL]))
     const store = useFirmwareStore()
     await expect(store.sync()).resolves.toEqual(result)
-    expect(globalThis.fetch).toHaveBeenCalledWith('/api/firmware/sync', { method: 'POST' })
+    expect(mockFetch).toHaveBeenCalledWith('/api/firmware/sync', { method: 'POST' })
     expect(store.firmware).toEqual([OFFICIAL])
   })
 
   it('sync records the server error message and returns null on failure', async () => {
-    ;(globalThis.fetch as any).mockResolvedValue(jsonResponse({ message: 'Could not sync firmware from TRMNL: boom' }, false))
+    mockFetch.mockResolvedValue(jsonResponse({ message: 'Could not sync firmware from TRMNL: boom' }, false))
     const store = useFirmwareStore()
     await expect(store.sync()).resolves.toBeNull()
     expect(store.error).toBe('Could not sync firmware from TRMNL: boom')
@@ -78,7 +77,7 @@ describe('firmware store', () => {
 
   it('upload posts multipart form data and refreshes the list', async () => {
     let capturedBody: FormData | undefined
-    ;(globalThis.fetch as any).mockImplementation(async (url: string, init?: RequestInit) => {
+    mockFetch.mockImplementation(async (_url, init) => {
       if (init?.method === 'POST') {
         capturedBody = init.body as FormData
         return jsonResponse({ id: 'fw-2' })
@@ -96,7 +95,7 @@ describe('firmware store', () => {
   })
 
   it('upload records the server error and returns false on failure', async () => {
-    ;(globalThis.fetch as any).mockResolvedValue(jsonResponse({ message: 'Firmware upload must be a .bin file' }, false))
+    mockFetch.mockResolvedValue(jsonResponse({ message: 'Firmware upload must be a .bin file' }, false))
     const store = useFirmwareStore()
     const file = new File(['binary'], 'og.zip')
     await expect(store.upload(file, '1.0.0')).resolves.toBe(false)
@@ -105,15 +104,15 @@ describe('firmware store', () => {
   })
 
   it('remove deletes a firmware and refreshes the list', async () => {
-    ;(globalThis.fetch as any).mockImplementation(async (url: string, init?: RequestInit) =>
+    mockFetch.mockImplementation(async (_url, init) =>
       init?.method === 'DELETE' ? jsonResponse({}) : jsonResponse([]))
     const store = useFirmwareStore()
     await expect(store.remove('fw-2')).resolves.toBe(true)
-    expect(globalThis.fetch).toHaveBeenCalledWith('/api/firmware/fw-2', { method: 'DELETE' })
+    expect(mockFetch).toHaveBeenCalledWith('/api/firmware/fw-2', { method: 'DELETE' })
   })
 
   it('remove records the server error and returns false on failure', async () => {
-    ;(globalThis.fetch as any).mockResolvedValue(jsonResponse({ message: 'Only custom firmware can be deleted' }, false))
+    mockFetch.mockResolvedValue(jsonResponse({ message: 'Only custom firmware can be deleted' }, false))
     const store = useFirmwareStore()
     await expect(store.remove('fw-1')).resolves.toBe(false)
     expect(store.error).toBe('Only custom firmware can be deleted')

--- a/packages/ui/src/stores/__test__/maintenance.spec.ts
+++ b/packages/ui/src/stores/__test__/maintenance.spec.ts
@@ -1,8 +1,9 @@
 import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { jsonResponse, stubFetch } from '../../test/fetch'
 import { useMaintenanceStore } from '../maintenance'
 
-globalThis.fetch = vi.fn()
+const mockFetch = stubFetch()
 
 describe('maintenanceStore', () => {
   beforeEach(() => {
@@ -22,10 +23,7 @@ describe('maintenanceStore', () => {
         scannedAt: '2026-04-24T12:00:00Z',
       }
 
-      vi.mocked(fetch).mockResolvedValueOnce({
-        ok: true,
-        json: async () => mockIssues,
-      } as Response)
+      mockFetch.mockResolvedValueOnce(jsonResponse(mockIssues))
 
       const store = useMaintenanceStore()
       await store.scanSystem()
@@ -37,26 +35,22 @@ describe('maintenanceStore', () => {
     })
 
     it('sets loading state during scan', async () => {
-      vi.mocked(fetch).mockImplementationOnce(() =>
+      mockFetch.mockImplementationOnce(() =>
         new Promise(resolve =>
           setTimeout(
             () =>
-              resolve({
-                ok: true,
-                json: async () => ({
-                  orphanedScreenFiles: [],
-                  orphanedDeviceDirs: [],
-                  brokenScreens: [],
-                  tempFiles: [],
-                  oldUploads: [],
-                  totalSize: 0,
-                  scannedAt: '2026-04-24T12:00:00Z',
-                }),
-              } as Response),
+              resolve(jsonResponse({
+                orphanedScreenFiles: [],
+                orphanedDeviceDirs: [],
+                brokenScreens: [],
+                tempFiles: [],
+                oldUploads: [],
+                totalSize: 0,
+                scannedAt: '2026-04-24T12:00:00Z',
+              })),
             100,
           ),
-        ),
-      )
+        ))
 
       const store = useMaintenanceStore()
       const scanPromise = store.scanSystem()
@@ -69,10 +63,7 @@ describe('maintenanceStore', () => {
     })
 
     it('handles scan errors', async () => {
-      vi.mocked(fetch).mockResolvedValueOnce({
-        ok: false,
-        statusText: 'Internal Server Error',
-      } as Response)
+      mockFetch.mockResolvedValueOnce(new Response(null, { status: 500, statusText: 'Internal Server Error' }))
 
       const store = useMaintenanceStore()
 
@@ -83,7 +74,7 @@ describe('maintenanceStore', () => {
     })
 
     it('handles network errors', async () => {
-      vi.mocked(fetch).mockRejectedValueOnce(new Error('Network error'))
+      mockFetch.mockRejectedValueOnce(new Error('Network error'))
 
       const store = useMaintenanceStore()
 
@@ -104,10 +95,7 @@ describe('maintenanceStore', () => {
         errors: [],
       }
 
-      vi.mocked(fetch).mockResolvedValueOnce({
-        ok: true,
-        json: async () => mockResult,
-      } as Response)
+      mockFetch.mockResolvedValueOnce(jsonResponse(mockResult))
 
       const store = useMaintenanceStore()
       const result = await store.cleanupIssues(
@@ -146,10 +134,7 @@ describe('maintenanceStore', () => {
         errors: [],
       }
 
-      vi.mocked(fetch).mockResolvedValueOnce({
-        ok: true,
-        json: async () => mockResult,
-      } as Response)
+      mockFetch.mockResolvedValueOnce(jsonResponse(mockResult))
 
       const store = useMaintenanceStore()
       await store.cleanupIssues()
@@ -177,25 +162,19 @@ describe('maintenanceStore', () => {
         errors: [],
       }
 
-      vi.mocked(fetch).mockResolvedValueOnce({
-        ok: true,
-        json: async () => mockResult,
-      } as Response)
+      mockFetch.mockResolvedValueOnce(jsonResponse(mockResult))
 
       const store = useMaintenanceStore()
       await store.cleanupIssues(['/file.png'], [], [], [], [], true)
 
-      const callArgs = vi.mocked(fetch).mock.calls[0]
+      const callArgs = mockFetch.mock.calls[0]
       const body = JSON.parse(callArgs[1]!.body as string)
 
       expect(body.dryRun).toBe(true)
     })
 
     it('handles cleanup errors', async () => {
-      vi.mocked(fetch).mockResolvedValueOnce({
-        ok: false,
-        statusText: 'Forbidden',
-      } as Response)
+      mockFetch.mockResolvedValueOnce(new Response(null, { status: 500, statusText: 'Forbidden' }))
 
       const store = useMaintenanceStore()
 
@@ -206,7 +185,7 @@ describe('maintenanceStore', () => {
     })
 
     it('handles network errors during cleanup', async () => {
-      vi.mocked(fetch).mockRejectedValueOnce(new Error('Connection refused'))
+      mockFetch.mockRejectedValueOnce(new Error('Connection refused'))
 
       const store = useMaintenanceStore()
 
@@ -224,10 +203,7 @@ describe('maintenanceStore', () => {
         totalSize: 1024000,
       }
 
-      vi.mocked(fetch).mockResolvedValueOnce({
-        ok: true,
-        json: async () => mockStats,
-      } as Response)
+      mockFetch.mockResolvedValueOnce(jsonResponse(mockStats))
 
       const store = useMaintenanceStore()
       const result = await store.getStats()
@@ -237,10 +213,7 @@ describe('maintenanceStore', () => {
     })
 
     it('handles stats fetch errors', async () => {
-      vi.mocked(fetch).mockResolvedValueOnce({
-        ok: false,
-        statusText: 'Service Unavailable',
-      } as Response)
+      mockFetch.mockResolvedValueOnce(new Response(null, { status: 500, statusText: 'Service Unavailable' }))
 
       const store = useMaintenanceStore()
 
@@ -250,7 +223,7 @@ describe('maintenanceStore', () => {
     })
 
     it('handles network errors during stats fetch', async () => {
-      vi.mocked(fetch).mockRejectedValueOnce(new Error('Timeout'))
+      mockFetch.mockRejectedValueOnce(new Error('Timeout'))
 
       const store = useMaintenanceStore()
 
@@ -272,10 +245,7 @@ describe('maintenanceStore', () => {
         scannedAt: '2026-04-24T12:00:00Z',
       }
 
-      vi.mocked(fetch).mockResolvedValueOnce({
-        ok: true,
-        json: async () => mockIssues,
-      } as Response)
+      mockFetch.mockResolvedValueOnce(jsonResponse(mockIssues))
 
       const store = useMaintenanceStore()
       await store.scanSystem()

--- a/packages/ui/src/stores/__test__/plugins.spec.ts
+++ b/packages/ui/src/stores/__test__/plugins.spec.ts
@@ -1,54 +1,50 @@
-import type { Plugin } from '@/types/plugin'
 import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { jsonResponse, stubFetch } from '../../test/fetch'
 import { usePluginsStore } from '../plugins'
 
 describe('plugins store', () => {
+  let mockFetch: ReturnType<typeof stubFetch>
+
   beforeEach(() => {
     setActivePinia(createPinia())
-    globalThis.fetch = vi.fn()
+    mockFetch = stubFetch()
   })
 
-  const mockPlugin: Plugin = {
+  // Wire-format shape: `createdAt`/`updatedAt` are typed `Date` on `Plugin`, but a real
+  // response only ever carries ISO strings — these tests round-trip through a real
+  // `Response`, so match that instead of the `Plugin` type's client-side shape.
+  const mockPlugin = {
     id: 'plugin-1',
     name: 'Test Plugin',
     description: 'Test',
     kind: 'Poll',
     refreshInterval: 15,
-    createdAt: new Date(),
-    updatedAt: new Date(),
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
   }
 
   it('fetchPluginsForDevice fetches plugins for a device', async () => {
     const plugins = [mockPlugin]
-    ;(globalThis.fetch as any).mockResolvedValue({
-      ok: true,
-      json: async () => plugins,
-    })
+    mockFetch.mockResolvedValue(jsonResponse(plugins))
 
     const store = usePluginsStore()
     await store.fetchPluginsForDevice('device-1')
 
-    expect(globalThis.fetch).toHaveBeenCalledWith('/api/plugins/device/device-1')
+    expect(mockFetch).toHaveBeenCalledWith('/api/plugins/device/device-1')
     expect(store.plugins).toEqual(plugins)
   })
 
   it('createPlugin creates a new plugin', async () => {
     const newPlugin = { ...mockPlugin, device: { id: 'device-1' } }
-    ;(globalThis.fetch as any)
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => newPlugin,
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => [newPlugin],
-      })
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse(newPlugin))
+      .mockResolvedValueOnce(jsonResponse([newPlugin]))
 
     const store = usePluginsStore()
     const result = await store.createPlugin({ name: 'Test Plugin' })
 
-    expect(globalThis.fetch).toHaveBeenCalledWith('/api/plugins', {
+    expect(mockFetch).toHaveBeenCalledWith('/api/plugins', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name: 'Test Plugin' }),
@@ -58,15 +54,12 @@ describe('plugins store', () => {
 
   it('updatePlugin updates an existing plugin', async () => {
     const updatedPlugin = { ...mockPlugin, name: 'Updated Plugin' }
-    ;(globalThis.fetch as any).mockResolvedValue({
-      ok: true,
-      json: async () => updatedPlugin,
-    })
+    mockFetch.mockResolvedValue(jsonResponse(updatedPlugin))
 
     const store = usePluginsStore()
     const result = await store.updatePlugin('plugin-1', { name: 'Updated Plugin' })
 
-    expect(globalThis.fetch).toHaveBeenCalledWith('/api/plugins/plugin-1', {
+    expect(mockFetch).toHaveBeenCalledWith('/api/plugins/plugin-1', {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name: 'Updated Plugin' }),
@@ -75,35 +68,27 @@ describe('plugins store', () => {
   })
 
   it('deletePlugin deletes a plugin and refetches for device', async () => {
-    ;(globalThis.fetch as any)
-      .mockResolvedValueOnce({
-        ok: true,
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => [],
-      })
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse(null))
+      .mockResolvedValueOnce(jsonResponse([]))
 
     const store = usePluginsStore()
     await store.deletePlugin('plugin-1', 'device-1')
 
-    expect(globalThis.fetch).toHaveBeenCalledWith('/api/plugins/plugin-1', {
+    expect(mockFetch).toHaveBeenCalledWith('/api/plugins/plugin-1', {
       method: 'DELETE',
     })
-    expect(globalThis.fetch).toHaveBeenCalledWith('/api/plugins/device/device-1')
+    expect(mockFetch).toHaveBeenCalledWith('/api/plugins/device/device-1')
   })
 
   it('assignToDevice assigns plugin to device', async () => {
     const assignment = { id: 'dp-1' }
-    ;(globalThis.fetch as any).mockResolvedValue({
-      ok: true,
-      json: async () => assignment,
-    })
+    mockFetch.mockResolvedValue(jsonResponse(assignment))
 
     const store = usePluginsStore()
     const result = await store.assignToDevice('plugin-1', 'device-1', true, 0)
 
-    expect(globalThis.fetch).toHaveBeenCalledWith('/api/plugins/plugin-1/assign', {
+    expect(mockFetch).toHaveBeenCalledWith('/api/plugins/plugin-1/assign', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ deviceId: 'device-1', isActive: true, order: 0 }),
@@ -112,29 +97,24 @@ describe('plugins store', () => {
   })
 
   it('unassignFromDevice unassigns plugin from device', async () => {
-    ;(globalThis.fetch as any).mockResolvedValue({
-      ok: true,
-    })
+    mockFetch.mockResolvedValue(jsonResponse(null))
 
     const store = usePluginsStore()
     await store.unassignFromDevice('plugin-1', 'device-1')
 
-    expect(globalThis.fetch).toHaveBeenCalledWith('/api/plugins/plugin-1/unassign/device-1', {
+    expect(mockFetch).toHaveBeenCalledWith('/api/plugins/plugin-1/unassign/device-1', {
       method: 'DELETE',
     })
   })
 
   it('updateDeviceAssignment updates device assignment', async () => {
     const updated = { id: 'dp-1', isActive: false }
-    ;(globalThis.fetch as any).mockResolvedValue({
-      ok: true,
-      json: async () => updated,
-    })
+    mockFetch.mockResolvedValue(jsonResponse(updated))
 
     const store = usePluginsStore()
     const result = await store.updateDeviceAssignment('dp-1', { isActive: false })
 
-    expect(globalThis.fetch).toHaveBeenCalledWith('/api/plugins/device-assignment/dp-1', {
+    expect(mockFetch).toHaveBeenCalledWith('/api/plugins/device-assignment/dp-1', {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ isActive: false }),
@@ -143,9 +123,7 @@ describe('plugins store', () => {
   })
 
   it('throws error when fetch fails', async () => {
-    ;(globalThis.fetch as any).mockResolvedValue({
-      ok: false,
-    })
+    mockFetch.mockResolvedValue(jsonResponse(null, false))
 
     const store = usePluginsStore()
 
@@ -153,10 +131,7 @@ describe('plugins store', () => {
   })
 
   it('createPlugin surfaces the server\'s validation message on failure', async () => {
-    ;(globalThis.fetch as any).mockResolvedValue({
-      ok: false,
-      json: async () => ({ message: 'Data source name "trmnl" is reserved' }),
-    })
+    mockFetch.mockResolvedValue(jsonResponse({ message: 'Data source name "trmnl" is reserved' }, false))
 
     const store = usePluginsStore()
 
@@ -164,10 +139,7 @@ describe('plugins store', () => {
   })
 
   it('updatePlugin surfaces the server\'s validation message on failure', async () => {
-    ;(globalThis.fetch as any).mockResolvedValue({
-      ok: false,
-      json: async () => ({ message: 'Data source name "weather" is used by more than one data source' }),
-    })
+    mockFetch.mockResolvedValue(jsonResponse({ message: 'Data source name "weather" is used by more than one data source' }, false))
 
     const store = usePluginsStore()
 

--- a/packages/ui/src/stores/__test__/schedule.spec.ts
+++ b/packages/ui/src/stores/__test__/schedule.spec.ts
@@ -1,19 +1,19 @@
+import type { Mock } from 'vitest'
 import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { jsonResponse, stubFetch } from '../../test/fetch'
 import { useScheduleStore } from '../schedule'
 
-function jsonResponse(body: unknown, ok = true) {
-  return { ok, json: async () => body }
-}
-
 describe('schedule store', () => {
+  let mockFetch: Mock<typeof fetch>
+
   beforeEach(() => {
     setActivePinia(createPinia())
-    globalThis.fetch = vi.fn()
+    mockFetch = stubFetch()
   })
 
   it('creates a schedule on the screen', async () => {
-    ;(globalThis.fetch as any).mockResolvedValue(jsonResponse({ id: 'schedule-1', enabled: true }))
+    mockFetch.mockResolvedValue(jsonResponse({ id: 'schedule-1', enabled: true }))
     const store = useScheduleStore()
 
     const result = await store.create('screen-1', { weekdays: [1, 2] })
@@ -26,7 +26,7 @@ describe('schedule store', () => {
   })
 
   it('updates a schedule on the screen', async () => {
-    ;(globalThis.fetch as any).mockResolvedValue(jsonResponse({ id: 'schedule-1', enabled: false }))
+    mockFetch.mockResolvedValue(jsonResponse({ id: 'schedule-1', enabled: false }))
     const store = useScheduleStore()
 
     const result = await store.update('screen-1', { enabled: false })
@@ -36,7 +36,7 @@ describe('schedule store', () => {
   })
 
   it('deletes a schedule from the screen', async () => {
-    ;(globalThis.fetch as any).mockResolvedValue(jsonResponse(null))
+    mockFetch.mockResolvedValue(jsonResponse(null))
     const store = useScheduleStore()
 
     await store.remove('screen-1')
@@ -45,26 +45,21 @@ describe('schedule store', () => {
   })
 
   it('surfaces the API error message when a save is rejected', async () => {
-    ;(globalThis.fetch as any).mockResolvedValue(jsonResponse({ message: 'Screen already has a schedule' }, false))
+    mockFetch.mockResolvedValue(jsonResponse({ message: 'Screen already has a schedule' }, false))
     const store = useScheduleStore()
 
     await expect(store.create('screen-1', {})).rejects.toThrow('Screen already has a schedule')
   })
 
   it('joins the field-level validation messages the API returns', async () => {
-    ;(globalThis.fetch as any).mockResolvedValue(jsonResponse({ message: ['startTime must be a HH:MM time of day', 'weekdays must be an array'] }, false))
+    mockFetch.mockResolvedValue(jsonResponse({ message: ['startTime must be a HH:MM time of day', 'weekdays must be an array'] }, false))
     const store = useScheduleStore()
 
     await expect(store.update('screen-1', { startTime: 'nope' })).rejects.toThrow('startTime must be a HH:MM time of day, weekdays must be an array')
   })
 
   it('falls back to a generic message when the error body is unreadable', async () => {
-    ;(globalThis.fetch as any).mockResolvedValue({
-      ok: false,
-      json: async () => {
-        throw new Error('not json')
-      },
-    })
+    mockFetch.mockResolvedValue(new Response('not json', { status: 500 }))
     const store = useScheduleStore()
 
     await expect(store.remove('screen-1')).rejects.toThrow('Failed to delete schedule')

--- a/packages/ui/src/stores/__test__/screens.spec.ts
+++ b/packages/ui/src/stores/__test__/screens.spec.ts
@@ -1,19 +1,17 @@
 import { createPinia, setActivePinia } from 'pinia'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { jsonResponse, stubFetch } from '../../test/fetch'
 import { useScreensStore } from '../screens'
 
 describe('screens store', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
-    globalThis.fetch = vi.fn()
   })
 
   it('reorderScreens sends the ordered ids and stores the server-confirmed order', async () => {
+    const mockFetch = stubFetch()
     const reordered = [{ id: 'b', order: 1 }, { id: 'a', order: 2 }]
-    ;(globalThis.fetch as any).mockResolvedValue({
-      ok: true,
-      json: async () => reordered,
-    })
+    mockFetch.mockResolvedValue(jsonResponse(reordered))
 
     const store = useScreensStore()
     await store.reorderScreens('device-1', ['b', 'a'])
@@ -27,10 +25,11 @@ describe('screens store', () => {
   })
 
   it('reorderScreens refetches the device screens and throws on failure', async () => {
+    const mockFetch = stubFetch()
     const serverScreens = [{ id: 'a', order: 1 }, { id: 'b', order: 2 }]
-    ;(globalThis.fetch as any)
-      .mockResolvedValueOnce({ ok: false })
-      .mockResolvedValueOnce({ ok: true, json: async () => serverScreens })
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse(null, false))
+      .mockResolvedValueOnce(jsonResponse(serverScreens))
 
     const store = useScreensStore()
     await expect(store.reorderScreens('device-1', ['b', 'a'])).rejects.toThrow('Failed to reorder screens')

--- a/packages/ui/src/test/browser.ts
+++ b/packages/ui/src/test/browser.ts
@@ -1,0 +1,16 @@
+export function stubVisualViewport(): VisualViewport {
+  return {
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+    width: 1024,
+    height: 768,
+    offsetLeft: 0,
+    offsetTop: 0,
+    pageLeft: 0,
+    pageTop: 0,
+    scale: 1,
+    onresize: null,
+    onscroll: null,
+  }
+}

--- a/packages/ui/src/test/fetch.ts
+++ b/packages/ui/src/test/fetch.ts
@@ -1,0 +1,13 @@
+import type { Mock } from 'vitest'
+import { vi } from 'vitest'
+
+export function stubFetch(): Mock<typeof fetch> {
+  const mock = vi.fn<typeof fetch>()
+  vi.stubGlobal('fetch', mock)
+  return mock
+}
+
+export function jsonResponse(body: unknown, init: boolean | { ok?: boolean, status?: number, statusText?: string } = true): Response {
+  const { ok = true, status, statusText } = typeof init === 'boolean' ? { ok: init } : init
+  return new Response(JSON.stringify(body), { status: status ?? (ok ? 200 : 500), statusText })
+}

--- a/packages/ui/src/test/fixtures.ts
+++ b/packages/ui/src/test/fixtures.ts
@@ -1,0 +1,10 @@
+import type { RenderTarget } from '@/utils/screenShell'
+
+/**
+ * The one documented boundary cast for the cross-package screen-shell golden fixture
+ * (`test/fixtures/screen-shell.fixture.ts`), which is deliberately typed with only the
+ * fields the shared renderer reads rather than a full `DeviceModel`/`Palette`.
+ */
+export function asRenderTarget(fixture: { model: object, palette: object }): RenderTarget {
+  return fixture as unknown as RenderTarget
+}

--- a/packages/ui/src/test/mockStore.ts
+++ b/packages/ui/src/test/mockStore.ts
@@ -1,0 +1,8 @@
+/**
+ * The one documented boundary cast for a hand-built Pinia store mock: a plain object of
+ * `vi.fn()`s is never structurally identical to the real store (getters, `$patch`, etc.),
+ * so it needs an `unknown` hop to satisfy a prop or composable typed as the real store.
+ */
+export function asStore<T>(mock: object): T {
+  return mock as unknown as T
+}

--- a/packages/ui/src/utils/__test__/schedule.spec.ts
+++ b/packages/ui/src/utils/__test__/schedule.spec.ts
@@ -37,7 +37,7 @@ describe('scheduleSummary', () => {
 
 describe('screenScheduleLabel', () => {
   function screen(schedule: Schedule | null): Screen {
-    return { id: 'screen-1', isActive: false, device: 'device-1', fetchManual: false, schedule } as Screen
+    return { id: 'screen-1', isActive: false, device: 'device-1', fetchManual: false, schedule }
   }
 
   it('reads as always for a screen with no schedule', () => {

--- a/packages/ui/src/utils/__test__/screenShell.spec.ts
+++ b/packages/ui/src/utils/__test__/screenShell.spec.ts
@@ -1,10 +1,10 @@
-import type { RenderTarget } from '../screenShell'
 import type { DeviceModel, Palette } from '@/types'
 import { describe, expect, it } from 'vitest'
 import { SCREEN_SHELL_FIXTURE_BODY, SCREEN_SHELL_FIXTURE_EXPECTED, SCREEN_SHELL_FIXTURE_MODEL, SCREEN_SHELL_FIXTURE_PALETTE } from '../../../../../test/fixtures/screen-shell.fixture'
+import { asRenderTarget } from '../../test/fixtures'
 import { screenClasses, screenStyle, viewFull, wrapInScreenShell } from '../screenShell'
 
-const fixtureTarget = { model: SCREEN_SHELL_FIXTURE_MODEL, palette: SCREEN_SHELL_FIXTURE_PALETTE } as unknown as RenderTarget
+const fixtureTarget = asRenderTarget({ model: SCREEN_SHELL_FIXTURE_MODEL, palette: SCREEN_SHELL_FIXTURE_PALETTE })
 
 const V2: DeviceModel = {
   name: 'v2',

--- a/packages/ui/src/views/__test__/PluginsOverviewView.spec.ts
+++ b/packages/ui/src/views/__test__/PluginsOverviewView.spec.ts
@@ -1,9 +1,11 @@
+import type { Mock } from 'vitest'
 import type { Plugin } from '@/types/plugin'
 import { mount } from '@vue/test-utils'
 import { createPinia } from 'pinia'
 import rop from 'resize-observer-polyfill'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import vuetify from '../../plugins/vuetify'
+import { jsonResponse, stubFetch } from '../../test/fetch'
 import PluginsOverviewView from '../PluginsOverviewView.vue'
 
 globalThis.ResizeObserver = rop
@@ -27,8 +29,10 @@ vi.mock('vue-router', () => ({
 }))
 
 describe('pluginsOverviewView', () => {
+  let mockFetch: Mock<typeof fetch>
+
   beforeEach(() => {
-    globalThis.fetch = vi.fn()
+    mockFetch = stubFetch()
     mockRouter.push.mockClear()
   })
 
@@ -43,10 +47,7 @@ describe('pluginsOverviewView', () => {
   }
 
   it('renders empty state when no plugins', async () => {
-    ;(globalThis.fetch as any).mockResolvedValue({
-      ok: true,
-      json: async () => [],
-    })
+    mockFetch.mockResolvedValue(jsonResponse([]))
 
     const wrapper = mount(PluginsOverviewView, {
       global: {
@@ -62,10 +63,7 @@ describe('pluginsOverviewView', () => {
   })
 
   it('renders plugin cards when plugins exist', async () => {
-    ;(globalThis.fetch as any).mockResolvedValue({
-      ok: true,
-      json: async () => [mockPlugin],
-    })
+    mockFetch.mockResolvedValue(jsonResponse([mockPlugin]))
 
     const wrapper = mount(PluginsOverviewView, {
       global: {
@@ -80,10 +78,7 @@ describe('pluginsOverviewView', () => {
   })
 
   it('navigates to create plugin on button click', async () => {
-    ;(globalThis.fetch as any).mockResolvedValue({
-      ok: true,
-      json: async () => [],
-    })
+    mockFetch.mockResolvedValue(jsonResponse([]))
 
     const wrapper = mount(PluginsOverviewView, {
       global: {

--- a/packages/ui/tsconfig.app.json
+++ b/packages/ui/tsconfig.app.json
@@ -8,5 +8,5 @@
     }
   },
   "include": ["env.d.ts", "src/**/*", "src/**/*.vue"],
-  "exclude": ["src/**/__tests__/*"]
+  "exclude": ["src/**/__test__/*"]
 }

--- a/packages/ui/tsconfig.vitest.json
+++ b/packages/ui/tsconfig.vitest.json
@@ -3,9 +3,9 @@
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.vitest.tsbuildinfo",
 
-    "lib": [],
+    "lib": ["ES2022"],
     "types": ["node", "jsdom"]
   },
-  "include": ["src/**/__tests__/*", "env.d.ts"],
+  "include": ["src/**/__test__/*", "env.d.ts"],
   "exclude": []
 }


### PR DESCRIPTION
## Summary
- Closes #817. Follow-up to #816: introduces `packages/{api,ui}/src/test/` shared fixture builders (`makeDevice`, `makeScreen`, `makePlugin`, ... one per entity), a typed `createMockRepository<T>()`/`asRepository()` pair, `asService<T>()`/`injectPrivate()`/`callPrivate()` boundary casts for hand-built service mocks, and `stubFetch()`/`jsonResponse()` fetch stubs — then migrates all ~90 spec files across both packages onto them.
- Removes every production-source-adjacent `any` / `as any` / `as unknown as X` from test files (359 `as any`, 65 `as unknown as X`, ~120 hand-cast entity fixtures per #817's inventory), replacing hand-cast `{ ... } as Device` fixtures with the typed builders and `wrapper.vm as any` reads with narrowly-scoped `defineExpose` on the components under test.
- Flips `ts/no-explicit-any` to `error` for test files in both `eslint.config.*` (the `warn` override from #816 is gone) — `pnpm run lint` passes with zero exceptions.
- Unifies the UI's stray `stores/__tests__/maintenance.spec.ts` into `__test__`, and moves `mockDeviceModelsService.ts` into the shared `test/` directory.
- Rebased onto main after #827 (literal Data Source mode) landed underneath this branch; brought its new spec cases and `PluginDataSourcesEditor.spec.ts` onto the same patterns, and fixed a real bug the rebase surfaced in the shared `PluginDataFetcherService` mock (`fetchOrLiteral`'s routing wrapper captured `fetchData` in a closure at construction time, so a spec reassigning `mockDataFetcher.fetchData` afterward was silently ignored).

## Trade-off called out for review
- `DeviceInformationCard.vue`'s tests directly poke internal refs and call action methods (`saveDevice`, `triggerReset`, `triggerFirmwareUpdate`) rather than driving the DOM — this predates this PR (the original tests already did `wrapper.vm as any` to do the same thing; confirmed via `git diff origin/main`). Making those tests DOM-driven instead would be a real improvement but is a behavioral change to the tests, which is out of scope for a type-hygiene-only PR — the `defineExpose` there is the minimal, faithful fix for the existing test architecture.
- A handful of narrow `as X` casts remain by design and are not part of `no-explicit-any`'s remit: DOM narrowing (`querySelector(...) as HTMLElement`), `yaml.load(...) as ExportedManifest` (an inherently-untyped external parse), a `RequestInit.body as FormData` narrowing, and `await import(...) as TrmnlSnapshotModule` (an inherently-untyped dynamic import). None of these are entity fixtures standing in for real data.

## Test plan
- [x] `pnpm run type-check` passes (both packages)
- [x] `pnpm run lint` passes — 0 errors, no test-file override left
- [x] `pnpm run test` — 777 API tests + 5 skipped, 170 UI tests, matching counts before and after the migration (checked at each stage)
- [x] `grep -rnE '\bany\b' packages/*/src` (excluding `expect.any(...)` and English prose) returns zero real `any` hits, in tests or production source
- [x] `grep -rn 'as unknown as'` returns zero hits outside `packages/*/src/test/` helpers
- [x] `grep -rnE '\} as (Device|Screen|Plugin|MashupSlot|MashupConfiguration|LogEntry|Palette)\b'` returns zero hits
- [x] Ran `/code-review --level high`; of 4 findings, fixed the two concrete ones (a UI `jsonResponse` helper narrower than its API counterpart causing 3 fallback hand-rolled `Response`s; duplicated `PluginDataFetcherService`/`PluginRendererService`/`PluginTransformService` collaborator mocks now centralized in `test/mockPluginCollaborators.ts`) and left the `defineExpose` trade-off and a minor `makeX({ ...alreadyFullEntity })` redundancy as noted above/inline

https://claude.ai/code/session_012rgEKraJJbeNmwDLLuCan2