### PR TITLE
refactor(api): share random URL-safe token generator

### DIFF
--- a/.fallow-baselines/dupes.baseline.json
+++ b/.fallow-baselines/dupes.baseline.json
@@ -4,7 +4,6 @@
     "packages/ui/src/views/PluginCreateView.vue:414-459|packages/ui/src/views/PluginEditView.vue:398-443",
     "packages/ui/src/views/PluginCreateView.vue:128-172|packages/ui/src/views/PluginEditView.vue:145-191",
     "packages/api/src/maintenance/maintenance.service.ts:11-54|packages/ui/src/types.ts:140-183",
-    "packages/api/src/utils/generateApikey.ts:3-21|packages/api/src/utils/generateFriendlyName.ts:3-21",
     "packages/api/src/devices/display.service.ts:290-300|packages/api/src/devices/display.service.ts:84-94",
     "packages/api/src/mashup/mashup.service.ts:150-168|packages/api/src/mashup/mashup.service.ts:52-70",
     "packages/api/src/maintenance/maintenance.service.ts:233-252|packages/api/src/maintenance/maintenance.service.ts:254-273",
@@ -31,7 +30,6 @@
     "dup:3f7e87f2:2",
     "dup:15bba9f8:2",
     "dup:d32ddf4a:2",
-    "dup:ffabf660:2",
     "dup:04d1333c:2",
     "dup:6ce3de45:2",
     "dup:7a63f3f3:2",
@@ -55,7 +53,6 @@
   ],
   "normalized_clone_fingerprints": [
     "dup:c77b3abb6f87acd9-10:2",
-    "dup:c77b3abb6f87acd9-20:2",
     "dup:c77b3abb6f87acd9-2:2",
     "dup:a3006799:2",
     "dup:c77b3abb6f87acd9-12:2",

--- a/packages/api/src/utils/__test__/generateApikey.spec.ts
+++ b/packages/api/src/utils/__test__/generateApikey.spec.ts
@@ -1,11 +1,6 @@
-import buffer from 'node:buffer'
 import { describe, expect, it } from 'vitest'
 import generateApiKey from '../generateApikey'
-
-// Polyfill btoa for Node.js
-globalThis.btoa = globalThis.btoa || function (str: string) {
-  return buffer.Buffer.from(str, 'binary').toString('base64')
-}
+import randomUrlSafeToken from '../randomUrlSafeToken'
 
 describe('generateApiKey', () => {
   it('returns a string of length 22', () => {
@@ -22,5 +17,14 @@ describe('generateApiKey', () => {
   it('returns unique values for multiple calls', () => {
     const keys = new Set(Array.from({ length: 100 }, () => generateApiKey()))
     expect(keys.size).toBe(100)
+  })
+})
+
+describe('randomUrlSafeToken', () => {
+  it('returns the requested URL-safe token length', () => {
+    const token = randomUrlSafeToken(10)
+
+    expect(token).toHaveLength(10)
+    expect(token).toMatch(/^[A-Za-z0-9_-]+$/)
   })
 })

--- a/packages/api/src/utils/__test__/generateApikey.spec.ts
+++ b/packages/api/src/utils/__test__/generateApikey.spec.ts
@@ -25,6 +25,6 @@ describe('randomUrlSafeToken', () => {
     const token = randomUrlSafeToken(10)
 
     expect(token).toHaveLength(10)
-    expect(token).toMatch(/^[A-Za-z0-9_-]+$/)
+    expect(token).toMatch(/^[\w-]+$/i)
   })
 })

--- a/packages/api/src/utils/generateApikey.ts
+++ b/packages/api/src/utils/generateApikey.ts
@@ -1,22 +1,5 @@
-import { randomUUID } from 'node:crypto'
+import randomUrlSafeToken from './randomUrlSafeToken'
 
 export default function () {
-  // Remove hyphens from UUID
-  const cleanUuid = randomUUID().replace(/-/g, '')
-
-  // Convert hex string to byte array
-  const hexPairs = cleanUuid.match(/.{1,2}/g) || []
-  const byteArray = new Uint8Array(hexPairs.map(hex => Number.parseInt(hex, 16)))
-
-  // Convert to Base64
-  const base64 = btoa(String.fromCharCode.apply(null, Array.from(byteArray)))
-
-  // Make URL-safe by replacing + with - and / with _
-  const urlSafe = base64.replace(/\+/g, '-').replace(/\//g, '_')
-
-  // Remove padding (=) characters
-  const withoutPadding = urlSafe.replace(/=+$/, '')
-
-  // Truncate to 22 characters
-  return withoutPadding.substring(0, 22)
+  return randomUrlSafeToken(22)
 }

--- a/packages/api/src/utils/generateFriendlyName.ts
+++ b/packages/api/src/utils/generateFriendlyName.ts
@@ -1,22 +1,5 @@
-import { randomUUID } from 'node:crypto'
+import randomUrlSafeToken from './randomUrlSafeToken'
 
 export default function () {
-  // Remove hyphens from UUID
-  const cleanUuid = randomUUID().replace(/-/g, '')
-
-  // Convert hex string to byte array
-  const hexPairs = cleanUuid.match(/.{1,2}/g) || []
-  const byteArray = new Uint8Array(hexPairs.map(hex => Number.parseInt(hex, 16)))
-
-  // Convert to Base64
-  const base64 = btoa(String.fromCharCode.apply(null, Array.from(byteArray)))
-
-  // Make URL-safe by replacing + with - and / with _
-  const urlSafe = base64.replace(/\+/g, '-').replace(/\//g, '_')
-
-  // Remove padding (=) characters
-  const withoutPadding = urlSafe.replace(/=+$/, '')
-
-  // Truncate to 22 characters
-  return withoutPadding.substring(0, 6)
+  return randomUrlSafeToken(6)
 }

--- a/packages/api/src/utils/randomUrlSafeToken.ts
+++ b/packages/api/src/utils/randomUrlSafeToken.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'node:buffer'
 import { randomUUID } from 'node:crypto'
 
 export default function randomUrlSafeToken(length: number) {

--- a/packages/api/src/utils/randomUrlSafeToken.ts
+++ b/packages/api/src/utils/randomUrlSafeToken.ts
@@ -1,0 +1,5 @@
+import { randomUUID } from 'node:crypto'
+
+export default function randomUrlSafeToken(length: number) {
+  return Buffer.from(randomUUID().replace(/-/g, ''), 'hex').toString('base64url').slice(0, length)
+}


### PR DESCRIPTION
## Summary
- extract the shared UUID-to-URL-safe-token conversion
- preserve the existing API key and friendly-name helpers
- add token length and character coverage
- remove the resolved duplicate-code baseline entry

Closes #843

## Validation
- focused Vitest test: pass
- API type-check: pass
- targeted ESLint: pass
- duplicate-code baseline check: pass

The full health baseline command still reports existing unrelated baseline findings in this checkout; no health baseline changes are included.