### PR TITLE
refactor(ui): tidy two small clone groups (plugins grid, screen card setup)

### DIFF
--- a/.fallow-baselines/dupes.baseline.json
+++ b/.fallow-baselines/dupes.baseline.json
@@ -10,9 +10,7 @@
     "packages/api/src/devices/display.service.ts:532-540|packages/api/src/mashup/services/mashup-renderer.service.ts:70-78",
     "packages/ui/src/stores/plugins.ts:18-23|packages/ui/src/stores/plugins.ts:35-40",
     "packages/api/src/plugins/services/plugin-importer.service.ts:253-261|packages/api/src/plugins/services/plugin-importer.service.ts:436-444",
-    "packages/api/src/test/fixtures.ts:88-107|packages/api/src/test/mockDeviceModelsService.ts:5-24",
-    "packages/ui/src/views/PluginsOverviewView.vue:79-93|packages/ui/src/views/PluginsView.vue:72-86",
-    "packages/ui/src/components/AddScreenCard.vue:14-20|packages/ui/src/components/ScreenListCard.vue:15-20"
+    "packages/api/src/test/fixtures.ts:88-107|packages/api/src/test/mockDeviceModelsService.ts:5-24"
   ],
   "clone_fingerprints": [
     "dup:d32ddf4a:2",
@@ -25,23 +23,19 @@
     "dup:3219d03d:2",
     "dup:a7daa5d0:2",
     "dup:78a90f7a:2",
-    "dup:5304ed0c:2",
-    "dup:61dc4236:2",
-    "dup:a4f7ef05:2"
+    "dup:5304ed0c:2"
   ],
   "normalized_clone_fingerprints": [
     "dup:a3006799:2",
     "dup:c61b2099:2",
-    "dup:c77b3abb6f87acd9-6:2",
-    "dup:c77b3abb6f87acd9-1:2",
     "dup:c77b3abb6f87acd9-5:2",
-    "dup:c77b3abb6f87acd9-9:2",
-    "dup:f2fdd24f:2",
-    "dup:c77b3abb6f87acd9-8:2",
-    "dup:c77b3abb6f87acd9-3:2",
-    "dup:c77b3abb6f87acd9-7:2",
-    "dup:c77b3abb6f87acd9-2:2",
+    "dup:c77b3abb6f87acd9-1:2",
     "dup:c77b3abb6f87acd9-4:2",
-    "dup:88ad7b32:2"
+    "dup:c77b3abb6f87acd9-8:2",
+    "dup:f2fdd24f:2",
+    "dup:c77b3abb6f87acd9-7:2",
+    "dup:c77b3abb6f87acd9-3:2",
+    "dup:c77b3abb6f87acd9-6:2",
+    "dup:c77b3abb6f87acd9-2:2"
   ]
 }

--- a/.fallow-baselines/health.baseline.json
+++ b/.fallow-baselines/health.baseline.json
@@ -134,9 +134,9 @@
   "runtime_coverage_findings": [],
   "target_keys": [
     "packages/ui/src/stores/deviceModels.ts:high impact",
-    "packages/ui/src/components/ScreenListCard.vue:complexity",
     "packages/api/src/plugins/plugins.service.ts:complexity",
     "packages/api/src/devices/display.service.ts:complexity",
+    "packages/ui/src/components/ScreenListCard.vue:complexity",
     "packages/ui/src/components/DeviceInformationCard.vue:complexity",
     "packages/ui/src/components/DeviceLogsCard.vue:complexity",
     "packages/ui/src/views/MaintenanceView.vue:complexity"

--- a/packages/ui/src/components/AddScreenCard.vue
+++ b/packages/ui/src/components/AddScreenCard.vue
@@ -5,19 +5,13 @@ import { VBtn, VCard, VCardText, VCardTitle, VCol, VDivider, VFileInput, VForm, 
 import AddMashupCard from '@/components/AddMashupCard.vue'
 import ScreenFrame from '@/components/ScreenFrame.vue'
 import { useDemoInfo } from '@/composeables/useDemoInfo.ts'
-import { useDeviceRenderTarget } from '@/composeables/useDeviceRenderTarget'
-import { useDeviceStore } from '@/stores/device.ts'
-import { useScreensStore } from '@/stores/screens'
+import { useDeviceRenderContext } from '@/composeables/useDeviceRenderContext'
 import exampleHtml from '@/utils/exampleHtml'
 import { viewFull } from '@/utils/screenShell'
 
 const props = defineProps<{ deviceId: string }>()
 
-const screensStore = useScreensStore()
-const deviceStore = useDeviceStore()
-
-const device = computed(() => deviceStore.getById(props.deviceId))
-const renderTarget = useDeviceRenderTarget(device)
+const { device, renderTarget, screensStore } = useDeviceRenderContext(() => props.deviceId)
 
 const externalLink = ref('')
 const fetchManual = ref(false)

--- a/packages/ui/src/components/PluginCardGrid.vue
+++ b/packages/ui/src/components/PluginCardGrid.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import type { Plugin } from '@/types/plugin'
+import { VCol, VRow } from 'vuetify/components'
+import PluginCard from './PluginCard.vue'
+
+defineProps<{
+  plugins: Plugin[]
+  deviceId?: string
+}>()
+
+const emit = defineEmits<{
+  assignmentsChanged: []
+  deleted: []
+}>()
+</script>
+
+<template>
+  <VRow>
+    <VCol
+      v-for="plugin in plugins"
+      :key="plugin.id"
+      cols="12"
+      md="6"
+      lg="4"
+    >
+      <PluginCard :plugin="plugin" :device-id="deviceId" @assignments-changed="emit('assignmentsChanged')" @deleted="emit('deleted')" />
+    </VCol>
+  </VRow>
+</template>

--- a/packages/ui/src/components/ScreenListCard.vue
+++ b/packages/ui/src/components/ScreenListCard.vue
@@ -1,23 +1,18 @@
 <script setup lang="ts">
 import type { Screen } from '@/types'
 import { mdiCalendarClock, mdiChevronDown, mdiChevronUp, mdiDelete, mdiDrag, mdiEye, mdiOpenInNew, mdiRefresh } from '@mdi/js'
-import { computed, ref } from 'vue'
+import { ref } from 'vue'
 import { VAlert, VBtn, VCard, VCardActions, VCardText, VCardTitle, VChip, VDialog, VDivider, VIcon, VOverlay, VSpacer, VTable, VTooltip } from 'vuetify/components'
 import ScreenFrame from '@/components/ScreenFrame.vue'
 import ScreenScheduleDialog from '@/components/ScreenScheduleDialog.vue'
-import { useDeviceRenderTarget } from '@/composeables/useDeviceRenderTarget'
-import { useDeviceStore } from '@/stores/device.ts'
-import { useScreensStore } from '@/stores/screens'
+import { useDeviceRenderContext } from '@/composeables/useDeviceRenderContext'
 import { cacheBustedUrl } from '@/utils/cacheBustedUrl'
 import { screenScheduleColor, screenScheduleLabel } from '@/utils/schedule'
 import { viewFull } from '@/utils/screenShell'
 
 const props = defineProps<{ deviceId: string }>()
 
-const screensStore = useScreensStore()
-const deviceStore = useDeviceStore()
-const device = computed(() => deviceStore.getById(props.deviceId))
-const renderTarget = useDeviceRenderTarget(device)
+const { device, renderTarget, screensStore } = useDeviceRenderContext(() => props.deviceId)
 async function deleteScreen(screenId: string) {
   if (!device.value)
     return

--- a/packages/ui/src/components/__test__/PluginCardGrid.spec.ts
+++ b/packages/ui/src/components/__test__/PluginCardGrid.spec.ts
@@ -1,0 +1,61 @@
+import type { Plugin } from '@/types/plugin'
+import { mount } from '@vue/test-utils'
+import { createPinia } from 'pinia'
+import rop from 'resize-observer-polyfill'
+import { describe, expect, it } from 'vitest'
+import vuetify from '../../plugins/vuetify'
+import PluginCardGrid from '../PluginCardGrid.vue'
+
+globalThis.ResizeObserver = rop
+
+globalThis.window.matchMedia = globalThis.window.matchMedia || function () {
+  return {
+    matches: false,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  }
+}
+
+const plugins: Plugin[] = [
+  { id: 'plugin-1', name: 'Weather', description: '', kind: 'Poll', refreshInterval: 15, createdAt: new Date(), updatedAt: new Date() },
+  { id: 'plugin-2', name: 'Calendar', description: '', kind: 'Poll', refreshInterval: 15, createdAt: new Date(), updatedAt: new Date() },
+]
+
+describe('pluginCardGrid', () => {
+  it('renders one card per plugin', () => {
+    const wrapper = mount(PluginCardGrid, {
+      props: { plugins },
+      global: { plugins: [createPinia(), vuetify] },
+    })
+
+    expect(wrapper.text()).toContain('Weather')
+    expect(wrapper.text()).toContain('Calendar')
+  })
+
+  it('passes the optional deviceId through to each card', () => {
+    const wrapper = mount(PluginCardGrid, {
+      props: { plugins, deviceId: 'device1' },
+      global: { plugins: [createPinia(), vuetify] },
+    })
+
+    expect(wrapper.findComponent({ name: 'PluginCard' }).props('deviceId')).toBe('device1')
+  })
+
+  it('re-emits assignments-changed and deleted from a card', async () => {
+    const wrapper = mount(PluginCardGrid, {
+      props: { plugins },
+      global: { plugins: [createPinia(), vuetify] },
+    })
+
+    const card = wrapper.findComponent({ name: 'PluginCard' })
+    card.vm.$emit('assignmentsChanged')
+    card.vm.$emit('deleted')
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.emitted('assignmentsChanged')).toHaveLength(1)
+    expect(wrapper.emitted('deleted')).toHaveLength(1)
+  })
+})

--- a/packages/ui/src/composeables/__test__/useDeviceRenderContext.spec.ts
+++ b/packages/ui/src/composeables/__test__/useDeviceRenderContext.spec.ts
@@ -1,0 +1,35 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import { useDeviceRenderContext } from '../useDeviceRenderContext'
+
+const customModel = { name: 'custom', label: 'Custom', width: 1200, height: 825, colors: 4, bitDepth: 2, scaleFactor: 1, rotation: 0, offsetX: 0, offsetY: 0, mimeType: 'image/png', kind: 'trmnl', paletteIds: [], cssClasses: [], cssVariables: {}, deprecated: false }
+
+vi.mock('@/stores/device', () => ({
+  useDeviceStore: vi.fn(() => ({
+    getById: vi.fn((id: string) => (id === 'device1' ? { id: 'device1', deviceModel: customModel, palette: { id: 'p', name: 'p', grays: 4, frameworkClass: 'x', deprecated: false } } : undefined)),
+  })),
+}))
+
+describe('useDeviceRenderContext', () => {
+  it('resolves the device for the given id and exposes a render target and the screens store', () => {
+    setActivePinia(createPinia())
+
+    const { device, renderTarget, screensStore } = useDeviceRenderContext(() => 'device1')
+
+    expect(device.value?.id).toBe('device1')
+    expect(renderTarget.value.model.width).toBe(1200)
+    expect(screensStore).toBeDefined()
+  })
+
+  it('tracks changes to the underlying device id', () => {
+    setActivePinia(createPinia())
+    const currentId = ref('device1')
+
+    const { device } = useDeviceRenderContext(() => currentId.value)
+    expect(device.value?.id).toBe('device1')
+
+    currentId.value = 'missing'
+    expect(device.value).toBeUndefined()
+  })
+})

--- a/packages/ui/src/composeables/useDeviceRenderContext.ts
+++ b/packages/ui/src/composeables/useDeviceRenderContext.ts
@@ -1,0 +1,15 @@
+import { computed } from 'vue'
+import { useDeviceRenderTarget } from '@/composeables/useDeviceRenderTarget'
+import { useDeviceStore } from '@/stores/device'
+import { useScreensStore } from '@/stores/screens'
+
+/** Shared device lookup, render target, and screens store used by the screen-editing cards. */
+export function useDeviceRenderContext(deviceId: () => string) {
+  const screensStore = useScreensStore()
+  const deviceStore = useDeviceStore()
+
+  const device = computed(() => deviceStore.getById(deviceId()))
+  const renderTarget = useDeviceRenderTarget(device)
+
+  return { device, renderTarget, screensStore }
+}

--- a/packages/ui/src/stores/screens.ts
+++ b/packages/ui/src/stores/screens.ts
@@ -88,5 +88,6 @@ export const useScreensStore = defineStore('screens', () => {
     screens.value = await res.json()
   }
 
+  // fallow-ignore-next-line unused-store-member -- addScreen/addScreenFile/addScreenHtml/deleteScreen/updateExternalScreen are called through the screensStore destructured from the useDeviceRenderContext composable, which fallow can't trace through
   return { screens, currentScreen, fetchScreensForDevice, addScreen, addScreenFile, addScreenHtml, deleteScreen, updateExternalScreen, reorderScreens, fetchCurrentScreenForDevice }
 })

--- a/packages/ui/src/views/PluginsOverviewView.vue
+++ b/packages/ui/src/views/PluginsOverviewView.vue
@@ -4,7 +4,7 @@ import { mdiPlus, mdiSync, mdiUpload } from '@mdi/js'
 import { onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { VBtn, VCard, VCardText, VCardTitle, VCol, VContainer, VDivider, VIconBtn, VRow, VTooltip } from 'vuetify/components'
-import PluginCard from '../components/PluginCard.vue'
+import PluginCardGrid from '../components/PluginCardGrid.vue'
 import PluginImportDialog from '../components/PluginImportDialog.vue'
 
 const router = useRouter()
@@ -82,17 +82,12 @@ function onPluginImported() {
           </VCardTitle>
           <VDivider />
           <VCardText>
-            <VRow v-if="plugins.length">
-              <VCol
-                v-for="plugin in plugins"
-                :key="plugin.id"
-                cols="12"
-                md="6"
-                lg="4"
-              >
-                <PluginCard :plugin="plugin" @assignments-changed="fetchAllPlugins" @deleted="fetchAllPlugins" />
-              </VCol>
-            </VRow>
+            <PluginCardGrid
+              v-if="plugins.length"
+              :plugins="plugins"
+              @assignments-changed="fetchAllPlugins"
+              @deleted="fetchAllPlugins"
+            />
             <div v-else class="text-center py-12">
               <div class="text-h5 mb-2">
                 No plugins yet

--- a/packages/ui/src/views/PluginsView.vue
+++ b/packages/ui/src/views/PluginsView.vue
@@ -3,7 +3,7 @@ import { mdiDownload, mdiPlus, mdiSync } from '@mdi/js'
 import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { VAlert, VBtn, VCard, VCardText, VCardTitle, VCol, VContainer, VDivider, VIconBtn, VRow } from 'vuetify/components'
-import PluginCard from '../components/PluginCard.vue'
+import PluginCardGrid from '../components/PluginCardGrid.vue'
 import { useDeviceStore } from '../stores/device'
 import { usePluginsStore } from '../stores/plugins'
 
@@ -75,17 +75,13 @@ function createPlugin() {
           </VCardTitle>
           <VDivider />
           <VCardText>
-            <VRow v-if="plugins.length">
-              <VCol
-                v-for="plugin in plugins"
-                :key="plugin.id"
-                cols="12"
-                md="6"
-                lg="4"
-              >
-                <PluginCard :plugin="plugin" :device-id="deviceId" @assignments-changed="update" @deleted="update" />
-              </VCol>
-            </VRow>
+            <PluginCardGrid
+              v-if="plugins.length"
+              :plugins="plugins"
+              :device-id="deviceId"
+              @assignments-changed="update"
+              @deleted="update"
+            />
             <VAlert v-else type="info" variant="tonal" class="text-body-2">
               No plugins yet. Add one with the button above.
             </VAlert>


### PR DESCRIPTION
## What / why

Fallow flagged two duplicate clusters in `packages/ui`:

1. The `VRow`/`VCol` grid rendering `PluginCard` per plugin, duplicated between `PluginsOverviewView.vue` and `PluginsView.vue`.
2. The `deviceId` prop + `useScreensStore`/`useDeviceStore`/`device` computed/`useDeviceRenderTarget` setup, duplicated between `AddScreenCard.vue` and `ScreenListCard.vue`.

This extracts both into shared units, with no behavior change:

- `PluginCardGrid.vue`: takes `plugins`, optional `deviceId`, emits `assignmentsChanged`/`deleted`. Used by both plugin views.
- `useDeviceRenderContext(deviceId: () => string)`: a composable in `composeables/` returning `{ device, renderTarget, screensStore }`. Used by both screen cards.

`packages/ui/src/stores/screens.ts` gets one `// fallow-ignore-next-line unused-store-member` suppression: after the refactor, `useScreensStore()` is called inside the new composable rather than directly in the consuming components, so fallow's static dead-code analyzer can no longer trace that `addScreen`/`addScreenFile`/`addScreenHtml`/`deleteScreen`/`updateExternalScreen` are still called through the destructured `screensStore` — a documented false-positive per `docs/agents/fallow.md`.

`pnpm fallow:baseline` was re-run so both fixed duplication findings drop out of `.fallow-baselines/dupes.baseline.json` (no new findings added).

## Test plan

- [x] Added `useDeviceRenderContext.spec.ts` and `PluginCardGrid.spec.ts` (TDD red→green)
- [x] Existing `AddScreenCard.spec.ts` / `ScreenListCard.spec.ts` / `PluginsOverviewView.spec.ts` / `PluginsView.spec.ts` all pass unchanged, confirming no behavior change
- [x] `pnpm --filter ./packages/ui test` — 197/197 pass
- [x] `pnpm --filter ./packages/ui lint` and `type-check` (vue-tsc --build) — clean
- [x] `pnpm fallow:ci` — passes (no new findings; both baselined dupes fixed)
- [ ] `pnpm --filter ./packages/ui test:e2e` — could not run in this sandbox (headless Chrome fails to launch: missing shared libs unrelated to this change); the touched components have no e2e coverage in `e2e/viewport-overflow.spec.ts`, and all data-test-ids are unchanged

Closes #845

> *Opened by Kongroo, karakuri's Projects agent — Stage: implement*