### PR TITLE
chore(ui): remove unused Pinia store members

### DIFF
--- a/.fallow-baselines/dead-code.baseline.json
+++ b/.fallow-baselines/dead-code.baseline.json
@@ -31,12 +31,7 @@
   "unused_optional_dependencies": [],
   "unused_enum_members": [],
   "unused_class_members": [],
-  "unused_store_members": [
-    "packages/ui/src/stores/mashup.ts:useMashupStore.getConfiguration",
-    "packages/ui/src/stores/mashup.ts:useMashupStore.layouts",
-    "packages/ui/src/stores/mashup.ts:useMashupStore.update",
-    "packages/ui/src/stores/plugins.ts:usePluginsStore.testPlugin"
-  ],
+  "unused_store_members": [],
   "unprovided_injects": [],
   "unrendered_components": [],
   "unused_component_props": [],

--- a/packages/ui/src/components/AddMashupCard.vue
+++ b/packages/ui/src/components/AddMashupCard.vue
@@ -40,7 +40,6 @@ const availablePlugins = computed(() => {
 
 onMounted(async () => {
   await pluginsStore.fetchPluginsForDevice(props.deviceId)
-  await mashupStore.fetchLayouts()
 })
 
 function updateSlotCount() {

--- a/packages/ui/src/stores/mashup.ts
+++ b/packages/ui/src/stores/mashup.ts
@@ -1,17 +1,6 @@
-import type { MashupConfiguration } from '@/types/mashup'
 import { defineStore } from 'pinia'
-import { ref } from 'vue'
 
 export const useMashupStore = defineStore('mashup', () => {
-  const layouts = ref<Record<string, unknown> | null>(null)
-
-  async function fetchLayouts() {
-    const res = await fetch('/api/mashup/layouts')
-    if (!res.ok)
-      throw new Error('Failed to fetch layouts')
-    layouts.value = await res.json()
-  }
-
   async function create(deviceId: string, filename: string, layout: string, pluginIds: string[]) {
     const res = await fetch('/api/mashup', {
       method: 'POST',
@@ -25,25 +14,5 @@ export const useMashupStore = defineStore('mashup', () => {
     return await res.json()
   }
 
-  async function update(screenId: string, filename: string, layout: string, pluginIds: string[]) {
-    const res = await fetch(`/api/mashup/${screenId}`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ filename, layout, pluginIds }),
-    })
-    if (!res.ok) {
-      const error = await res.json()
-      throw new Error(error.message || 'Failed to update mashup')
-    }
-    return await res.json()
-  }
-
-  async function getConfiguration(screenId: string): Promise<MashupConfiguration> {
-    const res = await fetch(`/api/mashup/${screenId}/configuration`)
-    if (!res.ok)
-      throw new Error('Failed to fetch mashup configuration')
-    return await res.json()
-  }
-
-  return { layouts, fetchLayouts, create, update, getConfiguration }
+  return { create }
 })

--- a/packages/ui/src/stores/plugins.ts
+++ b/packages/ui/src/stores/plugins.ts
@@ -57,15 +57,6 @@ export const usePluginsStore = defineStore('plugins', () => {
     }
   }
 
-  const testPlugin = async (id: string) => {
-    const res = await fetch(`/api/plugins/${id}/test`, {
-      method: 'POST',
-    })
-    if (!res.ok)
-      throw new Error('Failed to test plugin')
-    return await res.json()
-  }
-
   const assignToDevice = async (pluginId: string, deviceId: string, isActive = true, order = 0) => {
     const res = await fetch(`/api/plugins/${pluginId}/assign`, {
       method: 'POST',
@@ -102,7 +93,6 @@ export const usePluginsStore = defineStore('plugins', () => {
     createPlugin,
     updatePlugin,
     deletePlugin,
-    testPlugin,
     assignToDevice,
     unassignFromDevice,
     updateDeviceAssignment,

--- a/packages/ui/src/types/mashup.ts
+++ b/packages/ui/src/types/mashup.ts
@@ -1,22 +1,3 @@
-export interface MashupConfiguration {
-  id: string
-  layout: '1Lx1R' | '1Tx1B' | '1Lx2R' | '2Lx1R' | '2Tx1B' | '1Tx2B' | '2x2'
-  slots: MashupSlot[]
-  createdAt: Date
-  updatedAt: Date
-}
-
-export interface MashupSlot {
-  id: string
-  position: string
-  size: string
-  plugin: {
-    id: string
-    name: string
-  }
-  order: number
-}
-
 export interface LayoutConfig {
   value: string
   label: string

--- a/packages/ui/src/views/MaintenanceView.vue
+++ b/packages/ui/src/views/MaintenanceView.vue
@@ -435,9 +435,9 @@ async function executeCleanup() {
 
         <template v-else-if="maintenanceStore.issues">
           <VCard elevation="1" class="mb-4">
-            <VCardTitle>
+            <VCardTitle class="d-flex align-center flex-wrap ga-2">
               Scan Summary
-              <VChip v-if="maintenanceStore.issues.scannedAt" size="small" class="ml-2">
+              <VChip v-if="maintenanceStore.issues.scannedAt" size="small">
                 {{ new Date(maintenanceStore.issues.scannedAt).toLocaleString() }}
               </VChip>
             </VCardTitle>


### PR DESCRIPTION
## Summary
- Removes `update`, `getConfiguration`, `layouts`/`fetchLayouts` from `useMashupStore` and `testPlugin` from `usePluginsStore` — fallow confirmed none have any callers, and `testPlugin`'s target endpoint doesn't even exist server-side.
- Drops the dead `await mashupStore.fetchLayouts()` call in `AddMashupCard.vue` (it derives layout info from a local computed instead).
- Removes the now-unused `MashupConfiguration`/`MashupSlot` types, which became dead once `getConfiguration` was removed (confirmed with a follow-up `fallow` run so no new finding was introduced).
- Re-saved `.fallow-baselines/dead-code.baseline.json` via `pnpm fallow:baseline` so this finding disappears from the baseline.
- The backend API routes (`GET /api/mashup/layouts`, `GET /api/mashup/:id/configuration`, `PUT /api/mashup/:id`) are left untouched for future UI work.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm type-check`
- [x] `pnpm test` (full suite, both packages)
- [x] `pnpm fallow:ci` passes with no new findings

Fixes #834

https://claude.ai/code/session_01Fu1iQqUdmCD5RDPNNjd7EY