### PR TITLE
refactor(ui): split DeviceLogsCard template into smaller components

### DIFF
--- a/.fallow-baselines/health.baseline.json
+++ b/.fallow-baselines/health.baseline.json
@@ -82,11 +82,6 @@
         "count": 1
       }
     },
-    "packages/ui/src/components/DeviceLogsCard.vue": {
-      "complexity_critical": {
-        "count": 1
-      }
-    },
     "packages/ui/src/components/PluginCard.vue": {
       "complexity_moderate": {
         "count": 1
@@ -134,11 +129,10 @@
   "runtime_coverage_findings": [],
   "target_keys": [
     "packages/ui/src/stores/deviceModels.ts:high impact",
-    "packages/api/src/plugins/plugins.service.ts:complexity",
     "packages/api/src/devices/display.service.ts:complexity",
+    "packages/api/src/plugins/plugins.service.ts:complexity",
     "packages/ui/src/components/ScreenListCard.vue:complexity",
     "packages/ui/src/components/DeviceInformationCard.vue:complexity",
-    "packages/ui/src/components/DeviceLogsCard.vue:complexity",
     "packages/ui/src/views/MaintenanceView.vue:complexity"
   ]
 }

--- a/packages/ui/src/components/DeviceLogAdditionalInfo.vue
+++ b/packages/ui/src/components/DeviceLogAdditionalInfo.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+import { VCol, VRow } from 'vuetify/components'
+
+defineProps<{ info: Record<string, string | number | null | undefined> }>()
+
+function formatValue(value: string | number | null | undefined) {
+  return value || '—'
+}
+</script>
+
+<template>
+  <div>
+    <div class="text-subtitle-2 mb-2 font-weight-bold">
+      Additional Info
+    </div>
+    <VRow dense>
+      <VCol
+        v-for="(value, key) in info"
+        :key="key"
+        cols="12"
+        sm="6"
+      >
+        <div class="text-caption text-medium-emphasis">
+          {{ key }}
+        </div>
+        <div class="text-body-2">
+          {{ formatValue(value) }}
+        </div>
+      </VCol>
+    </VRow>
+  </div>
+</template>

--- a/packages/ui/src/components/DeviceLogAdditionalInfo.vue
+++ b/packages/ui/src/components/DeviceLogAdditionalInfo.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
+import type { AdditionalInfoMap } from '@/types.ts'
 import { VCol, VRow } from 'vuetify/components'
 
-defineProps<{ info: Record<string, string | number | null | undefined> }>()
+defineProps<{ info: AdditionalInfoMap }>()
 
-function formatValue(value: string | number | null | undefined) {
+function formatValue(value: AdditionalInfoMap[string]) {
   return value || '—'
 }
 </script>

--- a/packages/ui/src/components/DeviceLogEntry.vue
+++ b/packages/ui/src/components/DeviceLogEntry.vue
@@ -21,7 +21,9 @@ function formatLogTimestamp(date: Date) {
   })
 }
 
-function getLogSeverity(message: string) {
+type LogSeverity = 'error' | 'warning' | 'info' | 'default'
+
+function getLogSeverity(message: string): LogSeverity {
   const lowerMessage = message.toLowerCase()
   if (lowerMessage.includes('error') || lowerMessage.includes('failed'))
     return 'error'
@@ -32,7 +34,7 @@ function getLogSeverity(message: string) {
   return 'default'
 }
 
-function getSeverityColor(severity: string) {
+function getSeverityColor(severity: LogSeverity) {
   switch (severity) {
     case 'error': return 'error'
     case 'warning': return 'warning'
@@ -41,7 +43,7 @@ function getSeverityColor(severity: string) {
   }
 }
 
-function getSeverityIcon(severity: string) {
+function getSeverityIcon(severity: LogSeverity) {
   switch (severity) {
     case 'error': return 'mdi-alert-circle'
     case 'warning': return 'mdi-alert'
@@ -50,16 +52,12 @@ function getSeverityIcon(severity: string) {
   }
 }
 
-function detailsToggleIcon(expanded: boolean) {
-  return expanded ? 'mdi-chevron-up' : 'mdi-chevron-down'
-}
-
-function detailsToggleAriaLabel(expanded: boolean) {
-  return expanded ? 'Hide log details' : 'Show log details'
-}
-
-function detailsToggleLabel(expanded: boolean) {
-  return expanded ? 'Less' : 'Show Details'
+function detailsToggleState(expanded: boolean) {
+  return {
+    icon: expanded ? 'mdi-chevron-up' : 'mdi-chevron-down',
+    ariaLabel: expanded ? 'Hide log details' : 'Show log details',
+    label: expanded ? 'Less' : 'Show Details',
+  }
 }
 
 const message = computed(() => props.parsed?.log_message || props.logEntry.entry)
@@ -105,11 +103,11 @@ const hasDetails = computed(() => !!props.parsed?.device_status_stamp || hasAddi
                 <VBtn
                   size="x-small"
                   variant="text"
-                  :prepend-icon="detailsToggleIcon(expanded)"
-                  :aria-label="detailsToggleAriaLabel(expanded)"
+                  :prepend-icon="detailsToggleState(expanded).icon"
+                  :aria-label="detailsToggleState(expanded).ariaLabel"
                   data-test-id="log-entry-details-toggle"
                 >
-                  {{ detailsToggleLabel(expanded) }}
+                  {{ detailsToggleState(expanded).label }}
                 </VBtn>
               </template>
             </VExpansionPanelTitle>

--- a/packages/ui/src/components/DeviceLogEntry.vue
+++ b/packages/ui/src/components/DeviceLogEntry.vue
@@ -1,0 +1,137 @@
+<script setup lang="ts">
+import type { LogEntry, ParsedDeviceLogPayload } from '@/types.ts'
+import { computed } from 'vue'
+import { VAvatar, VBtn, VCard, VCardText, VChip, VExpansionPanel, VExpansionPanels, VExpansionPanelText, VExpansionPanelTitle, VIcon, VListItem, VListItemSubtitle, VListItemTitle } from 'vuetify/components'
+import DeviceLogAdditionalInfo from './DeviceLogAdditionalInfo.vue'
+import DeviceLogStatusPanel from './DeviceLogStatusPanel.vue'
+
+const props = defineProps<{
+  logEntry: LogEntry
+  parsed: ParsedDeviceLogPayload | null
+}>()
+
+function formatLogTimestamp(date: Date) {
+  return new Date(date).toLocaleString('en-US', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  })
+}
+
+function getLogSeverity(message: string) {
+  const lowerMessage = message.toLowerCase()
+  if (lowerMessage.includes('error') || lowerMessage.includes('failed'))
+    return 'error'
+  if (lowerMessage.includes('warning') || lowerMessage.includes('warn'))
+    return 'warning'
+  if (lowerMessage.includes('info'))
+    return 'info'
+  return 'default'
+}
+
+function getSeverityColor(severity: string) {
+  switch (severity) {
+    case 'error': return 'error'
+    case 'warning': return 'warning'
+    case 'info': return 'info'
+    default: return 'default'
+  }
+}
+
+function getSeverityIcon(severity: string) {
+  switch (severity) {
+    case 'error': return 'mdi-alert-circle'
+    case 'warning': return 'mdi-alert'
+    case 'info': return 'mdi-information'
+    default: return 'mdi-circle-small'
+  }
+}
+
+function detailsToggleIcon(expanded: boolean) {
+  return expanded ? 'mdi-chevron-up' : 'mdi-chevron-down'
+}
+
+function detailsToggleAriaLabel(expanded: boolean) {
+  return expanded ? 'Hide log details' : 'Show log details'
+}
+
+function detailsToggleLabel(expanded: boolean) {
+  return expanded ? 'Less' : 'Show Details'
+}
+
+const message = computed(() => props.parsed?.log_message || props.logEntry.entry)
+const severity = computed(() => getLogSeverity(props.parsed?.log_message || ''))
+const hasAdditionalInfo = computed(() =>
+  !!props.parsed?.additional_info && Object.keys(props.parsed.additional_info).length > 0,
+)
+const hasDetails = computed(() => !!props.parsed?.device_status_stamp || hasAdditionalInfo.value)
+</script>
+
+<template>
+  <VListItem data-test-id="log-list-item">
+    <template #prepend>
+      <VAvatar :color="getSeverityColor(severity)" size="40">
+        <VIcon :icon="getSeverityIcon(severity)" />
+      </VAvatar>
+    </template>
+
+    <VListItemTitle class="text-wrap mb-2">
+      {{ message }}
+    </VListItemTitle>
+
+    <VListItemSubtitle>
+      <div class="d-flex flex-column gap-1">
+        <div class="d-flex align-center gap-2 flex-wrap">
+          <VChip size="x-small" prepend-icon="mdi-clock-outline" variant="text">
+            {{ formatLogTimestamp(logEntry.date) }}
+          </VChip>
+          <VChip
+            v-if="parsed?.log_sourcefile"
+            size="x-small"
+            prepend-icon="mdi-file-code"
+            variant="text"
+          >
+            {{ parsed.log_sourcefile }}:{{ parsed.log_codeline }}
+          </VChip>
+        </div>
+
+        <VExpansionPanels v-if="hasDetails" flat>
+          <VExpansionPanel elevation="0" class="bg-transparent">
+            <VExpansionPanelTitle class="pa-0 min-height-auto">
+              <template #default="{ expanded }">
+                <VBtn
+                  size="x-small"
+                  variant="text"
+                  :prepend-icon="detailsToggleIcon(expanded)"
+                  :aria-label="detailsToggleAriaLabel(expanded)"
+                  data-test-id="log-entry-details-toggle"
+                >
+                  {{ detailsToggleLabel(expanded) }}
+                </VBtn>
+              </template>
+            </VExpansionPanelTitle>
+            <VExpansionPanelText class="pa-0 mt-2">
+              <VCard variant="tonal" class="mb-2">
+                <VCardText class="pa-3">
+                  <DeviceLogStatusPanel v-if="parsed?.device_status_stamp" :status="parsed.device_status_stamp" />
+                  <DeviceLogAdditionalInfo v-if="hasAdditionalInfo" :info="parsed?.additional_info ?? {}" />
+                </VCardText>
+              </VCard>
+            </VExpansionPanelText>
+          </VExpansionPanel>
+        </VExpansionPanels>
+      </div>
+    </VListItemSubtitle>
+  </VListItem>
+</template>
+
+<style scoped>
+.gap-1 { gap: 0.25rem; }
+.gap-2 { gap: 0.5rem; }
+.min-height-auto {
+  min-height: auto !important;
+}
+</style>

--- a/packages/ui/src/components/DeviceLogStatusPanel.vue
+++ b/packages/ui/src/components/DeviceLogStatusPanel.vue
@@ -1,0 +1,67 @@
+<script setup lang="ts">
+import type { DeviceStatusStamp } from '@/types.ts'
+import { computed } from 'vue'
+import { VCol, VRow } from 'vuetify/components'
+
+const props = defineProps<{ status: DeviceStatusStamp }>()
+
+const freeHeapKb = computed(() => (props.status.free_heap_size / 1024).toFixed(1))
+</script>
+
+<template>
+  <div class="mb-3">
+    <div class="text-subtitle-2 mb-2 font-weight-bold">
+      Device Status
+    </div>
+    <VRow dense>
+      <VCol cols="6" sm="4">
+        <div class="text-caption text-medium-emphasis">
+          WiFi RSSI
+        </div>
+        <div class="text-body-2">
+          {{ status.wifi_rssi_level }} dBm
+        </div>
+      </VCol>
+      <VCol cols="6" sm="4">
+        <div class="text-caption text-medium-emphasis">
+          Battery
+        </div>
+        <div class="text-body-2">
+          {{ status.battery_voltage }} V
+        </div>
+      </VCol>
+      <VCol cols="6" sm="4">
+        <div class="text-caption text-medium-emphasis">
+          Firmware
+        </div>
+        <div class="text-body-2">
+          {{ status.current_fw_version }}
+        </div>
+      </VCol>
+      <VCol cols="6" sm="4">
+        <div class="text-caption text-medium-emphasis">
+          Free Heap
+        </div>
+        <div class="text-body-2">
+          {{ freeHeapKb }} KB
+        </div>
+      </VCol>
+      <VCol cols="6" sm="4">
+        <div class="text-caption text-medium-emphasis">
+          Wakeup Reason
+        </div>
+        <div class="text-body-2">
+          {{ status.wakeup_reason }}
+        </div>
+      </VCol>
+      <VCol cols="6" sm="4">
+        <div class="text-caption text-medium-emphasis">
+          WiFi Status
+        </div>
+        <div class="text-body-2">
+          {{ status.wifi_status }}
+        </div>
+      </VCol>
+    </VRow>
+  </div>
+</template>

--- a/packages/ui/src/components/DeviceLogsCard.vue
+++ b/packages/ui/src/components/DeviceLogsCard.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
+import type { ParsedDeviceLogPayload } from '@/types.ts'
 import { mdiDelete } from '@mdi/js'
 import { computed } from 'vue'
-import { VAlert, VAvatar, VBtn, VCard, VCardText, VCardTitle, VChip, VCol, VDivider, VExpansionPanel, VExpansionPanels, VExpansionPanelText, VExpansionPanelTitle, VIcon, VList, VListItem, VListItemSubtitle, VListItemTitle, VRow, VSpacer } from 'vuetify/components'
+import { VAlert, VBtn, VCard, VCardText, VCardTitle, VChip, VDivider, VList, VSpacer } from 'vuetify/components'
 import { useDeviceStore } from '@/stores/device.ts'
 import { useLogStore } from '@/stores/logs.ts'
+import DeviceLogEntry from './DeviceLogEntry.vue'
 
 const props = defineProps<{ deviceId: string }>()
 
@@ -11,18 +13,7 @@ const deviceStore = useDeviceStore()
 const device = computed(() => deviceStore.getById(props.deviceId))
 const logsStore = useLogStore(props.deviceId)
 
-function formatDate(date: Date) {
-  return new Date(date).toLocaleString('en-US', {
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit',
-  })
-}
-
-function parseLogEntry(entryString: string) {
+function parseLogEntry(entryString: string): ParsedDeviceLogPayload | null {
   try {
     return JSON.parse(entryString)
   }
@@ -38,34 +29,10 @@ const parsedLogEntries = computed(() =>
   })),
 )
 
-function getLogSeverity(message: string) {
-  const lowerMessage = message.toLowerCase()
-  if (lowerMessage.includes('error') || lowerMessage.includes('failed'))
-    return 'error'
-  if (lowerMessage.includes('warning') || lowerMessage.includes('warn'))
-    return 'warning'
-  if (lowerMessage.includes('info'))
-    return 'info'
-  return 'default'
-}
-
-function getSeverityColor(severity: string) {
-  switch (severity) {
-    case 'error': return 'error'
-    case 'warning': return 'warning'
-    case 'info': return 'info'
-    default: return 'default'
-  }
-}
-
-function getSeverityIcon(severity: string) {
-  switch (severity) {
-    case 'error': return 'mdi-alert-circle'
-    case 'warning': return 'mdi-alert'
-    case 'info': return 'mdi-information'
-    default: return 'mdi-circle-small'
-  }
-}
+const entryCountLabel = computed(() => {
+  const count = logsStore.logEntries.length
+  return `${count} ${count === 1 ? 'Entry' : 'Entries'}`
+})
 </script>
 
 <template>
@@ -87,152 +54,14 @@ function getSeverityIcon(severity: string) {
           Clear Logs
         </VBtn>
         <VChip v-if="logsStore.logEntries.length > 0" size="small" color="primary">
-          {{ logsStore.logEntries.length }} {{ logsStore.logEntries.length === 1 ? 'Entry' : 'Entries' }}
+          {{ entryCountLabel }}
         </VChip>
       </VCardTitle>
       <VDivider />
       <VCardText class="pa-0">
         <VList v-if="parsedLogEntries.length !== 0" lines="three" data-test-id="logs-list">
           <template v-for="(item, index) in parsedLogEntries" :key="item.logEntry.logId">
-            <VListItem data-test-id="log-list-item">
-              <template #prepend>
-                <VAvatar
-                  :color="getSeverityColor(getLogSeverity(item.parsed?.log_message || ''))"
-                  size="40"
-                >
-                  <VIcon :icon="getSeverityIcon(getLogSeverity(item.parsed?.log_message || ''))" />
-                </VAvatar>
-              </template>
-
-              <VListItemTitle class="text-wrap mb-2">
-                {{ item.parsed?.log_message || item.logEntry.entry }}
-              </VListItemTitle>
-
-              <VListItemSubtitle>
-                <div class="d-flex flex-column gap-1">
-                  <div class="d-flex align-center gap-2 flex-wrap">
-                    <VChip size="x-small" prepend-icon="mdi-clock-outline" variant="text">
-                      {{ formatDate(item.logEntry.date) }}
-                    </VChip>
-                    <VChip
-                      v-if="item.parsed?.log_sourcefile"
-                      size="x-small"
-                      prepend-icon="mdi-file-code"
-                      variant="text"
-                    >
-                      {{ item.parsed.log_sourcefile }}:{{ item.parsed.log_codeline }}
-                    </VChip>
-                  </div>
-
-                  <VExpansionPanels
-                    v-if="item.parsed?.device_status_stamp || item.parsed?.additional_info"
-                    flat
-                  >
-                    <VExpansionPanel elevation="0" class="bg-transparent">
-                      <VExpansionPanelTitle class="pa-0 min-height-auto">
-                        <template #default="{ expanded }">
-                          <VBtn
-                            size="x-small"
-                            variant="text"
-                            :prepend-icon="expanded ? 'mdi-chevron-up' : 'mdi-chevron-down'"
-                            :aria-label="expanded ? 'Hide log details' : 'Show log details'"
-                          >
-                            {{ expanded ? 'Less' : 'Show Details' }}
-                          </VBtn>
-                        </template>
-                      </VExpansionPanelTitle>
-                      <VExpansionPanelText class="pa-0 mt-2">
-                        <VCard variant="tonal" class="mb-2">
-                          <VCardText class="pa-3">
-                            <!-- Device Status -->
-                            <div v-if="item.parsed?.device_status_stamp" class="mb-3">
-                              <div class="text-subtitle-2 mb-2 font-weight-bold">
-                                Device Status
-                              </div>
-                              <VRow dense>
-                                <VCol cols="6" sm="4">
-                                  <div class="text-caption text-medium-emphasis">
-                                    WiFi RSSI
-                                  </div>
-                                  <div class="text-body-2">
-                                    {{ item.parsed.device_status_stamp.wifi_rssi_level }} dBm
-                                  </div>
-                                </VCol>
-                                <VCol cols="6" sm="4">
-                                  <div class="text-caption text-medium-emphasis">
-                                    Battery
-                                  </div>
-                                  <div class="text-body-2">
-                                    {{ item.parsed.device_status_stamp.battery_voltage }} V
-                                  </div>
-                                </VCol>
-                                <VCol cols="6" sm="4">
-                                  <div class="text-caption text-medium-emphasis">
-                                    Firmware
-                                  </div>
-                                  <div class="text-body-2">
-                                    {{ item.parsed.device_status_stamp.current_fw_version }}
-                                  </div>
-                                </VCol>
-                                <VCol cols="6" sm="4">
-                                  <div class="text-caption text-medium-emphasis">
-                                    Free Heap
-                                  </div>
-                                  <div class="text-body-2">
-                                    {{ (item.parsed.device_status_stamp.free_heap_size / 1024).toFixed(1) }} KB
-                                  </div>
-                                </VCol>
-                                <VCol cols="6" sm="4">
-                                  <div class="text-caption text-medium-emphasis">
-                                    Wakeup Reason
-                                  </div>
-                                  <div class="text-body-2">
-                                    {{ item.parsed.device_status_stamp.wakeup_reason }}
-                                  </div>
-                                </VCol>
-                                <VCol cols="6" sm="4">
-                                  <div class="text-caption text-medium-emphasis">
-                                    WiFi Status
-                                  </div>
-                                  <div class="text-body-2">
-                                    {{ item.parsed.device_status_stamp.wifi_status }}
-                                  </div>
-                                </VCol>
-                              </VRow>
-                            </div>
-
-                            <!-- Additional Info -->
-                            <div
-                              v-if="item.parsed?.additional_info
-                                && Object.keys(item.parsed.additional_info).length > 0"
-                            >
-                              <div class="text-subtitle-2 mb-2 font-weight-bold">
-                                Additional Info
-                              </div>
-                              <VRow dense>
-                                <VCol
-                                  v-for="(value, key) in item.parsed.additional_info"
-                                  :key="key"
-                                  cols="12"
-                                  sm="6"
-                                >
-                                  <div class="text-caption text-medium-emphasis">
-                                    {{ key }}
-                                  </div>
-                                  <div class="text-body-2">
-                                    {{ value || '—' }}
-                                  </div>
-                                </VCol>
-                              </VRow>
-                            </div>
-                          </VCardText>
-                        </VCard>
-                      </VExpansionPanelText>
-                    </VExpansionPanel>
-                  </VExpansionPanels>
-                </div>
-              </VListItemSubtitle>
-            </VListItem>
+            <DeviceLogEntry :log-entry="item.logEntry" :parsed="item.parsed" />
             <VDivider v-if="index < parsedLogEntries.length - 1" />
           </template>
         </VList>
@@ -243,11 +72,3 @@ function getSeverityIcon(severity: string) {
     </VCard>
   </template>
 </template>
-
-<style scoped>
-.gap-1 { gap: 0.25rem; }
-.gap-2 { gap: 0.5rem; }
-.min-height-auto {
-  min-height: auto !important;
-}
-</style>

--- a/packages/ui/src/components/__test__/DeviceLogAdditionalInfo.spec.ts
+++ b/packages/ui/src/components/__test__/DeviceLogAdditionalInfo.spec.ts
@@ -1,0 +1,26 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import vuetify from '../../plugins/vuetify'
+import DeviceLogAdditionalInfo from '../DeviceLogAdditionalInfo.vue'
+
+describe('deviceLogAdditionalInfo', () => {
+  it('renders each key/value pair', () => {
+    const wrapper = mount(DeviceLogAdditionalInfo, {
+      props: { info: { retries: 0, note: 'ok' } },
+      global: { plugins: [vuetify] },
+    })
+
+    expect(wrapper.text()).toContain('retries')
+    expect(wrapper.text()).toContain('note')
+    expect(wrapper.text()).toContain('ok')
+  })
+
+  it('falls back to an em dash for falsy values', () => {
+    const wrapper = mount(DeviceLogAdditionalInfo, {
+      props: { info: { retries: 0 } },
+      global: { plugins: [vuetify] },
+    })
+
+    expect(wrapper.text()).toContain('—')
+  })
+})

--- a/packages/ui/src/components/__test__/DeviceLogEntry.spec.ts
+++ b/packages/ui/src/components/__test__/DeviceLogEntry.spec.ts
@@ -1,0 +1,109 @@
+import type { LogEntry, ParsedDeviceLogPayload } from '@/types.ts'
+import { mount } from '@vue/test-utils'
+import rop from 'resize-observer-polyfill'
+import { describe, expect, it } from 'vitest'
+import vuetify from '../../plugins/vuetify'
+import DeviceLogEntry from '../DeviceLogEntry.vue'
+
+globalThis.ResizeObserver = rop
+
+globalThis.window.matchMedia = globalThis.window.matchMedia || function () {
+  return {
+    matches: false,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  }
+}
+
+const logEntry: LogEntry = { logId: 1, date: new Date('2026-01-01T12:00:00Z'), entry: 'raw entry text' }
+
+function mountEntry(parsed: ParsedDeviceLogPayload | null = null, entry: LogEntry = logEntry) {
+  return mount(DeviceLogEntry, {
+    props: { logEntry: entry, parsed },
+    global: { plugins: [vuetify] },
+  })
+}
+
+describe('deviceLogEntry', () => {
+  it('falls back to the raw entry text when parsing failed', () => {
+    const wrapper = mountEntry(null)
+    expect(wrapper.find('[data-test-id="log-list-item"]').exists()).toBe(true)
+    expect(wrapper.text()).toContain('raw entry text')
+  })
+
+  it('prefers the parsed log message over the raw entry', () => {
+    const wrapper = mountEntry({ log_message: 'Something failed' })
+    expect(wrapper.text()).toContain('Something failed')
+    expect(wrapper.text()).not.toContain('raw entry text')
+  })
+
+  it('shows the source file chip only when present', () => {
+    const withSource = mountEntry({ log_message: 'info message', log_sourcefile: 'main.c', log_codeline: 42 })
+    expect(withSource.text()).toContain('main.c:42')
+
+    const withoutSource = mountEntry({ log_message: 'info message' })
+    expect(withoutSource.text()).not.toContain('main.c')
+  })
+
+  it('hides the details expansion panel when there is no status or additional info', () => {
+    const wrapper = mountEntry({ log_message: 'info message' })
+    expect(wrapper.find('[data-test-id="log-entry-details-toggle"]').exists()).toBe(false)
+  })
+
+  it('shows device status fields inside the details panel', async () => {
+    const wrapper = mountEntry({
+      log_message: 'status update',
+      device_status_stamp: {
+        wifi_rssi_level: -55,
+        battery_voltage: 3.7,
+        current_fw_version: '1.2.3',
+        free_heap_size: 20480,
+        wakeup_reason: 'timer',
+        wifi_status: 'connected',
+      },
+    })
+    const toggle = wrapper.find('[data-test-id="log-entry-details-toggle"]')
+    expect(toggle.exists()).toBe(true)
+    await toggle.trigger('click')
+
+    expect(wrapper.text()).toContain('-55 dBm')
+    expect(wrapper.text()).toContain('3.7 V')
+    expect(wrapper.text()).toContain('1.2.3')
+    expect(wrapper.text()).toContain('20.0 KB')
+    expect(wrapper.text()).toContain('timer')
+    expect(wrapper.text()).toContain('connected')
+  })
+
+  it('shows additional info entries and falls back to an em dash for falsy values', async () => {
+    const wrapper = mountEntry({
+      log_message: 'extra info',
+      additional_info: { retries: 0, note: 'ok' },
+    })
+    const toggle = wrapper.find('[data-test-id="log-entry-details-toggle"]')
+    expect(toggle.exists()).toBe(true)
+    await toggle.trigger('click')
+
+    expect(wrapper.text()).toContain('retries')
+    expect(wrapper.text()).toContain('—')
+    expect(wrapper.text()).toContain('note')
+    expect(wrapper.text()).toContain('ok')
+  })
+
+  it('hides the additional info section when it is an empty object', () => {
+    const wrapper = mountEntry({ log_message: 'no extras', additional_info: {} })
+    expect(wrapper.find('[data-test-id="log-entry-details-toggle"]').exists()).toBe(false)
+  })
+
+  it.each([
+    ['A critical error occurred', 'mdi-alert-circle'],
+    ['This is just a warning', 'mdi-alert'],
+    ['Info: startup complete', 'mdi-information'],
+    ['nothing special happened', 'mdi-circle-small'],
+  ])('picks the severity icon for message %s', (message, icon) => {
+    const wrapper = mountEntry({ log_message: message })
+    expect(wrapper.html()).toContain(icon)
+  })
+})

--- a/packages/ui/src/components/__test__/DeviceLogStatusPanel.spec.ts
+++ b/packages/ui/src/components/__test__/DeviceLogStatusPanel.spec.ts
@@ -1,0 +1,30 @@
+import type { DeviceStatusStamp } from '@/types.ts'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import vuetify from '../../plugins/vuetify'
+import DeviceLogStatusPanel from '../DeviceLogStatusPanel.vue'
+
+const status: DeviceStatusStamp = {
+  wifi_rssi_level: -55,
+  battery_voltage: 3.7,
+  current_fw_version: '1.2.3',
+  free_heap_size: 20480,
+  wakeup_reason: 'timer',
+  wifi_status: 'connected',
+}
+
+describe('deviceLogStatusPanel', () => {
+  it('renders every device status field', () => {
+    const wrapper = mount(DeviceLogStatusPanel, {
+      props: { status },
+      global: { plugins: [vuetify] },
+    })
+
+    expect(wrapper.text()).toContain('-55 dBm')
+    expect(wrapper.text()).toContain('3.7 V')
+    expect(wrapper.text()).toContain('1.2.3')
+    expect(wrapper.text()).toContain('20.0 KB')
+    expect(wrapper.text()).toContain('timer')
+    expect(wrapper.text()).toContain('connected')
+  })
+})

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -123,6 +123,23 @@ export interface LogEntry {
   entry: string
 }
 
+export interface DeviceStatusStamp {
+  wifi_rssi_level: number
+  battery_voltage: number
+  current_fw_version: string
+  free_heap_size: number
+  wakeup_reason: string
+  wifi_status: string
+}
+
+export interface ParsedDeviceLogPayload {
+  log_message?: string
+  log_sourcefile?: string
+  log_codeline?: number
+  device_status_stamp?: DeviceStatusStamp
+  additional_info?: Record<string, string | number | null | undefined>
+}
+
 export interface MaintenanceStats {
   fileCount: number
   totalSize: number

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -132,12 +132,14 @@ export interface DeviceStatusStamp {
   wifi_status: string
 }
 
+export type AdditionalInfoMap = Record<string, string | number | null | undefined>
+
 export interface ParsedDeviceLogPayload {
   log_message?: string
   log_sourcefile?: string
   log_codeline?: number
   device_status_stamp?: DeviceStatusStamp
-  additional_info?: Record<string, string | number | null | undefined>
+  additional_info?: AdditionalInfoMap
 }
 
 export interface MaintenanceStats {


### PR DESCRIPTION
## What/why

`DeviceLogsCard.vue`'s `<template>` had grown to cyclomatic 29 / cognitive 61 (fallow health, critical) by mixing the toolbar, per-entry rendering, severity/formatting logic, and expandable device-status/additional-info payloads in one block.

Splits it into:
- `DeviceLogEntry.vue` — renders a single log entry (severity avatar, title, timestamp/source chips, expand toggle).
- `DeviceLogStatusPanel.vue` — the device-status grid inside the expansion panel.
- `DeviceLogAdditionalInfo.vue` — the additional-info key/value grid.

Pure formatting/severity logic (`getLogSeverity`, `getSeverityColor`, `getSeverityIcon`, timestamp formatting, the expand-toggle icon/label/aria-label) moved into `<script setup>` functions instead of template ternaries/expressions. All original `data-test-id`s are preserved (`clear-log-button`, `logs-list`, `log-list-item`, `log-list-empty-alert`); a new `log-entry-details-toggle` id was added for the expand button.

Every template is now under the cyclomatic 20 / cognitive 15 target — `pnpm fallow health` reports no complexity findings for any of the new `DeviceLog*` files.

## Test evidence

- `pnpm --filter ./packages/ui test` — 206/206 passing, including new specs for `DeviceLogEntry`, `DeviceLogStatusPanel`, and `DeviceLogAdditionalInfo` (written test-first).
- `pnpm lint && pnpm type-check && pnpm test` (repo-wide) — all pass.
- `pnpm fallow:baseline` re-run — removes the `DeviceLogsCard.vue` `complexity_critical` entry from `.fallow-baselines/health.baseline.json`; no new findings added.
- `pnpm fallow:ci` — passes (exit 0).
- `pnpm --filter ./packages/ui test:e2e` — could not run in this sandbox (Puppeteer's Chrome binary isn't installed here, unrelated to this change); no `data-test-id`s were removed or renamed, so the existing e2e coverage should be unaffected.

Closes #849

> *Opened by Kongroo, karakuri's Projects agent — Stage: implement*