### PR TITLE
refactor(ui): split DeviceInformationCard.vue template into per-section components

### DIFF
--- a/.fallow-baselines/health.baseline.json
+++ b/.fallow-baselines/health.baseline.json
@@ -74,14 +74,6 @@
         "count": 1
       }
     },
-    "packages/ui/src/components/DeviceInformationCard.vue": {
-      "complexity_high": {
-        "count": 1
-      },
-      "crap_moderate": {
-        "count": 1
-      }
-    },
     "packages/ui/src/components/DeviceLogsCard.vue": {
       "complexity_critical": {
         "count": 1
@@ -124,9 +116,8 @@
   "runtime_coverage_findings": [],
   "target_keys": [
     "packages/ui/src/stores/deviceModels.ts:high impact",
-    "packages/api/src/plugins/plugins.service.ts:complexity",
     "packages/api/src/devices/display.service.ts:complexity",
-    "packages/ui/src/components/DeviceInformationCard.vue:complexity",
+    "packages/api/src/plugins/plugins.service.ts:complexity",
     "packages/ui/src/components/DeviceLogsCard.vue:complexity"
   ]
 }

--- a/packages/ui/src/components/DeviceInformationCard.vue
+++ b/packages/ui/src/components/DeviceInformationCard.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
+import type { Device } from '@/types'
 import {
-  mdiAlert,
   mdiBattery,
   mdiBattery10,
   mdiBattery20,
@@ -13,28 +13,25 @@ import {
   mdiBattery90,
   mdiBatteryOutline,
   mdiBatteryUnknown,
-  mdiCheck,
-  mdiCircle,
-  mdiContentCopy,
-  mdiContentSave,
-  mdiDelete,
-  mdiEye,
-  mdiEyeOff,
-  mdiPencil,
   mdiSignalCellular1,
   mdiSignalCellular2,
   mdiSignalCellular3,
   mdiSignalCellularOutline,
 } from '@mdi/js'
-import { useClipboard } from '@vueuse/core'
 import { computed, onMounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
-import { VBtn, VCard, VCardText, VCardTitle, VChip, VCol, VDivider, VExpansionPanel, VExpansionPanels, VExpansionPanelText, VExpansionPanelTitle, VIcon, VNumberInput, VRow, VSelect, VSwitch, VTextField, VTooltip } from 'vuetify/components'
+import { VCard, VCardText, VCardTitle, VDivider, VExpansionPanel, VExpansionPanels, VExpansionPanelText, VExpansionPanelTitle } from 'vuetify/components'
+import DeviceFirmwareSection from '@/components/device/DeviceFirmwareSection.vue'
+import DeviceHardwareControlsSection from '@/components/device/DeviceHardwareControlsSection.vue'
+import DeviceHeaderBar from '@/components/device/DeviceHeaderBar.vue'
+import DeviceMirroringSection from '@/components/device/DeviceMirroringSection.vue'
+import DeviceModelPaletteSection from '@/components/device/DeviceModelPaletteSection.vue'
+import DeviceSleepModeSection from '@/components/device/DeviceSleepModeSection.vue'
+import DeviceStatusOverview from '@/components/device/DeviceStatusOverview.vue'
 import { useDeviceStore } from '@/stores/device'
 import { useDeviceModelsStore } from '@/stores/deviceModels'
 import { useFirmwareStore } from '@/stores/firmware'
 import { DEFAULT_RENDER_SIZE } from '@/utils/deviceRenderSize'
-import { formatDate } from '@/utils/formatDate'
 import { isValidMac } from '@/utils/getRandomMac'
 import { isDeviceOnline } from '@/utils/isDeviceOnline'
 import { secondsToTimeInput, timeInputToSeconds } from '@/utils/sleepMode'
@@ -59,14 +56,25 @@ const sleepStartTime = ref('')
 const sleepEndTime = ref('')
 const pendingSpecialFunction = ref('none')
 
-watch(device, (current) => {
-  selectedModelName.value = current?.deviceModel?.name ?? null
-  selectedPaletteId.value = current?.palette?.id ?? null
-  selectedFirmwareId.value = current?.targetFirmware?.id ?? null
-  sleepStartTime.value = secondsToTimeInput(current?.sleepStartTime)
-  sleepEndTime.value = secondsToTimeInput(current?.sleepEndTime)
-  pendingSpecialFunction.value = current?.specialFunction ?? 'none'
-}, { immediate: true })
+function syncFormStateFromDevice(current: Device | undefined) {
+  if (!current) {
+    selectedModelName.value = null
+    selectedPaletteId.value = null
+    selectedFirmwareId.value = null
+    sleepStartTime.value = ''
+    sleepEndTime.value = ''
+    pendingSpecialFunction.value = 'none'
+    return
+  }
+  selectedModelName.value = current.deviceModel?.name ?? null
+  selectedPaletteId.value = current.palette?.id ?? null
+  selectedFirmwareId.value = current.targetFirmware?.id ?? null
+  sleepStartTime.value = secondsToTimeInput(current.sleepStartTime)
+  sleepEndTime.value = secondsToTimeInput(current.sleepEndTime)
+  pendingSpecialFunction.value = current.specialFunction ?? 'none'
+}
+
+watch(device, syncFormStateFromDevice, { immediate: true })
 
 const sleepWindowSpansMidnight = computed(() => Boolean(sleepStartTime.value && sleepEndTime.value && sleepStartTime.value > sleepEndTime.value))
 
@@ -165,8 +173,6 @@ const reportMismatch = computed(() => {
   return current.width !== model.width || current.height !== model.height
 })
 
-const { copy: copyToClipboard, copied: macCopied } = useClipboard()
-
 const rssiStrength = computed(() => {
   if (!device.value || !device.value.rssi)
     return -1
@@ -206,16 +212,6 @@ const rssiIcon = computed((): string => {
   }
 })
 
-const specialFunctionalities = [
-  { title: 'None', value: 'none' },
-  { title: 'Identify', value: 'identify' },
-  { title: 'Sleep', value: 'sleep' },
-  { title: 'Add WiFi', value: 'add_wifi' },
-  { title: 'Restart playlist (unavailable)', value: 'restart_playlist' },
-  { title: 'Rewind', value: 'rewind' },
-  { title: 'Send to me (unavailable)', value: 'send_to_me' },
-]
-
 const router = useRouter()
 
 async function deleteDevice() {
@@ -247,8 +243,6 @@ const batteryColor = computed(() => {
     return 'warning'
   return 'success'
 })
-
-const showApikey = ref(false)
 
 const batteryIcon = computed(() => {
   const iconMap = [
@@ -356,7 +350,6 @@ async function saveDevice() {
     ...(selectedPaletteId.value ? { paletteId: selectedPaletteId.value } : {}),
   })
 }
-const nameEditing = ref(false)
 
 defineExpose({
   selectedModelName,
@@ -378,238 +371,72 @@ defineExpose({
   <template v-if="device">
     <VCard class="mb-6" elevation="1">
       <VCardTitle class="d-flex align-center justify-space-between flex-wrap ga-2">
-        <div v-if="!nameEditing">
-          <span data-test-id="device-name">{{ device.name }}</span>
-          <v-icon-btn :icon="mdiPencil" size="x-small" class="ml-2" aria-label="Edit device name" variant="text" @click="nameEditing = true" />
-          <VIcon :icon="mdiCircle" :color="isDeviceOnline(device) ? 'success' : 'error'" size="x-small" class="ml-2" />
-        </div>
-        <div v-else>
-          <VTextField v-model="device.name" variant="underlined" density="compact" autofocus :hide-details="true" min-width="200" @blur="nameEditing = false" />
-        </div>
-        <div>
-          <VBtn color="success" variant="tonal" :prepend-icon="mdiContentSave" class="mr-5" :disabled="!valid" @click="saveDevice">
-            Update
-          </VBtn>
-          <VBtn color="error" variant="tonal" :prepend-icon="mdiDelete" data-test-id="delete-device-btn" @click="deleteDevice">
-            Delete
-          </VBtn>
-        </div>
+        <DeviceHeaderBar
+          v-model:name="device.name"
+          :online="isDeviceOnline(device)"
+          :valid="valid"
+          @save="saveDevice"
+          @delete="deleteDevice"
+        />
       </VCardTitle>
       <VDivider />
       <VCardText>
-        <VRow class="mb-4" density="comfortable">
-          <VCol cols="12" sm="4">
-            <strong>Firmware Version:</strong>
-            <div>{{ device.fwVersion || 'N/A' }}</div>
-          </VCol>
-          <VCol cols="12" sm="4">
-            <VIcon size="x-large" :color="rssiColor" class="mr-1" :icon="rssiIcon" />
-            {{ device.rssi ? `(${device.rssi} dBm)` : 'N/A' }}
-          </VCol>
-          <VCol cols="12" sm="4">
-            <VIcon size="x-large" :color="batteryColor" class="mr-1" :icon="batteryIcon" />
-            {{ device.batteryVoltage ? `(${batteryPercentage} %)` : 'N/A' }}
-          </VCol>
-          <VCol cols="12" sm="4">
-            <strong>Model:</strong>
-            <div data-test-id="device-model-summary">
-              {{ modelSummary }}
-              <VTooltip v-if="reportMismatch" location="top" text="The device reports a different panel size than its assigned model. Check the model in Advanced.">
-                <template #activator="{ props: tooltipProps }">
-                  <VIcon
-                    v-bind="tooltipProps"
-                    :icon="mdiAlert"
-                    color="warning"
-                    size="small"
-                    class="ml-1"
-                    tabindex="0"
-                    role="img"
-                    aria-label="The device reports a different panel size than its assigned model. Check the model in Advanced."
-                    data-test-id="device-model-mismatch"
-                  />
-                </template>
-              </VTooltip>
-            </div>
-            <div v-if="reportedSummary" class="text-caption text-medium-emphasis">
-              Reported: {{ reportedSummary }}
-            </div>
-          </VCol>
-          <VCol cols="12" sm="4">
-            <strong>Last seen:</strong>
-            <div class="text-truncate">
-              {{ device.lastSeen ? formatDate(device.lastSeen) : 'N/A' }}
-            </div>
-          </VCol>
-          <VCol cols="12" sm="4">
-            <strong>User Agent:</strong>
-            <div class="text-truncate">
-              {{ device.userAgent || 'N/A' }}
-            </div>
-          </VCol>
-        </VRow>
-        <VDivider class="my-2" />
-        <VRow class="mb-2" density="comfortable">
-          <VCol cols="12" sm="12" md="6" lg="4">
-            <VTextField v-model="device.friendlyId" readonly density="compact" hide-details label="Friendly ID" />
-          </VCol>
-          <VCol cols="12" sm="12" md="6" lg="4">
-            <VTextField v-model="device.mac" readonly density="compact" hide-details label="MAC" :append-icon="macCopied ? mdiCheck : mdiContentCopy" @click:append="copyToClipboard(device.mac)" />
-          </VCol>
-          <VCol cols="12" sm="12" md="6" lg="4">
-            <VTextField v-model="device.apikey" readonly density="compact" :type="showApikey ? 'text' : 'password'" label="API key" :append-icon="showApikey ? mdiEyeOff : mdiEye" @click:append="showApikey = !showApikey" />
-          </VCol>
-        </VRow>
+        <DeviceStatusOverview
+          :device="device"
+          :rssi-color="rssiColor"
+          :rssi-icon="rssiIcon"
+          :battery-color="batteryColor"
+          :battery-icon="batteryIcon"
+          :battery-percentage="batteryPercentage"
+          :model-summary="modelSummary"
+          :reported-summary="reportedSummary"
+          :report-mismatch="reportMismatch"
+        />
         <VExpansionPanels class="mt-2" flat>
           <VExpansionPanel>
             <VExpansionPanelTitle>Advanced</VExpansionPanelTitle>
             <VExpansionPanelText>
-              <VRow class="mb-2" density="comfortable">
-                <VCol cols="12" sm="12" md="6" lg="4">
-                  <VRow>
-                    <VCol cols="12" sm="5">
-                      <VNumberInput v-model="refreshRateNumber" control-variant="hidden" type="number" density="compact" label="Refresh Rate" />
-                    </VCol>
-                    <VCol cols="12" sm="7">
-                      <VSelect v-model="refreshRateUnit" density="compact" label="Unit" :items="['hours', 'minutes', 'seconds']" />
-                    </VCol>
-                  </VRow>
-                </VCol>
-                <VCol cols="12" sm="8" md="6" class="d-flex align-center ga-3">
-                  <VSelect
-                    v-model="pendingSpecialFunction"
-                    :items="specialFunctionalities"
-                    density="compact"
-                    label="Special Function"
-                    data-test-id="device-special-function-select"
-                  />
-                  <VBtn
-                    size="small"
-                    color="secondary"
-                    variant="tonal"
-                    :loading="specialFunctionTriggering"
-                    :disabled="pendingSpecialFunction === 'none'"
-                    data-test-id="device-special-function-trigger-btn"
-                    @click="triggerSpecialFunction"
-                  >
-                    Trigger
-                  </VBtn>
-                </VCol>
-                <VCol cols="12" sm="4" md="6" class="d-flex align-center">
-                  <VBtn
-                    size="small"
-                    color="secondary"
-                    variant="tonal"
-                    :loading="resetTriggering"
-                    data-test-id="device-reset-trigger-btn"
-                    @click="triggerReset"
-                  >
-                    Reset device
-                  </VBtn>
-                </VCol>
-              </VRow>
-              <VRow class="mb-2" density="comfortable">
-                <VCol cols="12" sm="6" md="4">
-                  <VSelect
-                    v-model="selectedModelName"
-                    :items="modelOptions"
-                    density="compact"
-                    label="Device model"
-                    data-test-id="device-model-select"
-                  />
-                </VCol>
-                <VCol cols="12" sm="6" md="4">
-                  <VSelect
-                    v-model="selectedPaletteId"
-                    :items="paletteOptions"
-                    :disabled="!selectedModel"
-                    density="compact"
-                    label="Palette"
-                    placeholder="Default (richest available)"
-                    persistent-placeholder
-                    data-test-id="device-palette-select"
-                  />
-                </VCol>
-                <VCol v-if="device.deviceModel?.deprecated" cols="12" sm="12" md="4" class="d-flex align-center">
-                  <VChip color="warning" size="small" variant="tonal">
-                    Assigned model no longer exists upstream
-                  </VChip>
-                </VCol>
-              </VRow>
-              <VRow class="mb-2" density="comfortable">
-                <VCol cols="12" sm="8" md="6">
-                  <VSelect
-                    v-model="selectedFirmwareId"
-                    :items="firmwareOptions"
-                    density="compact"
-                    label="Target firmware"
-                    placeholder="None"
-                    persistent-placeholder
-                    data-test-id="device-firmware-select"
-                  />
-                </VCol>
-                <VCol cols="12" sm="4" md="6" class="d-flex align-center ga-3">
-                  <span class="text-caption text-medium-emphasis">Reported: {{ device.fwVersion || 'N/A' }}</span>
-                  <VBtn
-                    size="small"
-                    color="secondary"
-                    variant="tonal"
-                    :loading="firmwareUpdating"
-                    :disabled="!selectedFirmwareId"
-                    data-test-id="device-firmware-update-btn"
-                    @click="triggerFirmwareUpdate"
-                  >
-                    Update now
-                  </VBtn>
-                  <VChip v-if="device.updateFirmware" color="info" size="small" variant="tonal">
-                    Update pending
-                  </VChip>
-                </VCol>
-              </VRow>
-              <VRow class="mb-2" density="comfortable">
-                <VCol cols="12" sm="6" md="4">
-                  <VSwitch v-model="device.mirrorEnabled" color="secondary" label="Mirroring" />
-                </VCol>
-                <VCol cols="12" sm="6" md="4">
-                  <VTextField v-model="device.mirrorMac" density="compact" label="Mirror MAC address" :disabled="!device.mirrorEnabled" :rules="macRules" />
-                </VCol>
-                <VCol cols="12" sm="6" md="4">
-                  <VTextField v-model="device.mirrorApikey" density="compact" label="Mirror API key" :disabled="!device.mirrorEnabled" :rules="apikeyRules" />
-                </VCol>
-              </VRow>
+              <DeviceHardwareControlsSection
+                v-model:refresh-rate-number="refreshRateNumber"
+                v-model:refresh-rate-unit="refreshRateUnit"
+                v-model:pending-special-function="pendingSpecialFunction"
+                :special-function-triggering="specialFunctionTriggering"
+                :reset-triggering="resetTriggering"
+                @trigger-special-function="triggerSpecialFunction"
+                @trigger-reset="triggerReset"
+              />
+              <DeviceModelPaletteSection
+                v-model:selected-model-name="selectedModelName"
+                v-model:selected-palette-id="selectedPaletteId"
+                :model-options="modelOptions"
+                :palette-options="paletteOptions"
+                :palette-disabled="!selectedModel"
+                :deprecated-assigned="Boolean(device.deviceModel?.deprecated)"
+              />
+              <DeviceFirmwareSection
+                v-model:selected-firmware-id="selectedFirmwareId"
+                :firmware-options="firmwareOptions"
+                :firmware-updating="firmwareUpdating"
+                :fw-version="device.fwVersion"
+                :update-pending="device.updateFirmware"
+                @trigger-firmware-update="triggerFirmwareUpdate"
+              />
+              <DeviceMirroringSection
+                v-model:mirror-enabled="device.mirrorEnabled"
+                v-model:mirror-mac="device.mirrorMac"
+                v-model:mirror-apikey="device.mirrorApikey"
+                :mac-rules="macRules"
+                :apikey-rules="apikeyRules"
+              />
               <VDivider class="my-2" />
-              <VRow class="mb-0" density="comfortable">
-                <VCol cols="12" sm="6" md="3">
-                  <VSwitch v-model="device.sleepModeEnabled" color="secondary" label="Sleep Mode" data-test-id="sleep-mode-switch" />
-                </VCol>
-                <VCol cols="12" sm="6" md="3">
-                  <VTextField
-                    v-model="sleepStartTime"
-                    type="time"
-                    density="compact"
-                    label="Sleep window from"
-                    :error="!sleepWindowValid"
-                    :error-messages="!sleepWindowValid ? ['Set both a start and end time to enable Sleep Mode.'] : []"
-                    data-test-id="sleep-start-time"
-                  />
-                </VCol>
-                <VCol cols="12" sm="6" md="3">
-                  <VTextField
-                    v-model="sleepEndTime"
-                    type="time"
-                    density="compact"
-                    label="Sleep window to"
-                    :error="!sleepWindowValid"
-                    :error-messages="!sleepWindowValid ? ['Set both a start and end time to enable Sleep Mode.'] : []"
-                    data-test-id="sleep-end-time"
-                  />
-                </VCol>
-                <VCol cols="12" sm="6" md="3">
-                  <VSwitch v-model="device.sleepScreenEnabled" color="secondary" label="Show dedicated sleep screen" data-test-id="sleep-screen-switch" />
-                </VCol>
-                <VCol v-if="sleepWindowSpansMidnight" cols="12">
-                  <span class="text-caption text-medium-emphasis" data-test-id="sleep-window-midnight-hint">This window crosses midnight.</span>
-                </VCol>
-              </VRow>
+              <DeviceSleepModeSection
+                v-model:sleep-mode-enabled="device.sleepModeEnabled"
+                v-model:sleep-start-time="sleepStartTime"
+                v-model:sleep-end-time="sleepEndTime"
+                v-model:sleep-screen-enabled="device.sleepScreenEnabled"
+                :sleep-window-valid="sleepWindowValid"
+                :sleep-window-spans-midnight="sleepWindowSpansMidnight"
+              />
             </VExpansionPanelText>
           </VExpansionPanel>
         </VExpansionPanels>

--- a/packages/ui/src/components/DeviceInformationCard.vue
+++ b/packages/ui/src/components/DeviceInformationCard.vue
@@ -1,23 +1,5 @@
 <script setup lang="ts">
 import type { Device } from '@/types'
-import {
-  mdiBattery,
-  mdiBattery10,
-  mdiBattery20,
-  mdiBattery30,
-  mdiBattery40,
-  mdiBattery50,
-  mdiBattery60,
-  mdiBattery70,
-  mdiBattery80,
-  mdiBattery90,
-  mdiBatteryOutline,
-  mdiBatteryUnknown,
-  mdiSignalCellular1,
-  mdiSignalCellular2,
-  mdiSignalCellular3,
-  mdiSignalCellularOutline,
-} from '@mdi/js'
 import { computed, onMounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { VCard, VCardText, VCardTitle, VDivider, VExpansionPanel, VExpansionPanels, VExpansionPanelText, VExpansionPanelTitle } from 'vuetify/components'
@@ -31,7 +13,6 @@ import DeviceStatusOverview from '@/components/device/DeviceStatusOverview.vue'
 import { useDeviceStore } from '@/stores/device'
 import { useDeviceModelsStore } from '@/stores/deviceModels'
 import { useFirmwareStore } from '@/stores/firmware'
-import { DEFAULT_RENDER_SIZE } from '@/utils/deviceRenderSize'
 import { isValidMac } from '@/utils/getRandomMac'
 import { isDeviceOnline } from '@/utils/isDeviceOnline'
 import { secondsToTimeInput, timeInputToSeconds } from '@/utils/sleepMode'
@@ -150,68 +131,6 @@ watch(selectedModel, (model) => {
     selectedPaletteId.value = null
 })
 
-const modelSummary = computed(() => {
-  const model = device.value?.deviceModel
-  if (!model)
-    return `Not resolved yet — renders as TRMNL OG (${DEFAULT_RENDER_SIZE.width}x${DEFAULT_RENDER_SIZE.height})`
-  return `${model.label} (${model.width}x${model.height})`
-})
-
-const reportedSummary = computed(() => {
-  const current = device.value
-  if (!current)
-    return null
-  const parts = [current.reportedModel, current.width && current.height ? `${current.width}x${current.height}` : null].filter(Boolean)
-  return parts.length > 0 ? parts.join(' · ') : null
-})
-
-const reportMismatch = computed(() => {
-  const current = device.value
-  const model = current?.deviceModel
-  if (!current || !model || !current.width || !current.height)
-    return false
-  return current.width !== model.width || current.height !== model.height
-})
-
-const rssiStrength = computed(() => {
-  if (!device.value || !device.value.rssi)
-    return -1
-  const rssi = Number.parseInt(device.value.rssi)
-  if (Number.isNaN(rssi))
-    return -1
-  if (rssi >= -70)
-    return 3
-  if (rssi >= -80)
-    return 2
-  if (rssi >= -90)
-    return 1
-  return 0
-})
-const rssiColor = computed((): string => {
-  switch (rssiStrength.value) {
-    case 3: return 'success'
-    case 2: return 'warning'
-    case 1: return 'warning'
-    case 0: return 'error'
-    case -1: return 'secondary'
-    default:
-      { const _: never = rssiStrength.value }
-      return ''
-  }
-})
-const rssiIcon = computed((): string => {
-  switch (rssiStrength.value) {
-    case 3: return mdiSignalCellular3
-    case 2: return mdiSignalCellular2
-    case 1: return mdiSignalCellular1
-    case 0: return mdiSignalCellularOutline
-    case -1: return mdiSignalCellularOutline
-    default:
-      { const _: never = rssiStrength.value }
-      return ''
-  }
-})
-
 const router = useRouter()
 
 async function deleteDevice() {
@@ -220,46 +139,6 @@ async function deleteDevice() {
   await deviceStore.deleteDevice(device.value.id)
   await router.push({ name: 'overview' })
 }
-
-const batteryPercentage = computed(() => {
-  if (!device.value?.batteryVoltage)
-    return -1
-  const voltage = Number.parseFloat(device.value.batteryVoltage)
-  if (voltage >= 4.2)
-    return 100
-  if (voltage <= 3.0)
-    return 0
-  return Math.round(((voltage - 3.0) / 0.012))
-})
-
-const batteryColor = computed(() => {
-  if (batteryPercentage.value === -1)
-    return 'secondary'
-  if (batteryPercentage.value <= 10)
-    return 'error'
-  if (batteryPercentage.value <= 20)
-    return 'warning'
-  if (batteryPercentage.value <= 60)
-    return 'warning'
-  return 'success'
-})
-
-const batteryIcon = computed(() => {
-  const iconMap = [
-    { min: 95, icon: mdiBattery },
-    { min: 85, icon: mdiBattery90 },
-    { min: 75, icon: mdiBattery80 },
-    { min: 65, icon: mdiBattery70 },
-    { min: 55, icon: mdiBattery60 },
-    { min: 45, icon: mdiBattery50 },
-    { min: 35, icon: mdiBattery40 },
-    { min: 25, icon: mdiBattery30 },
-    { min: 15, icon: mdiBattery20 },
-    { min: 5, icon: mdiBattery10 },
-    { min: 0, icon: mdiBatteryOutline },
-  ]
-  return iconMap.find(item => batteryPercentage.value >= item.min)?.icon || mdiBatteryUnknown
-})
 
 const macRules = [
   (value: string) => {
@@ -381,17 +260,7 @@ defineExpose({
       </VCardTitle>
       <VDivider />
       <VCardText>
-        <DeviceStatusOverview
-          :device="device"
-          :rssi-color="rssiColor"
-          :rssi-icon="rssiIcon"
-          :battery-color="batteryColor"
-          :battery-icon="batteryIcon"
-          :battery-percentage="batteryPercentage"
-          :model-summary="modelSummary"
-          :reported-summary="reportedSummary"
-          :report-mismatch="reportMismatch"
-        />
+        <DeviceStatusOverview :device="device" />
         <VExpansionPanels class="mt-2" flat>
           <VExpansionPanel>
             <VExpansionPanelTitle>Advanced</VExpansionPanelTitle>

--- a/packages/ui/src/components/device/DeviceFirmwareSection.vue
+++ b/packages/ui/src/components/device/DeviceFirmwareSection.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import { VBtn, VChip, VCol, VRow, VSelect } from 'vuetify/components'
+
+defineProps<{
+  firmwareOptions: { title: string, value: string }[]
+  firmwareUpdating: boolean
+  fwVersion?: string
+  updatePending: boolean
+}>()
+
+defineEmits<{
+  triggerFirmwareUpdate: []
+}>()
+
+const selectedFirmwareId = defineModel<string | null>('selectedFirmwareId', { required: true })
+</script>
+
+<template>
+  <VRow class="mb-2" density="comfortable">
+    <VCol cols="12" sm="8" md="6">
+      <VSelect
+        v-model="selectedFirmwareId"
+        :items="firmwareOptions"
+        density="compact"
+        label="Target firmware"
+        placeholder="None"
+        persistent-placeholder
+        data-test-id="device-firmware-select"
+      />
+    </VCol>
+    <VCol cols="12" sm="4" md="6" class="d-flex align-center ga-3">
+      <span class="text-caption text-medium-emphasis">Reported: {{ fwVersion || 'N/A' }}</span>
+      <VBtn
+        size="small"
+        color="secondary"
+        variant="tonal"
+        :loading="firmwareUpdating"
+        :disabled="!selectedFirmwareId"
+        data-test-id="device-firmware-update-btn"
+        @click="$emit('triggerFirmwareUpdate')"
+      >
+        Update now
+      </VBtn>
+      <VChip v-if="updatePending" color="info" size="small" variant="tonal">
+        Update pending
+      </VChip>
+    </VCol>
+  </VRow>
+</template>

--- a/packages/ui/src/components/device/DeviceHardwareControlsSection.vue
+++ b/packages/ui/src/components/device/DeviceHardwareControlsSection.vue
@@ -1,0 +1,74 @@
+<script setup lang="ts">
+import { VBtn, VCol, VNumberInput, VRow, VSelect } from 'vuetify/components'
+
+defineProps<{
+  specialFunctionTriggering: boolean
+  resetTriggering: boolean
+}>()
+
+defineEmits<{
+  triggerSpecialFunction: []
+  triggerReset: []
+}>()
+
+const refreshRateNumber = defineModel<number>('refreshRateNumber', { required: true })
+const refreshRateUnit = defineModel<'hours' | 'minutes' | 'seconds'>('refreshRateUnit', { required: true })
+const pendingSpecialFunction = defineModel<string>('pendingSpecialFunction', { required: true })
+
+const specialFunctionalities = [
+  { title: 'None', value: 'none' },
+  { title: 'Identify', value: 'identify' },
+  { title: 'Sleep', value: 'sleep' },
+  { title: 'Add WiFi', value: 'add_wifi' },
+  { title: 'Restart playlist (unavailable)', value: 'restart_playlist' },
+  { title: 'Rewind', value: 'rewind' },
+  { title: 'Send to me (unavailable)', value: 'send_to_me' },
+]
+</script>
+
+<template>
+  <VRow class="mb-2" density="comfortable">
+    <VCol cols="12" sm="12" md="6" lg="4">
+      <VRow>
+        <VCol cols="12" sm="5">
+          <VNumberInput v-model="refreshRateNumber" control-variant="hidden" type="number" density="compact" label="Refresh Rate" />
+        </VCol>
+        <VCol cols="12" sm="7">
+          <VSelect v-model="refreshRateUnit" density="compact" label="Unit" :items="['hours', 'minutes', 'seconds']" />
+        </VCol>
+      </VRow>
+    </VCol>
+    <VCol cols="12" sm="8" md="6" class="d-flex align-center ga-3">
+      <VSelect
+        v-model="pendingSpecialFunction"
+        :items="specialFunctionalities"
+        density="compact"
+        label="Special Function"
+        data-test-id="device-special-function-select"
+      />
+      <VBtn
+        size="small"
+        color="secondary"
+        variant="tonal"
+        :loading="specialFunctionTriggering"
+        :disabled="pendingSpecialFunction === 'none'"
+        data-test-id="device-special-function-trigger-btn"
+        @click="$emit('triggerSpecialFunction')"
+      >
+        Trigger
+      </VBtn>
+    </VCol>
+    <VCol cols="12" sm="4" md="6" class="d-flex align-center">
+      <VBtn
+        size="small"
+        color="secondary"
+        variant="tonal"
+        :loading="resetTriggering"
+        data-test-id="device-reset-trigger-btn"
+        @click="$emit('triggerReset')"
+      >
+        Reset device
+      </VBtn>
+    </VCol>
+  </VRow>
+</template>

--- a/packages/ui/src/components/device/DeviceHeaderBar.vue
+++ b/packages/ui/src/components/device/DeviceHeaderBar.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import { mdiCircle, mdiContentSave, mdiDelete, mdiPencil } from '@mdi/js'
+import { ref } from 'vue'
+import { VBtn, VIcon, VTextField } from 'vuetify/components'
+
+defineProps<{
+  online: boolean
+  valid: boolean
+}>()
+
+defineEmits<{
+  save: []
+  delete: []
+}>()
+
+const name = defineModel<string>('name', { required: true })
+
+const nameEditing = ref(false)
+</script>
+
+<template>
+  <div v-if="!nameEditing">
+    <span data-test-id="device-name">{{ name }}</span>
+    <v-icon-btn :icon="mdiPencil" size="x-small" class="ml-2" aria-label="Edit device name" variant="text" @click="nameEditing = true" />
+    <VIcon :icon="mdiCircle" :color="online ? 'success' : 'error'" size="x-small" class="ml-2" />
+  </div>
+  <div v-else>
+    <VTextField v-model="name" variant="underlined" density="compact" autofocus :hide-details="true" min-width="200" @blur="nameEditing = false" />
+  </div>
+  <div>
+    <VBtn color="success" variant="tonal" :prepend-icon="mdiContentSave" class="mr-5" :disabled="!valid" @click="$emit('save')">
+      Update
+    </VBtn>
+    <VBtn color="error" variant="tonal" :prepend-icon="mdiDelete" data-test-id="delete-device-btn" @click="$emit('delete')">
+      Delete
+    </VBtn>
+  </div>
+</template>

--- a/packages/ui/src/components/device/DeviceMirroringSection.vue
+++ b/packages/ui/src/components/device/DeviceMirroringSection.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+import { VCol, VRow, VSwitch, VTextField } from 'vuetify/components'
+
+defineProps<{
+  macRules: ((value: string) => true | string)[]
+  apikeyRules: ((value: string) => true | string)[]
+}>()
+
+const mirrorEnabled = defineModel<boolean>('mirrorEnabled', { required: true })
+const mirrorMac = defineModel<string>('mirrorMac', { required: true })
+const mirrorApikey = defineModel<string>('mirrorApikey', { required: true })
+</script>
+
+<template>
+  <VRow class="mb-2" density="comfortable">
+    <VCol cols="12" sm="6" md="4">
+      <VSwitch v-model="mirrorEnabled" color="secondary" label="Mirroring" />
+    </VCol>
+    <VCol cols="12" sm="6" md="4">
+      <VTextField v-model="mirrorMac" density="compact" label="Mirror MAC address" :disabled="!mirrorEnabled" :rules="macRules" />
+    </VCol>
+    <VCol cols="12" sm="6" md="4">
+      <VTextField v-model="mirrorApikey" density="compact" label="Mirror API key" :disabled="!mirrorEnabled" :rules="apikeyRules" />
+    </VCol>
+  </VRow>
+</template>

--- a/packages/ui/src/components/device/DeviceModelPaletteSection.vue
+++ b/packages/ui/src/components/device/DeviceModelPaletteSection.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import { VChip, VCol, VRow, VSelect } from 'vuetify/components'
+
+defineProps<{
+  modelOptions: { title: string, value: string }[]
+  paletteOptions: { title: string, value: string }[]
+  paletteDisabled: boolean
+  deprecatedAssigned: boolean
+}>()
+
+const selectedModelName = defineModel<string | null>('selectedModelName', { required: true })
+const selectedPaletteId = defineModel<string | null>('selectedPaletteId', { required: true })
+</script>
+
+<template>
+  <VRow class="mb-2" density="comfortable">
+    <VCol cols="12" sm="6" md="4">
+      <VSelect
+        v-model="selectedModelName"
+        :items="modelOptions"
+        density="compact"
+        label="Device model"
+        data-test-id="device-model-select"
+      />
+    </VCol>
+    <VCol cols="12" sm="6" md="4">
+      <VSelect
+        v-model="selectedPaletteId"
+        :items="paletteOptions"
+        :disabled="paletteDisabled"
+        density="compact"
+        label="Palette"
+        placeholder="Default (richest available)"
+        persistent-placeholder
+        data-test-id="device-palette-select"
+      />
+    </VCol>
+    <VCol v-if="deprecatedAssigned" cols="12" sm="12" md="4" class="d-flex align-center">
+      <VChip color="warning" size="small" variant="tonal">
+        Assigned model no longer exists upstream
+      </VChip>
+    </VCol>
+  </VRow>
+</template>

--- a/packages/ui/src/components/device/DeviceSleepModeSection.vue
+++ b/packages/ui/src/components/device/DeviceSleepModeSection.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import { VCol, VRow, VSwitch, VTextField } from 'vuetify/components'
+
+defineProps<{
+  sleepWindowValid: boolean
+  sleepWindowSpansMidnight: boolean
+}>()
+
+const sleepModeEnabled = defineModel<boolean>('sleepModeEnabled', { required: true })
+const sleepStartTime = defineModel<string>('sleepStartTime', { required: true })
+const sleepEndTime = defineModel<string>('sleepEndTime', { required: true })
+const sleepScreenEnabled = defineModel<boolean>('sleepScreenEnabled', { required: true })
+</script>
+
+<template>
+  <VRow class="mb-0" density="comfortable">
+    <VCol cols="12" sm="6" md="3">
+      <VSwitch v-model="sleepModeEnabled" color="secondary" label="Sleep Mode" data-test-id="sleep-mode-switch" />
+    </VCol>
+    <VCol cols="12" sm="6" md="3">
+      <VTextField
+        v-model="sleepStartTime"
+        type="time"
+        density="compact"
+        label="Sleep window from"
+        :error="!sleepWindowValid"
+        :error-messages="!sleepWindowValid ? ['Set both a start and end time to enable Sleep Mode.'] : []"
+        data-test-id="sleep-start-time"
+      />
+    </VCol>
+    <VCol cols="12" sm="6" md="3">
+      <VTextField
+        v-model="sleepEndTime"
+        type="time"
+        density="compact"
+        label="Sleep window to"
+        :error="!sleepWindowValid"
+        :error-messages="!sleepWindowValid ? ['Set both a start and end time to enable Sleep Mode.'] : []"
+        data-test-id="sleep-end-time"
+      />
+    </VCol>
+    <VCol cols="12" sm="6" md="3">
+      <VSwitch v-model="sleepScreenEnabled" color="secondary" label="Show dedicated sleep screen" data-test-id="sleep-screen-switch" />
+    </VCol>
+    <VCol v-if="sleepWindowSpansMidnight" cols="12">
+      <span class="text-caption text-medium-emphasis" data-test-id="sleep-window-midnight-hint">This window crosses midnight.</span>
+    </VCol>
+  </VRow>
+</template>

--- a/packages/ui/src/components/device/DeviceStatusOverview.vue
+++ b/packages/ui/src/components/device/DeviceStatusOverview.vue
@@ -1,26 +1,140 @@
 <script setup lang="ts">
 import type { Device } from '@/types'
-import { mdiAlert, mdiCheck, mdiContentCopy, mdiEye, mdiEyeOff } from '@mdi/js'
+import {
+  mdiAlert,
+  mdiBattery,
+  mdiBattery10,
+  mdiBattery20,
+  mdiBattery30,
+  mdiBattery40,
+  mdiBattery50,
+  mdiBattery60,
+  mdiBattery70,
+  mdiBattery80,
+  mdiBattery90,
+  mdiBatteryOutline,
+  mdiBatteryUnknown,
+  mdiCheck,
+  mdiContentCopy,
+  mdiEye,
+  mdiEyeOff,
+  mdiSignalCellular1,
+  mdiSignalCellular2,
+  mdiSignalCellular3,
+  mdiSignalCellularOutline,
+} from '@mdi/js'
 import { useClipboard } from '@vueuse/core'
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import { VCol, VDivider, VIcon, VRow, VTextField, VTooltip } from 'vuetify/components'
+import { DEFAULT_RENDER_SIZE } from '@/utils/deviceRenderSize'
 import { formatDate } from '@/utils/formatDate'
 
-defineProps<{
+const props = defineProps<{
   device: Device
-  rssiColor: string
-  rssiIcon: string
-  batteryColor: string
-  batteryIcon: string
-  batteryPercentage: number
-  modelSummary: string
-  reportedSummary: string | null
-  reportMismatch: boolean
 }>()
 
 const { copy: copyToClipboard, copied: macCopied } = useClipboard()
 
 const showApikey = ref(false)
+
+const modelSummary = computed(() => {
+  const model = props.device.deviceModel
+  if (!model)
+    return `Not resolved yet — renders as TRMNL OG (${DEFAULT_RENDER_SIZE.width}x${DEFAULT_RENDER_SIZE.height})`
+  return `${model.label} (${model.width}x${model.height})`
+})
+
+const reportedSummary = computed(() => {
+  const { reportedModel, width, height } = props.device
+  const parts = [reportedModel, width && height ? `${width}x${height}` : null].filter(Boolean)
+  return parts.length > 0 ? parts.join(' · ') : null
+})
+
+const reportMismatch = computed(() => {
+  const { deviceModel, width, height } = props.device
+  if (!deviceModel || !width || !height)
+    return false
+  return width !== deviceModel.width || height !== deviceModel.height
+})
+
+const rssiStrength = computed(() => {
+  if (!props.device.rssi)
+    return -1
+  const rssi = Number.parseInt(props.device.rssi)
+  if (Number.isNaN(rssi))
+    return -1
+  if (rssi >= -70)
+    return 3
+  if (rssi >= -80)
+    return 2
+  if (rssi >= -90)
+    return 1
+  return 0
+})
+const rssiColor = computed((): string => {
+  switch (rssiStrength.value) {
+    case 3: return 'success'
+    case 2: return 'warning'
+    case 1: return 'warning'
+    case 0: return 'error'
+    case -1: return 'secondary'
+    default:
+      { const _: never = rssiStrength.value }
+      return ''
+  }
+})
+const rssiIcon = computed((): string => {
+  switch (rssiStrength.value) {
+    case 3: return mdiSignalCellular3
+    case 2: return mdiSignalCellular2
+    case 1: return mdiSignalCellular1
+    case 0: return mdiSignalCellularOutline
+    case -1: return mdiSignalCellularOutline
+    default:
+      { const _: never = rssiStrength.value }
+      return ''
+  }
+})
+
+const batteryPercentage = computed(() => {
+  if (!props.device.batteryVoltage)
+    return -1
+  const voltage = Number.parseFloat(props.device.batteryVoltage)
+  if (voltage >= 4.2)
+    return 100
+  if (voltage <= 3.0)
+    return 0
+  return Math.round(((voltage - 3.0) / 0.012))
+})
+
+const batteryColor = computed(() => {
+  if (batteryPercentage.value === -1)
+    return 'secondary'
+  if (batteryPercentage.value <= 10)
+    return 'error'
+  if (batteryPercentage.value <= 20)
+    return 'warning'
+  if (batteryPercentage.value <= 60)
+    return 'warning'
+  return 'success'
+})
+
+const batteryIcon = computed(() => {
+  const iconMap = [
+    { min: 95, icon: mdiBattery },
+    { min: 85, icon: mdiBattery90 },
+    { min: 75, icon: mdiBattery80 },
+    { min: 65, icon: mdiBattery70 },
+    { min: 55, icon: mdiBattery60 },
+    { min: 45, icon: mdiBattery50 },
+    { min: 35, icon: mdiBattery40 },
+    { min: 25, icon: mdiBattery30 },
+    { min: 15, icon: mdiBattery20 },
+    { min: 5, icon: mdiBattery10 },
+    { min: 0, icon: mdiBatteryOutline },
+  ]
+  return iconMap.find(item => batteryPercentage.value >= item.min)?.icon || mdiBatteryUnknown
+})
 </script>
 
 <template>

--- a/packages/ui/src/components/device/DeviceStatusOverview.vue
+++ b/packages/ui/src/components/device/DeviceStatusOverview.vue
@@ -1,0 +1,89 @@
+<script setup lang="ts">
+import type { Device } from '@/types'
+import { mdiAlert, mdiCheck, mdiContentCopy, mdiEye, mdiEyeOff } from '@mdi/js'
+import { useClipboard } from '@vueuse/core'
+import { ref } from 'vue'
+import { VCol, VDivider, VIcon, VRow, VTextField, VTooltip } from 'vuetify/components'
+import { formatDate } from '@/utils/formatDate'
+
+defineProps<{
+  device: Device
+  rssiColor: string
+  rssiIcon: string
+  batteryColor: string
+  batteryIcon: string
+  batteryPercentage: number
+  modelSummary: string
+  reportedSummary: string | null
+  reportMismatch: boolean
+}>()
+
+const { copy: copyToClipboard, copied: macCopied } = useClipboard()
+
+const showApikey = ref(false)
+</script>
+
+<template>
+  <VRow class="mb-4" density="comfortable">
+    <VCol cols="12" sm="4">
+      <strong>Firmware Version:</strong>
+      <div>{{ device.fwVersion || 'N/A' }}</div>
+    </VCol>
+    <VCol cols="12" sm="4">
+      <VIcon size="x-large" :color="rssiColor" class="mr-1" :icon="rssiIcon" />
+      {{ device.rssi ? `(${device.rssi} dBm)` : 'N/A' }}
+    </VCol>
+    <VCol cols="12" sm="4">
+      <VIcon size="x-large" :color="batteryColor" class="mr-1" :icon="batteryIcon" />
+      {{ device.batteryVoltage ? `(${batteryPercentage} %)` : 'N/A' }}
+    </VCol>
+    <VCol cols="12" sm="4">
+      <strong>Model:</strong>
+      <div data-test-id="device-model-summary">
+        {{ modelSummary }}
+        <VTooltip v-if="reportMismatch" location="top" text="The device reports a different panel size than its assigned model. Check the model in Advanced.">
+          <template #activator="{ props: tooltipProps }">
+            <VIcon
+              v-bind="tooltipProps"
+              :icon="mdiAlert"
+              color="warning"
+              size="small"
+              class="ml-1"
+              tabindex="0"
+              role="img"
+              aria-label="The device reports a different panel size than its assigned model. Check the model in Advanced."
+              data-test-id="device-model-mismatch"
+            />
+          </template>
+        </VTooltip>
+      </div>
+      <div v-if="reportedSummary" class="text-caption text-medium-emphasis">
+        Reported: {{ reportedSummary }}
+      </div>
+    </VCol>
+    <VCol cols="12" sm="4">
+      <strong>Last seen:</strong>
+      <div class="text-truncate">
+        {{ device.lastSeen ? formatDate(device.lastSeen) : 'N/A' }}
+      </div>
+    </VCol>
+    <VCol cols="12" sm="4">
+      <strong>User Agent:</strong>
+      <div class="text-truncate">
+        {{ device.userAgent || 'N/A' }}
+      </div>
+    </VCol>
+  </VRow>
+  <VDivider class="my-2" />
+  <VRow class="mb-2" density="comfortable">
+    <VCol cols="12" sm="12" md="6" lg="4">
+      <VTextField :model-value="device.friendlyId" readonly density="compact" hide-details label="Friendly ID" />
+    </VCol>
+    <VCol cols="12" sm="12" md="6" lg="4">
+      <VTextField :model-value="device.mac" readonly density="compact" hide-details label="MAC" :append-icon="macCopied ? mdiCheck : mdiContentCopy" @click:append="copyToClipboard(device.mac)" />
+    </VCol>
+    <VCol cols="12" sm="12" md="6" lg="4">
+      <VTextField :model-value="device.apikey" readonly density="compact" :type="showApikey ? 'text' : 'password'" label="API key" :append-icon="showApikey ? mdiEyeOff : mdiEye" @click:append="showApikey = !showApikey" />
+    </VCol>
+  </VRow>
+</template>

--- a/packages/ui/src/components/device/__test__/DeviceFirmwareSection.spec.ts
+++ b/packages/ui/src/components/device/__test__/DeviceFirmwareSection.spec.ts
@@ -1,0 +1,41 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import vuetify from '@/plugins/vuetify'
+import DeviceFirmwareSection from '../DeviceFirmwareSection.vue'
+
+function mountSection(props: Partial<InstanceType<typeof DeviceFirmwareSection>['$props']> = {}) {
+  return mount(DeviceFirmwareSection, {
+    props: {
+      firmwareOptions: [{ title: '1.5.6 (official)', value: 'fw-1' }],
+      firmwareUpdating: false,
+      fwVersion: undefined,
+      updatePending: false,
+      selectedFirmwareId: null,
+      ...props,
+    },
+    global: { plugins: [vuetify] },
+  })
+}
+
+describe('deviceFirmwareSection', () => {
+  it('shows N/A when no firmware version was reported', () => {
+    expect(mountSection().text()).toContain('Reported: N/A')
+    expect(mountSection({ fwVersion: '1.5.6' }).text()).toContain('Reported: 1.5.6')
+  })
+
+  it('disables the update button until a firmware is selected', () => {
+    expect(mountSection().find('[data-test-id="device-firmware-update-btn"]').attributes('disabled')).toBeDefined()
+    expect(mountSection({ selectedFirmwareId: 'fw-1' }).find('[data-test-id="device-firmware-update-btn"]').attributes('disabled')).toBeUndefined()
+  })
+
+  it('shows the update pending chip only when updatePending is true', () => {
+    expect(mountSection().text()).not.toContain('Update pending')
+    expect(mountSection({ updatePending: true }).text()).toContain('Update pending')
+  })
+
+  it('emits triggerFirmwareUpdate when the update button is clicked', async () => {
+    const wrapper = mountSection({ selectedFirmwareId: 'fw-1' })
+    await wrapper.find('[data-test-id="device-firmware-update-btn"]').trigger('click')
+    expect(wrapper.emitted('triggerFirmwareUpdate')).toHaveLength(1)
+  })
+})

--- a/packages/ui/src/components/device/__test__/DeviceHardwareControlsSection.spec.ts
+++ b/packages/ui/src/components/device/__test__/DeviceHardwareControlsSection.spec.ts
@@ -1,0 +1,38 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import vuetify from '@/plugins/vuetify'
+import DeviceHardwareControlsSection from '../DeviceHardwareControlsSection.vue'
+
+function mountSection(props: Partial<InstanceType<typeof DeviceHardwareControlsSection>['$props']> = {}) {
+  return mount(DeviceHardwareControlsSection, {
+    props: {
+      specialFunctionTriggering: false,
+      resetTriggering: false,
+      refreshRateNumber: 300,
+      refreshRateUnit: 'seconds',
+      pendingSpecialFunction: 'none',
+      ...props,
+    },
+    global: { plugins: [vuetify] },
+  })
+}
+
+describe('deviceHardwareControlsSection', () => {
+  it('disables the special function trigger button when none is selected', () => {
+    const wrapper = mountSection()
+    expect(wrapper.find('[data-test-id="device-special-function-trigger-btn"]').attributes('disabled')).toBeDefined()
+  })
+
+  it('enables the trigger button once a special function is selected', () => {
+    const wrapper = mountSection({ pendingSpecialFunction: 'identify' })
+    expect(wrapper.find('[data-test-id="device-special-function-trigger-btn"]').attributes('disabled')).toBeUndefined()
+  })
+
+  it('emits triggerSpecialFunction and triggerReset when clicked', async () => {
+    const wrapper = mountSection({ pendingSpecialFunction: 'identify' })
+    await wrapper.find('[data-test-id="device-special-function-trigger-btn"]').trigger('click')
+    await wrapper.find('[data-test-id="device-reset-trigger-btn"]').trigger('click')
+    expect(wrapper.emitted('triggerSpecialFunction')).toHaveLength(1)
+    expect(wrapper.emitted('triggerReset')).toHaveLength(1)
+  })
+})

--- a/packages/ui/src/components/device/__test__/DeviceHeaderBar.spec.ts
+++ b/packages/ui/src/components/device/__test__/DeviceHeaderBar.spec.ts
@@ -1,0 +1,46 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import vuetify from '@/plugins/vuetify'
+import DeviceHeaderBar from '../DeviceHeaderBar.vue'
+
+function mountBar(props: Partial<InstanceType<typeof DeviceHeaderBar>['$props']> = {}) {
+  return mount(DeviceHeaderBar, {
+    props: {
+      name: 'Test Device',
+      online: false,
+      valid: true,
+      ...props,
+    },
+    global: { plugins: [vuetify] },
+  })
+}
+
+describe('deviceHeaderBar', () => {
+  it('shows the device name and a delete button', () => {
+    const wrapper = mountBar()
+    expect(wrapper.find('[data-test-id="device-name"]').text()).toContain('Test Device')
+    expect(wrapper.find('[data-test-id="delete-device-btn"]').exists()).toBe(true)
+  })
+
+  it('switches to an editable text field and emits update:name on change', async () => {
+    const wrapper = mountBar()
+    await wrapper.find('[aria-label="Edit device name"]').trigger('click')
+    expect(wrapper.find('[data-test-id="device-name"]').exists()).toBe(false)
+
+    await wrapper.find('input').setValue('Renamed Device')
+    expect(wrapper.emitted('update:name')).toEqual([['Renamed Device']])
+  })
+
+  it('disables the Update button when invalid', () => {
+    const wrapper = mountBar({ valid: false })
+    expect(wrapper.findAll('button')[1].attributes('disabled')).toBeDefined()
+  })
+
+  it('emits save and delete when their buttons are clicked', async () => {
+    const wrapper = mountBar()
+    await wrapper.findAll('button')[1].trigger('click')
+    await wrapper.find('[data-test-id="delete-device-btn"]').trigger('click')
+    expect(wrapper.emitted('save')).toHaveLength(1)
+    expect(wrapper.emitted('delete')).toHaveLength(1)
+  })
+})

--- a/packages/ui/src/components/device/__test__/DeviceMirroringSection.spec.ts
+++ b/packages/ui/src/components/device/__test__/DeviceMirroringSection.spec.ts
@@ -1,0 +1,41 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import vuetify from '@/plugins/vuetify'
+import DeviceMirroringSection from '../DeviceMirroringSection.vue'
+
+function mountSection(props: Partial<InstanceType<typeof DeviceMirroringSection>['$props']> = {}) {
+  return mount(DeviceMirroringSection, {
+    props: {
+      macRules: [(value: string) => value.length > 0 || 'required'],
+      apikeyRules: [(value: string) => value.length > 0 || 'required'],
+      mirrorEnabled: false,
+      mirrorMac: '',
+      mirrorApikey: '',
+      ...props,
+    },
+    global: { plugins: [vuetify] },
+  })
+}
+
+describe('deviceMirroringSection', () => {
+  it('disables the MAC and API key fields until mirroring is enabled', () => {
+    const wrapper = mountSection()
+    const inputs = wrapper.findAll('input[type="text"]')
+    expect(inputs.some(input => input.attributes('disabled') !== undefined)).toBe(true)
+  })
+
+  it('enables the fields once mirroring is on', () => {
+    const wrapper = mountSection({ mirrorEnabled: true })
+    const textInputs = wrapper.findAll('.v-text-field input')
+    expect(textInputs.every(input => input.attributes('disabled') === undefined)).toBe(true)
+  })
+
+  it('emits update:mirrorMac and update:mirrorApikey on input', async () => {
+    const wrapper = mountSection({ mirrorEnabled: true })
+    const [macInput, apikeyInput] = wrapper.findAll('.v-text-field input')
+    await macInput.setValue('AA:BB:CC:DD:EE:FF')
+    await apikeyInput.setValue('secret')
+    expect(wrapper.emitted('update:mirrorMac')).toEqual([['AA:BB:CC:DD:EE:FF']])
+    expect(wrapper.emitted('update:mirrorApikey')).toEqual([['secret']])
+  })
+})

--- a/packages/ui/src/components/device/__test__/DeviceModelPaletteSection.spec.ts
+++ b/packages/ui/src/components/device/__test__/DeviceModelPaletteSection.spec.ts
@@ -1,0 +1,37 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import vuetify from '@/plugins/vuetify'
+import DeviceModelPaletteSection from '../DeviceModelPaletteSection.vue'
+
+function mountSection(props: Partial<InstanceType<typeof DeviceModelPaletteSection>['$props']> = {}) {
+  return mount(DeviceModelPaletteSection, {
+    props: {
+      modelOptions: [{ title: 'TRMNL OG (800x480)', value: 'og_plus' }],
+      paletteOptions: [{ title: '4 Grays (2-bit)', value: 'gray-4' }],
+      paletteDisabled: false,
+      deprecatedAssigned: false,
+      selectedModelName: null,
+      selectedPaletteId: null,
+      ...props,
+    },
+    global: { plugins: [vuetify] },
+  })
+}
+
+describe('deviceModelPaletteSection', () => {
+  it('shows a deprecated chip only when the assigned model is deprecated', () => {
+    expect(mountSection().text()).not.toContain('no longer exists upstream')
+    expect(mountSection({ deprecatedAssigned: true }).text()).toContain('no longer exists upstream')
+  })
+
+  it('disables the palette select when there is no resolved model', () => {
+    const wrapper = mountSection({ paletteDisabled: true })
+    expect(wrapper.find('[data-test-id="device-palette-select"] input').attributes('disabled')).toBeDefined()
+  })
+
+  it('renders the model and palette selects', () => {
+    const wrapper = mountSection()
+    expect(wrapper.find('[data-test-id="device-model-select"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test-id="device-palette-select"]').exists()).toBe(true)
+  })
+})

--- a/packages/ui/src/components/device/__test__/DeviceSleepModeSection.spec.ts
+++ b/packages/ui/src/components/device/__test__/DeviceSleepModeSection.spec.ts
@@ -1,0 +1,49 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import vuetify from '@/plugins/vuetify'
+import DeviceSleepModeSection from '../DeviceSleepModeSection.vue'
+
+function mountSection(props: Partial<InstanceType<typeof DeviceSleepModeSection>['$props']> = {}) {
+  return mount(DeviceSleepModeSection, {
+    props: {
+      sleepWindowValid: true,
+      sleepWindowSpansMidnight: false,
+      sleepModeEnabled: false,
+      sleepStartTime: '',
+      sleepEndTime: '',
+      sleepScreenEnabled: false,
+      ...props,
+    },
+    global: { plugins: [vuetify] },
+  })
+}
+
+describe('deviceSleepModeSection', () => {
+  it('shows an error message on the time fields when the window is invalid', () => {
+    const wrapper = mountSection({ sleepWindowValid: false })
+    expect(wrapper.text()).toContain('Set both a start and end time to enable Sleep Mode.')
+  })
+
+  it('shows no error when the window is valid', () => {
+    const wrapper = mountSection({ sleepWindowValid: true })
+    expect(wrapper.text()).not.toContain('Set both a start and end time to enable Sleep Mode.')
+  })
+
+  it('shows the midnight hint only when the window spans midnight', () => {
+    expect(mountSection().find('[data-test-id="sleep-window-midnight-hint"]').exists()).toBe(false)
+    expect(mountSection({ sleepWindowSpansMidnight: true }).find('[data-test-id="sleep-window-midnight-hint"]').exists()).toBe(true)
+  })
+
+  it('emits update events for all four models', async () => {
+    const wrapper = mountSection()
+    await wrapper.find('[data-test-id="sleep-mode-switch"] input').setValue(true)
+    await wrapper.find('[data-test-id="sleep-start-time"] input').setValue('22:00')
+    await wrapper.find('[data-test-id="sleep-end-time"] input').setValue('06:00')
+    await wrapper.find('[data-test-id="sleep-screen-switch"] input').setValue(true)
+
+    expect(wrapper.emitted('update:sleepModeEnabled')).toEqual([[true]])
+    expect(wrapper.emitted('update:sleepStartTime')).toEqual([['22:00']])
+    expect(wrapper.emitted('update:sleepEndTime')).toEqual([['06:00']])
+    expect(wrapper.emitted('update:sleepScreenEnabled')).toEqual([[true]])
+  })
+})

--- a/packages/ui/src/components/device/__test__/DeviceStatusOverview.spec.ts
+++ b/packages/ui/src/components/device/__test__/DeviceStatusOverview.spec.ts
@@ -1,9 +1,27 @@
-import type { Device } from '@/types'
-import { mdiSignalCellular3 } from '@mdi/js'
+import type { Device, DeviceModel } from '@/types'
 import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
 import vuetify from '@/plugins/vuetify'
 import DeviceStatusOverview from '../DeviceStatusOverview.vue'
+
+const OG_PLUS: DeviceModel = {
+  name: 'og_plus',
+  label: 'TRMNL OG (2-bit)',
+  width: 800,
+  height: 480,
+  colors: 4,
+  bitDepth: 2,
+  scaleFactor: 1,
+  rotation: 0,
+  offsetX: 0,
+  offsetY: 0,
+  mimeType: 'image/png',
+  kind: 'trmnl',
+  paletteIds: ['bw', 'gray-4'],
+  cssClasses: [],
+  cssVariables: {},
+  deprecated: false,
+}
 
 function baseDevice(overrides: Partial<Device> = {}): Device {
   return {
@@ -25,39 +43,50 @@ function baseDevice(overrides: Partial<Device> = {}): Device {
   }
 }
 
-function mountOverview(props: Partial<InstanceType<typeof DeviceStatusOverview>['$props']> = {}) {
+function mountOverview(device: Partial<Device> = {}) {
   return mount(DeviceStatusOverview, {
-    props: {
-      device: baseDevice(),
-      rssiColor: 'success',
-      rssiIcon: mdiSignalCellular3,
-      batteryColor: 'success',
-      batteryIcon: mdiSignalCellular3,
-      batteryPercentage: 80,
-      modelSummary: 'TRMNL OG (800x480)',
-      reportedSummary: null,
-      reportMismatch: false,
-      ...props,
-    },
+    props: { device: baseDevice(device) },
     global: { plugins: [vuetify] },
   })
 }
 
 describe('deviceStatusOverview', () => {
-  it('shows the model summary and friendly id/mac/apikey fields', () => {
+  it('explains that an unassigned device renders as a TRMNL OG', () => {
     const wrapper = mountOverview()
-    expect(wrapper.find('[data-test-id="device-model-summary"]').text()).toContain('TRMNL OG (800x480)')
+    const summary = wrapper.find('[data-test-id="device-model-summary"]').text()
+    expect(summary).toContain('Not resolved yet')
+    expect(summary).toContain('800x480')
     expect(wrapper.findAll('input').map(input => input.element.value)).toContain('ABC123')
   })
 
-  it('flags a mismatch only when reportMismatch is true', () => {
-    expect(mountOverview().find('[data-test-id="device-model-mismatch"]').exists()).toBe(false)
-    expect(mountOverview({ reportMismatch: true }).find('[data-test-id="device-model-mismatch"]').exists()).toBe(true)
+  it('shows the assigned model with its dimensions', () => {
+    const wrapper = mountOverview({ deviceModel: OG_PLUS })
+    expect(wrapper.find('[data-test-id="device-model-summary"]').text()).toContain('TRMNL OG (2-bit) (800x480)')
+  })
+
+  it('flags a mismatch only when the reported panel size differs from the assigned model', () => {
+    expect(mountOverview({ deviceModel: OG_PLUS, width: 800, height: 480 }).find('[data-test-id="device-model-mismatch"]').exists()).toBe(false)
+    expect(mountOverview({ deviceModel: OG_PLUS, width: 1872, height: 1404 }).find('[data-test-id="device-model-mismatch"]').exists()).toBe(true)
   })
 
   it('shows the reported summary line only when present', () => {
     expect(mountOverview().text()).not.toContain('Reported:')
-    expect(mountOverview({ reportedSummary: 'x · 1872x1404' }).text()).toContain('Reported: x · 1872x1404')
+    expect(mountOverview({ reportedModel: 'x', width: 1872, height: 1404 }).text()).toContain('Reported: x · 1872x1404')
+  })
+
+  it('shows N/A for rssi and battery when unreported', () => {
+    const wrapper = mountOverview()
+    expect(wrapper.text()).toContain('N/A')
+  })
+
+  it('shows the battery percentage derived from voltage', () => {
+    const wrapper = mountOverview({ batteryVoltage: '4.2' })
+    expect(wrapper.text()).toContain('(100 %)')
+  })
+
+  it('shows the rssi reading in dBm', () => {
+    const wrapper = mountOverview({ rssi: '-65' })
+    expect(wrapper.text()).toContain('(-65 dBm)')
   })
 
   it('hides the API key by default and reveals it on toggle', async () => {

--- a/packages/ui/src/components/device/__test__/DeviceStatusOverview.spec.ts
+++ b/packages/ui/src/components/device/__test__/DeviceStatusOverview.spec.ts
@@ -1,0 +1,71 @@
+import type { Device } from '@/types'
+import { mdiSignalCellular3 } from '@mdi/js'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import vuetify from '@/plugins/vuetify'
+import DeviceStatusOverview from '../DeviceStatusOverview.vue'
+
+function baseDevice(overrides: Partial<Device> = {}): Device {
+  return {
+    id: 'device1',
+    name: 'Test Device',
+    friendlyId: 'ABC123',
+    mac: 'AA:BB:CC:DD:EE:FF',
+    apikey: 'super-secret',
+    mirrorEnabled: false,
+    mirrorMac: '',
+    mirrorApikey: '',
+    specialFunction: '',
+    sleepModeEnabled: false,
+    sleepScreenEnabled: false,
+    resetDevice: false,
+    updateFirmware: false,
+    lastSeen: '',
+    ...overrides,
+  }
+}
+
+function mountOverview(props: Partial<InstanceType<typeof DeviceStatusOverview>['$props']> = {}) {
+  return mount(DeviceStatusOverview, {
+    props: {
+      device: baseDevice(),
+      rssiColor: 'success',
+      rssiIcon: mdiSignalCellular3,
+      batteryColor: 'success',
+      batteryIcon: mdiSignalCellular3,
+      batteryPercentage: 80,
+      modelSummary: 'TRMNL OG (800x480)',
+      reportedSummary: null,
+      reportMismatch: false,
+      ...props,
+    },
+    global: { plugins: [vuetify] },
+  })
+}
+
+describe('deviceStatusOverview', () => {
+  it('shows the model summary and friendly id/mac/apikey fields', () => {
+    const wrapper = mountOverview()
+    expect(wrapper.find('[data-test-id="device-model-summary"]').text()).toContain('TRMNL OG (800x480)')
+    expect(wrapper.findAll('input').map(input => input.element.value)).toContain('ABC123')
+  })
+
+  it('flags a mismatch only when reportMismatch is true', () => {
+    expect(mountOverview().find('[data-test-id="device-model-mismatch"]').exists()).toBe(false)
+    expect(mountOverview({ reportMismatch: true }).find('[data-test-id="device-model-mismatch"]').exists()).toBe(true)
+  })
+
+  it('shows the reported summary line only when present', () => {
+    expect(mountOverview().text()).not.toContain('Reported:')
+    expect(mountOverview({ reportedSummary: 'x · 1872x1404' }).text()).toContain('Reported: x · 1872x1404')
+  })
+
+  it('hides the API key by default and reveals it on toggle', async () => {
+    const wrapper = mountOverview()
+    const apikeyInput = wrapper.findAll('input').find(input => input.element.value === 'super-secret')!
+    expect(apikeyInput.attributes('type')).toBe('password')
+
+    await wrapper.find('[aria-label="API key appended action"]').trigger('click')
+    expect(apikeyInput.attributes('type')).toBe('text')
+  })
+})


### PR DESCRIPTION
## What

Splits `packages/ui/src/components/DeviceInformationCard.vue`'s 604-line template (cyclomatic 21, cognitive 36 — flagged by `fallow`) into 7 focused components under `packages/ui/src/components/device/`:

- `DeviceHeaderBar` — name edit toggle, online status, Update/Delete actions
- `DeviceStatusOverview` — firmware version/rssi/battery/model summary/last seen/user agent + friendly id/mac/apikey (now derives rssi/battery color+icon and the model summary itself from the `device` prop it already receives, instead of taking them as precomputed props)
- `DeviceHardwareControlsSection` — refresh rate, special function trigger, reset device
- `DeviceModelPaletteSection` — device model + palette select
- `DeviceFirmwareSection` — target firmware select + update
- `DeviceMirroringSection` — mirror enabled/MAC/API key
- `DeviceSleepModeSection` — sleep mode switch/times/screen/midnight hint

`DeviceInformationCard.vue` keeps all Pinia store wiring and business logic; each child is a presentational component wired via props/`defineModel`/emits, matching the pattern used in the earlier `MaintenanceView.vue` split.

Also turns the arrow function at line 62 (a chain of `?.`/`??` fallbacks, cyclomatic 11) into a named function, `syncFormStateFromDevice`, with an early return for the "no device" case — cyclomatic complexity drops under the cyclomatic-10 target.

## Why

Flagged by the initial `fallow` scan as a complexity hotspot and baselined so CI stays green until fixed. Closes #850.

## Test evidence

- `pnpm lint && pnpm type-check && pnpm test` — all pass (api: 742 passed/38 skipped, ui: 271 passed, including 7 new component spec files + the untouched original `DeviceInformationCard.spec.ts`, still exercising the same `data-test-id`s and `defineExpose`d surface)
- `pnpm --filter ./packages/ui test:e2e` — the existing `viewport-overflow` e2e spec (24 tests across 8 routes × 3 widths) passes with zero horizontal-overflow regressions
- `pnpm fallow health` — `DeviceInformationCard.vue` no longer appears in high-complexity findings or refactoring targets
- `pnpm fallow:baseline` run in this PR — the `DeviceInformationCard.vue` finding is gone from `.fallow-baselines/health.baseline.json`; `pnpm fallow:ci` passes with no new findings in any baseline
- All 16 original `data-test-id`s verified present, unchanged, across the new files
- Ran the repo's `mattpocock-skills:code-review` skill (Standards + Spec axes) against the merge-base with `origin/main`; addressed the one substantive Standards finding (an inconsistent split boundary in `DeviceStatusOverview` — now fixed by deriving status display values from `device` instead of taking them precomputed)

Closes #850

> *Opened by Kongroo, karakuri's Projects agent — Stage: implement*