### PR TITLE
refactor(ui): split remaining moderate/high complexity hotspots

### DIFF
--- a/.fallow-baselines/health.baseline.json
+++ b/.fallow-baselines/health.baseline.json
@@ -82,24 +82,6 @@
         "count": 1
       }
     },
-    "packages/ui/src/components/PluginCard.vue": {
-      "complexity_moderate": {
-        "count": 1
-      }
-    },
-    "packages/ui/src/components/PluginImportDialog.vue": {
-      "complexity_high": {
-        "count": 1
-      },
-      "crap_high": {
-        "count": 1
-      }
-    },
-    "packages/ui/src/components/ScreenScheduleDialog.vue": {
-      "crap_high": {
-        "count": 1
-      }
-    },
     "packages/ui/src/composeables/usePluginPreview.ts": {
       "crap_moderate": {
         "count": 1
@@ -107,11 +89,6 @@
     },
     "packages/ui/src/views/PluginEditView.vue": {
       "complexity_high": {
-        "count": 1
-      }
-    },
-    "packages/ui/src/views/VirtualDeviceView.vue": {
-      "crap_moderate": {
         "count": 1
       }
     }

--- a/packages/ui/src/components/PluginCard.vue
+++ b/packages/ui/src/components/PluginCard.vue
@@ -1,11 +1,9 @@
 <script setup lang="ts">
 import type { Plugin } from '../types/plugin'
-import { mdiAccountMultiple, mdiDelete, mdiDownload, mdiPencil, mdiPower } from '@mdi/js'
-import { computed, ref } from 'vue'
-import { useRouter } from 'vue-router'
-import { VBtn, VCard, VCardActions, VCardText, VCardTitle, VChip, VDialog, VDivider, VSnackbar, VSpacer } from 'vuetify/components'
-import { usePluginsStore } from '../stores/plugins'
-import PluginAssignDialog from './PluginAssignDialog.vue'
+import { mdiAccountMultiple } from '@mdi/js'
+import { computed } from 'vue'
+import { VCard, VCardText, VCardTitle, VChip, VDivider } from 'vuetify/components'
+import PluginCardActions from './PluginCardActions.vue'
 
 const props = defineProps<{
   plugin: Plugin
@@ -17,74 +15,11 @@ const emit = defineEmits<{
   deleted: []
 }>()
 
-const router = useRouter()
-const pluginsStore = usePluginsStore()
-
-const showAssignDialog = ref(false)
-const showDeleteDialog = ref(false)
-const showExportSnackbar = ref(false)
-
 const assignedCount = computed(() => props.plugin.deviceAssignments?.length || 0)
-
-const loadingDelete = ref(false)
-async function confirmDelete() {
-  loadingDelete.value = true
-  try {
-    await pluginsStore.deletePlugin(props.plugin.id, props.deviceId)
-    showDeleteDialog.value = false
-    emit('deleted')
-  }
-  finally {
-    loadingDelete.value = false
-  }
-}
-
-function deletePlugin() {
-  showDeleteDialog.value = true
-}
-
-const loadingToggle = ref(false)
-async function toggleActive() {
-  loadingToggle.value = true
-  try {
-    // If we have deviceId and _devicePluginId, toggle assignment
-    if (props.deviceId && props.plugin._devicePluginId) {
-      await pluginsStore.updateDeviceAssignment(props.plugin._devicePluginId, {
-        isActive: !props.plugin._isActive,
-      })
-      if (props.deviceId) {
-        await pluginsStore.fetchPluginsForDevice(props.deviceId)
-      }
-    }
-  }
-  finally {
-    loadingToggle.value = false
-  }
-}
-
-function editPlugin() {
-  router.push({ name: 'pluginEdit', params: { id: props.plugin.id } })
-}
-
-function exportPlugin() {
-  window.location.href = `/api/plugins/${props.plugin.id}/export`
-  showExportSnackbar.value = true
-}
-
-function openAssignDialog() {
-  showAssignDialog.value = true
-}
-
-function onAssigned() {
-  emit('assignmentsChanged')
-}
 </script>
 
 <template>
   <VCard elevation="1" class="h-100">
-    <VSnackbar v-model="showExportSnackbar" :timeout="3000" color="success">
-      Downloading plugin export...
-    </VSnackbar>
     <VCardTitle class="d-flex align-center justify-space-between flex-wrap ga-2">
       <span>{{ plugin.name }}</span>
       <div class="d-flex ga-2">
@@ -115,93 +50,11 @@ function onAssigned() {
         No description
       </div>
     </VCardText>
-    <VCardActions class="d-flex ga-2 flex-wrap">
-      <VBtn
-        variant="tonal"
-        size="small"
-        :prepend-icon="mdiPencil"
-        @click="editPlugin"
-      >
-        Edit
-      </VBtn>
-      <VBtn
-        v-if="!deviceId"
-        variant="tonal"
-        size="small"
-        :prepend-icon="mdiAccountMultiple"
-        @click="openAssignDialog"
-      >
-        Assign to Devices
-      </VBtn>
-      <VBtn
-        v-if="deviceId"
-        variant="tonal"
-        size="small"
-        :prepend-icon="mdiPower"
-        :color="plugin._isActive ? 'default' : 'success'"
-        :loading="loadingToggle"
-        @click="toggleActive"
-      >
-        {{ plugin._isActive ? 'Disable' : 'Enable' }}
-      </VBtn>
-      <VBtn
-        variant="tonal"
-        size="small"
-        :prepend-icon="mdiDownload"
-        @click="exportPlugin"
-      >
-        Export
-      </VBtn>
-      <VSpacer />
-      <VBtn
-        variant="tonal"
-        size="small"
-        color="error"
-        :prepend-icon="mdiDelete"
-        :loading="loadingDelete"
-        @click="deletePlugin"
-      >
-        Delete
-      </VBtn>
-    </VCardActions>
-
-    <PluginAssignDialog
-      v-model="showAssignDialog"
+    <PluginCardActions
       :plugin="plugin"
-      @assigned="onAssigned"
+      :device-id="deviceId"
+      @assignments-changed="emit('assignmentsChanged')"
+      @deleted="emit('deleted')"
     />
-
-    <VDialog v-model="showDeleteDialog" max-width="500">
-      <VCard>
-        <VCardTitle>Delete Plugin?</VCardTitle>
-        <VDivider />
-        <VCardText>
-          <p class="mb-2">
-            Are you sure you want to delete <strong>{{ plugin.name }}</strong>?
-          </p>
-          <p v-if="assignedCount > 0" class="text-error">
-            This plugin is assigned to {{ assignedCount }} device{{ assignedCount !== 1 ? 's' : '' }}. Deleting it will remove it from all devices.
-          </p>
-          <p class="text-medium-emphasis text-body-2">
-            This action cannot be undone.
-          </p>
-        </VCardText>
-        <VDivider />
-        <VCardActions>
-          <VSpacer />
-          <VBtn variant="text" @click="showDeleteDialog = false">
-            Cancel
-          </VBtn>
-          <VBtn
-            color="error"
-            variant="tonal"
-            :loading="loadingDelete"
-            @click="confirmDelete"
-          >
-            Delete
-          </VBtn>
-        </VCardActions>
-      </VCard>
-    </VDialog>
   </VCard>
 </template>

--- a/packages/ui/src/components/PluginCardActions.vue
+++ b/packages/ui/src/components/PluginCardActions.vue
@@ -1,0 +1,175 @@
+<script setup lang="ts">
+import type { Plugin } from '../types/plugin'
+import { mdiAccountMultiple, mdiDelete, mdiDownload, mdiPencil, mdiPower } from '@mdi/js'
+import { computed, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { VBtn, VCard, VCardActions, VCardText, VCardTitle, VDialog, VDivider, VSnackbar, VSpacer } from 'vuetify/components'
+import { usePluginsStore } from '../stores/plugins'
+import PluginAssignDialog from './PluginAssignDialog.vue'
+
+const props = defineProps<{
+  plugin: Plugin
+  deviceId?: string
+}>()
+
+const emit = defineEmits<{
+  assignmentsChanged: []
+  deleted: []
+}>()
+
+const router = useRouter()
+const pluginsStore = usePluginsStore()
+
+const showAssignDialog = ref(false)
+const showDeleteDialog = ref(false)
+const showExportSnackbar = ref(false)
+
+const assignedCount = computed(() => props.plugin.deviceAssignments?.length || 0)
+
+const loadingDelete = ref(false)
+async function confirmDelete() {
+  loadingDelete.value = true
+  try {
+    await pluginsStore.deletePlugin(props.plugin.id, props.deviceId)
+    showDeleteDialog.value = false
+    emit('deleted')
+  }
+  finally {
+    loadingDelete.value = false
+  }
+}
+
+function deletePlugin() {
+  showDeleteDialog.value = true
+}
+
+const loadingToggle = ref(false)
+async function toggleActive() {
+  loadingToggle.value = true
+  try {
+    // If we have deviceId and _devicePluginId, toggle assignment
+    if (props.deviceId && props.plugin._devicePluginId) {
+      await pluginsStore.updateDeviceAssignment(props.plugin._devicePluginId, {
+        isActive: !props.plugin._isActive,
+      })
+      if (props.deviceId) {
+        await pluginsStore.fetchPluginsForDevice(props.deviceId)
+      }
+    }
+  }
+  finally {
+    loadingToggle.value = false
+  }
+}
+
+function editPlugin() {
+  router.push({ name: 'pluginEdit', params: { id: props.plugin.id } })
+}
+
+function exportPlugin() {
+  window.location.href = `/api/plugins/${props.plugin.id}/export`
+  showExportSnackbar.value = true
+}
+
+function openAssignDialog() {
+  showAssignDialog.value = true
+}
+
+function onAssigned() {
+  emit('assignmentsChanged')
+}
+</script>
+
+<template>
+  <VSnackbar v-model="showExportSnackbar" :timeout="3000" color="success">
+    Downloading plugin export...
+  </VSnackbar>
+  <VCardActions class="d-flex ga-2 flex-wrap">
+    <VBtn
+      variant="tonal"
+      size="small"
+      :prepend-icon="mdiPencil"
+      @click="editPlugin"
+    >
+      Edit
+    </VBtn>
+    <VBtn
+      v-if="!deviceId"
+      variant="tonal"
+      size="small"
+      :prepend-icon="mdiAccountMultiple"
+      @click="openAssignDialog"
+    >
+      Assign to Devices
+    </VBtn>
+    <VBtn
+      v-if="deviceId"
+      variant="tonal"
+      size="small"
+      :prepend-icon="mdiPower"
+      :color="plugin._isActive ? 'default' : 'success'"
+      :loading="loadingToggle"
+      @click="toggleActive"
+    >
+      {{ plugin._isActive ? 'Disable' : 'Enable' }}
+    </VBtn>
+    <VBtn
+      variant="tonal"
+      size="small"
+      :prepend-icon="mdiDownload"
+      @click="exportPlugin"
+    >
+      Export
+    </VBtn>
+    <VSpacer />
+    <VBtn
+      variant="tonal"
+      size="small"
+      color="error"
+      :prepend-icon="mdiDelete"
+      :loading="loadingDelete"
+      @click="deletePlugin"
+    >
+      Delete
+    </VBtn>
+  </VCardActions>
+
+  <PluginAssignDialog
+    v-model="showAssignDialog"
+    :plugin="plugin"
+    @assigned="onAssigned"
+  />
+
+  <VDialog v-model="showDeleteDialog" max-width="500">
+    <VCard>
+      <VCardTitle>Delete Plugin?</VCardTitle>
+      <VDivider />
+      <VCardText>
+        <p class="mb-2">
+          Are you sure you want to delete <strong>{{ plugin.name }}</strong>?
+        </p>
+        <p v-if="assignedCount > 0" class="text-error">
+          This plugin is assigned to {{ assignedCount }} device{{ assignedCount !== 1 ? 's' : '' }}. Deleting it will remove it from all devices.
+        </p>
+        <p class="text-medium-emphasis text-body-2">
+          This action cannot be undone.
+        </p>
+      </VCardText>
+      <VDivider />
+      <VCardActions>
+        <VSpacer />
+        <VBtn variant="text" @click="showDeleteDialog = false">
+          Cancel
+        </VBtn>
+        <VBtn
+          color="error"
+          variant="tonal"
+          :loading="loadingDelete"
+          @click="confirmDelete"
+        >
+          Delete
+        </VBtn>
+      </VCardActions>
+    </VCard>
+  </VDialog>
+</template>

--- a/packages/ui/src/components/PluginImportDialog.vue
+++ b/packages/ui/src/components/PluginImportDialog.vue
@@ -16,7 +16,7 @@ const emit = defineEmits<{
 
 const deviceStore = useDeviceStore()
 
-const importTab = ref('file')
+const importTab = ref<'file' | 'github' | 'recipe'>('file')
 const selectedFile = ref<File | null>(null)
 const githubUrl = ref('')
 const recipeId = ref('')
@@ -88,7 +88,7 @@ async function importPlugin() {
   error.value = ''
 
   try {
-    await importBySource[importTab.value as keyof typeof importBySource](selectedDeviceId.value)
+    await importBySource[importTab.value](selectedDeviceId.value)
     emit('imported')
     close()
   }

--- a/packages/ui/src/components/PluginImportDialog.vue
+++ b/packages/ui/src/components/PluginImportDialog.vue
@@ -32,6 +32,52 @@ function onFileChange(files: File | File[]) {
   }
 }
 
+async function postImport(url: string, body: BodyInit, headers?: HeadersInit) {
+  const res = await fetch(url, { method: 'POST', headers, body })
+  if (!res.ok) {
+    const errorData = await res.json()
+    throw new Error(errorData.message || 'Import failed')
+  }
+}
+
+async function importFromFile(deviceId: string) {
+  if (!selectedFile.value) {
+    throw new Error('Please select a file')
+  }
+  const formData = new FormData()
+  formData.append('file', selectedFile.value)
+  formData.append('deviceId', deviceId)
+  await postImport('/api/plugins/import', formData)
+}
+
+async function importFromGithub(deviceId: string) {
+  if (!githubUrl.value) {
+    throw new Error('Please enter a GitHub URL')
+  }
+  await postImport(
+    '/api/plugins/import-github',
+    JSON.stringify({ githubUrl: githubUrl.value, deviceId }),
+    { 'Content-Type': 'application/json' },
+  )
+}
+
+async function importFromRecipe(deviceId: string) {
+  if (!recipeId.value) {
+    throw new Error('Please enter a Recipe id or URL')
+  }
+  await postImport(
+    '/api/plugins/import-recipe',
+    JSON.stringify({ recipeId: recipeId.value, deviceId }),
+    { 'Content-Type': 'application/json' },
+  )
+}
+
+const importBySource = {
+  file: importFromFile,
+  github: importFromGithub,
+  recipe: importFromRecipe,
+}
+
 async function importPlugin() {
   if (!selectedDeviceId.value) {
     error.value = 'Please select a device'
@@ -42,67 +88,7 @@ async function importPlugin() {
   error.value = ''
 
   try {
-    if (importTab.value === 'file') {
-      if (!selectedFile.value) {
-        error.value = 'Please select a file'
-        return
-      }
-
-      const formData = new FormData()
-      formData.append('file', selectedFile.value)
-      formData.append('deviceId', selectedDeviceId.value)
-
-      const res = await fetch('/api/plugins/import', {
-        method: 'POST',
-        body: formData,
-      })
-
-      if (!res.ok) {
-        const errorData = await res.json()
-        throw new Error(errorData.message || 'Import failed')
-      }
-    }
-    else if (importTab.value === 'github') {
-      if (!githubUrl.value) {
-        error.value = 'Please enter a GitHub URL'
-        return
-      }
-
-      const res = await fetch('/api/plugins/import-github', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          githubUrl: githubUrl.value,
-          deviceId: selectedDeviceId.value,
-        }),
-      })
-
-      if (!res.ok) {
-        const errorData = await res.json()
-        throw new Error(errorData.message || 'Import failed')
-      }
-    }
-    else {
-      if (!recipeId.value) {
-        error.value = 'Please enter a Recipe id or URL'
-        return
-      }
-
-      const res = await fetch('/api/plugins/import-recipe', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          recipeId: recipeId.value,
-          deviceId: selectedDeviceId.value,
-        }),
-      })
-
-      if (!res.ok) {
-        const errorData = await res.json()
-        throw new Error(errorData.message || 'Import failed')
-      }
-    }
-
+    await importBySource[importTab.value as keyof typeof importBySource](selectedDeviceId.value)
     emit('imported')
     close()
   }
@@ -168,6 +154,7 @@ function close() {
           <VWindowItem value="github">
             <VTextField
               v-model="githubUrl"
+              data-test-id="github-url"
               label="GitHub Repository URL"
               placeholder="https://github.com/owner/repo"
               hint="Enter the URL of a GitHub repository containing a Terminus plugin"
@@ -181,6 +168,7 @@ function close() {
           <VWindowItem value="recipe">
             <VTextField
               v-model="recipeId"
+              data-test-id="recipe-id"
               label="TRMNL Recipe id or URL"
               placeholder="150460 or https://trmnl.com/recipes/150460"
               hint="Enter a Recipe's numeric id or its trmnl.com/recipes/... page URL"
@@ -212,6 +200,7 @@ function close() {
         <VBtn
           color="primary"
           variant="tonal"
+          data-test-id="import-submit"
           :loading="loading"
           :disabled="(!selectedFile && !githubUrl && !recipeId) || !selectedDeviceId"
           @click="importPlugin"

--- a/packages/ui/src/components/ScreenScheduleDialog.vue
+++ b/packages/ui/src/components/ScreenScheduleDialog.vue
@@ -32,16 +32,30 @@ const saving = ref(false)
 const hasSchedule = computed(() => Boolean(props.screen.schedule))
 const spansMidnight = computed(() => Boolean(startTime.value && endTime.value && startTime.value > endTime.value))
 
+function scheduleToForm(schedule: Screen['schedule']) {
+  if (!schedule) {
+    return { enabled: true, weekdays: [], startTime: '', endTime: '', startDate: '', endDate: '' }
+  }
+  return {
+    enabled: schedule.enabled,
+    weekdays: schedule.weekdays ? [...schedule.weekdays] : [],
+    startTime: schedule.startTime ? withoutSeconds(schedule.startTime) : '',
+    endTime: schedule.endTime ? withoutSeconds(schedule.endTime) : '',
+    startDate: schedule.startDate ?? '',
+    endDate: schedule.endDate ?? '',
+  }
+}
+
 watch(() => props.modelValue, (open) => {
   if (!open)
     return
-  const schedule = props.screen.schedule
-  enabled.value = schedule?.enabled ?? true
-  weekdays.value = schedule?.weekdays ? [...schedule.weekdays] : []
-  startTime.value = schedule?.startTime ? withoutSeconds(schedule.startTime) : ''
-  endTime.value = schedule?.endTime ? withoutSeconds(schedule.endTime) : ''
-  startDate.value = schedule?.startDate ?? ''
-  endDate.value = schedule?.endDate ?? ''
+  const form = scheduleToForm(props.screen.schedule)
+  enabled.value = form.enabled
+  weekdays.value = form.weekdays
+  startTime.value = form.startTime
+  endTime.value = form.endTime
+  startDate.value = form.startDate
+  endDate.value = form.endDate
   error.value = null
 }, { immediate: true })
 

--- a/packages/ui/src/components/__test__/PluginImportDialog.spec.ts
+++ b/packages/ui/src/components/__test__/PluginImportDialog.spec.ts
@@ -1,0 +1,142 @@
+import type { Mock } from 'vitest'
+import type { useDeviceStore } from '@/stores/device'
+import { flushPromises, mount } from '@vue/test-utils'
+import { createPinia } from 'pinia'
+import rop from 'resize-observer-polyfill'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { VFileInput, VSelect, VTabs } from 'vuetify/components'
+import vuetify from '../../plugins/vuetify'
+import { stubVisualViewport } from '../../test/browser'
+import { jsonResponse, stubFetch } from '../../test/fetch'
+import { asStore } from '../../test/mockStore'
+import PluginImportDialog from '../PluginImportDialog.vue'
+
+globalThis.ResizeObserver = rop
+
+globalThis.window.matchMedia = globalThis.window.matchMedia || function () {
+  return {
+    matches: false,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  }
+}
+
+globalThis.visualViewport = globalThis.visualViewport || stubVisualViewport()
+
+let deviceStoreMock: ReturnType<typeof useDeviceStore>
+vi.mock('@/stores/device', () => ({
+  useDeviceStore: () => deviceStoreMock,
+}))
+
+function mountDialog() {
+  return mount(PluginImportDialog, {
+    props: { modelValue: true },
+    global: { plugins: [createPinia(), vuetify] },
+    attachTo: document.body,
+  })
+}
+
+async function selectDevice(wrapper: ReturnType<typeof mountDialog>) {
+  wrapper.findComponent(VSelect).vm.$emit('update:modelValue', 'device-1')
+  await flushPromises()
+}
+
+async function switchTab(wrapper: ReturnType<typeof mountDialog>, tab: string) {
+  wrapper.findComponent(VTabs).vm.$emit('update:modelValue', tab)
+  await flushPromises()
+}
+
+function setInput(testId: string, value: string) {
+  const input = document.querySelector(`[data-test-id="${testId}"] input`) as HTMLInputElement
+  input.value = value
+  input.dispatchEvent(new Event('input'))
+  return flushPromises()
+}
+
+function clickButton(testId: string) {
+  const button = document.querySelector(`[data-test-id="${testId}"]`) as HTMLElement
+  button.click()
+  return flushPromises()
+}
+
+describe('pluginImportDialog', () => {
+  let mockFetch: Mock<typeof fetch>
+
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    mockFetch = stubFetch()
+    deviceStoreMock = asStore<ReturnType<typeof useDeviceStore>>({
+      devices: [{ id: 'device-1', name: 'Device 1' }],
+    })
+  })
+
+  it('imports a file for the selected device', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({}))
+    const wrapper = mountDialog()
+    await flushPromises()
+    await selectDevice(wrapper)
+    wrapper.findComponent(VFileInput).vm.$emit('update:modelValue', [new File(['content'], 'plugin.zip')])
+    await flushPromises()
+
+    await clickButton('import-submit')
+
+    expect(mockFetch).toHaveBeenCalledWith('/api/plugins/import', expect.objectContaining({ method: 'POST' }))
+    const body = mockFetch.mock.calls[0][1]?.body as FormData
+    expect(body.get('deviceId')).toBe('device-1')
+    expect((body.get('file') as File).name).toBe('plugin.zip')
+    expect(wrapper.emitted('imported')).toBeTruthy()
+    expect(wrapper.emitted('update:modelValue')).toContainEqual([false])
+  })
+
+  it('imports from a GitHub URL for the selected device', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({}))
+    const wrapper = mountDialog()
+    await flushPromises()
+    await selectDevice(wrapper)
+    await switchTab(wrapper, 'github')
+    await setInput('github-url', 'https://github.com/owner/repo')
+
+    await clickButton('import-submit')
+
+    expect(mockFetch).toHaveBeenCalledWith('/api/plugins/import-github', expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify({ githubUrl: 'https://github.com/owner/repo', deviceId: 'device-1' }),
+    }))
+    expect(wrapper.emitted('imported')).toBeTruthy()
+  })
+
+  it('imports from a recipe id for the selected device', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({}))
+    const wrapper = mountDialog()
+    await flushPromises()
+    await selectDevice(wrapper)
+    await switchTab(wrapper, 'recipe')
+    await setInput('recipe-id', '150460')
+
+    await clickButton('import-submit')
+
+    expect(mockFetch).toHaveBeenCalledWith('/api/plugins/import-recipe', expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify({ recipeId: '150460', deviceId: 'device-1' }),
+    }))
+    expect(wrapper.emitted('imported')).toBeTruthy()
+  })
+
+  it('surfaces the API error message and keeps the dialog open', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ message: 'Bad plugin' }, false))
+    const wrapper = mountDialog()
+    await flushPromises()
+    await selectDevice(wrapper)
+    await switchTab(wrapper, 'github')
+    await setInput('github-url', 'https://github.com/owner/repo')
+
+    await clickButton('import-submit')
+
+    expect(document.body.textContent).toContain('Bad plugin')
+    expect(wrapper.emitted('imported')).toBeUndefined()
+    expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+  })
+})

--- a/packages/ui/src/views/VirtualDeviceView.vue
+++ b/packages/ui/src/views/VirtualDeviceView.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { Device } from '@/types'
 import { mdiClipboardArrowRight, mdiSend, mdiSync } from '@mdi/js'
 import { computed, ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
@@ -147,21 +148,33 @@ watch(macInputTab, () => {
   }
 })
 
-watch(mac, () => {
+const deviceHeaderSources: { [K in keyof typeof customHeaders.value]: (device: Device) => string | undefined } = {
+  'battery-voltage': device => device.batteryVoltage,
+  'fw-version': device => device.fwVersion,
+  'refresh-rate': device => device.refreshRate?.toString(),
+  'rssi': device => device.rssi,
+  'user-agent': device => device.userAgent,
+  'width': device => device.width?.toString(),
+  'height': device => device.height?.toString(),
+  'model': device => device.reportedModel ?? undefined,
+}
+
+function applyDeviceHeaders(device: Device) {
+  for (const [key, source] of Object.entries(deviceHeaderSources) as [keyof typeof customHeaders.value, (device: Device) => string | undefined][]) {
+    customHeaders.value[key] = source(device) || customHeaders.value[key]
+  }
+}
+
+function syncHeadersFromSelectedDevice() {
   if (macInputTab.value !== 'device')
     return
   const device = deviceStore.devices.find(d => d.mac === mac.value)
   if (!device)
     return
-  customHeaders.value['battery-voltage'] = device.batteryVoltage || customHeaders.value['battery-voltage']
-  customHeaders.value['fw-version'] = device.fwVersion || customHeaders.value['fw-version']
-  customHeaders.value['refresh-rate'] = device.refreshRate?.toString() || customHeaders.value['refresh-rate']
-  customHeaders.value.rssi = device.rssi || customHeaders.value.rssi
-  customHeaders.value['user-agent'] = device.userAgent || customHeaders.value['user-agent']
-  customHeaders.value.width = device.width?.toString() || customHeaders.value.width
-  customHeaders.value.height = device.height?.toString() || customHeaders.value.height
-  customHeaders.value.model = device.reportedModel || customHeaders.value.model
-})
+  applyDeviceHeaders(device)
+}
+
+watch(mac, syncHeadersFromSelectedDevice)
 </script>
 
 <template>

--- a/packages/ui/src/views/__test__/VirtualDeviceView.spec.ts
+++ b/packages/ui/src/views/__test__/VirtualDeviceView.spec.ts
@@ -1,0 +1,98 @@
+import type { useDeviceStore } from '@/stores/device'
+import { flushPromises, mount } from '@vue/test-utils'
+import { createPinia } from 'pinia'
+import rop from 'resize-observer-polyfill'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { VAutocomplete, VTabs, VTextField } from 'vuetify/components'
+import vuetify from '../../plugins/vuetify'
+import { stubVisualViewport } from '../../test/browser'
+import { asStore } from '../../test/mockStore'
+import VirtualDeviceView from '../VirtualDeviceView.vue'
+
+globalThis.ResizeObserver = rop
+
+globalThis.window.matchMedia = globalThis.window.matchMedia || function () {
+  return {
+    matches: false,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  }
+}
+
+globalThis.visualViewport = globalThis.visualViewport || stubVisualViewport()
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ name: 'virtualDevice', params: {} }),
+}))
+
+let deviceStoreMock: ReturnType<typeof useDeviceStore>
+vi.mock('@/stores/device', () => ({
+  useDeviceStore: () => deviceStoreMock,
+}))
+
+function mountView() {
+  return mount(VirtualDeviceView, {
+    global: { plugins: [createPinia(), vuetify] },
+    attachTo: document.body,
+  })
+}
+
+function headerField(wrapper: ReturnType<typeof mountView>, label: string) {
+  return wrapper.findAllComponents(VTextField).find(field => field.props('label') === label)
+}
+
+describe('virtualDeviceView', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    deviceStoreMock = asStore<ReturnType<typeof useDeviceStore>>({
+      devices: [{
+        id: 'device-1',
+        mac: 'AA:BB:CC:DD:EE:FF',
+        batteryVoltage: '3.9V',
+        fwVersion: '1.2.3',
+        refreshRate: 300,
+        rssi: '-50',
+        userAgent: 'custom-ua',
+        width: 800,
+        height: 480,
+        reportedModel: 'og2',
+      }],
+    })
+  })
+
+  it('fills the custom headers from the selected device when picking it from the device tab', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    wrapper.findComponent(VTabs).vm.$emit('update:modelValue', 'device')
+    await flushPromises()
+    wrapper.findComponent(VAutocomplete).vm.$emit('update:modelValue', 'AA:BB:CC:DD:EE:FF')
+    await flushPromises()
+
+    expect(headerField(wrapper, 'battery-voltage')?.props('modelValue')).toBe('3.9V')
+    expect(headerField(wrapper, 'fw-version')?.props('modelValue')).toBe('1.2.3')
+    expect(headerField(wrapper, 'refresh-rate')?.props('modelValue')).toBe('300')
+    expect(headerField(wrapper, 'rssi')?.props('modelValue')).toBe('-50')
+    expect(headerField(wrapper, 'user-agent')?.props('modelValue')).toBe('custom-ua')
+    expect(headerField(wrapper, 'width')?.props('modelValue')).toBe('800')
+    expect(headerField(wrapper, 'height')?.props('modelValue')).toBe('480')
+    expect(headerField(wrapper, 'model')?.props('modelValue')).toBe('og2')
+  })
+
+  it('keeps the current header value when the device does not report that field', async () => {
+    deviceStoreMock.devices[0].batteryVoltage = undefined
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    wrapper.findComponent(VTabs).vm.$emit('update:modelValue', 'device')
+    await flushPromises()
+    wrapper.findComponent(VAutocomplete).vm.$emit('update:modelValue', 'AA:BB:CC:DD:EE:FF')
+    await flushPromises()
+
+    expect(headerField(wrapper, 'battery-voltage')?.props('modelValue')).toBe('4.2V')
+  })
+})


### PR DESCRIPTION
## What

Resolves the four fallow complexity findings baselined in #853:

- **PluginImportDialog.vue** (`importPlugin`, cyclomatic 14 → split): extracts `importFromFile`/`importFromGithub`/`importFromRecipe`, dispatched from a `importBySource` lookup keyed by the tab; `importPlugin` now just validates the device selection and dispatches.
- **ScreenScheduleDialog.vue** (`modelValue` watcher, cyclomatic 14 → split): extracts `scheduleToForm(schedule)`, returning the whole form state in one object; the watcher just assigns from it.
- **PluginCard.vue** (`<template>`, cyclomatic 14/cognitive 18/207 lines → split): moves the action buttons, the assign dialog, the delete-confirm dialog, and the export snackbar into a new `PluginCardActions.vue` child; `PluginCard.vue` keeps only the title/description display.
- **VirtualDeviceView.vue** (`mac` watcher arrow, cyclomatic 11 → split): extracts a named `syncHeadersFromSelectedDevice` function backed by a `deviceHeaderSources` lookup table instead of eight chained `||` assignments.

Re-saved `.fallow-baselines/health.baseline.json` (`pnpm fallow:baseline`) — all four findings are gone, nothing new added.

## Why

Smaller UI complexity findings flagged by the initial fallow scan; each file now sits under the cyclomatic/cognitive targets set in the issue.

## Test evidence

- `pnpm lint && pnpm type-check && pnpm test` — pass (262 tests, 48 files).
- `pnpm fallow:ci` — passes (exit 0); the four baselined findings for these files are gone from `.fallow-baselines/health.baseline.json`.
- Added characterization/regression specs for the two files that had no prior coverage (`PluginImportDialog.spec.ts`, `VirtualDeviceView.spec.ts`) before refactoring them, as a safety net for the behavior-preserving split. `ScreenScheduleDialog.vue` and `PluginCard.vue` already had specs, which stayed green through the refactor unmodified.
- `pnpm --filter ./packages/ui test:e2e` was run for the two files with template changes (PluginImportDialog, PluginCard) per the issue's verification note, but the suite cannot launch Chromium in this sandbox (`Target.setAutoAttach: Target closed` from puppeteer-core) — confirmed this is a pre-existing environment limitation, not caused by this change, by running the same suite on an unmodified checkout of this branch's base commit and getting the identical failure.

Closes #853

*Opened by Kongroo, karakuri's Projects agent — Stage: implement*