### PR TITLE
refactor(api): remaining moderate complexity hotspots (devices.service, ssrfGuard, plugin-data-fetcher, config)

### DIFF
--- a/.fallow-baselines/health.baseline.json
+++ b/.fallow-baselines/health.baseline.json
@@ -1,15 +1,5 @@
 {
   "finding_counts": {
-    "packages/api/src/config/config.ts": {
-      "crap_critical": {
-        "count": 1
-      }
-    },
-    "packages/api/src/devices/devices.service.ts": {
-      "crap_moderate": {
-        "count": 1
-      }
-    },
     "packages/api/src/devices/display.service.ts": {
       "complexity_critical": {
         "count": 2
@@ -32,22 +22,12 @@
         "count": 1
       }
     },
-    "packages/api/src/plugins/plugin-data-source-mode.ts": {
-      "complexity_moderate": {
-        "count": 1
-      }
-    },
     "packages/api/src/plugins/plugins.service.ts": {
       "complexity_critical": {
         "count": 2
       },
       "crap_critical": {
         "count": 2
-      }
-    },
-    "packages/api/src/plugins/services/plugin-data-fetcher.service.ts": {
-      "crap_moderate": {
-        "count": 1
       }
     },
     "packages/api/src/plugins/services/plugin-importer.service.ts": {
@@ -59,11 +39,6 @@
       },
       "crap_moderate": {
         "count": 2
-      }
-    },
-    "packages/api/src/utils/ssrfGuard.ts": {
-      "crap_moderate": {
-        "count": 1
       }
     },
     "packages/ui/src/components/PluginCard.vue": {

--- a/packages/api/src/config/__test__/config.spec.ts
+++ b/packages/api/src/config/__test__/config.spec.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import config from '../config'
+
+const CONFIG_ENV_VARS = [
+  'KUROSHIRO_PORT',
+  'KUROSHIRO_API_URL',
+  'KUROSHIRO_DEMO_MODE',
+  'KUROSHIRO_DB_HOST',
+  'KUROSHIRO_DB_PORT',
+  'KUROSHIRO_DB_DB',
+  'KUROSHIRO_DB_USER',
+  'KUROSHIRO_DB_PASSWORD',
+] as const
+
+describe('config', () => {
+  const originalEnv = Object.fromEntries(CONFIG_ENV_VARS.map(key => [key, process.env[key]]))
+
+  afterEach(() => {
+    for (const key of CONFIG_ENV_VARS) {
+      if (originalEnv[key] === undefined)
+        delete process.env[key]
+      else
+        process.env[key] = originalEnv[key]
+    }
+  })
+
+  it('falls back to defaults when no env vars are set', () => {
+    for (const key of CONFIG_ENV_VARS)
+      delete process.env[key]
+
+    expect(config()).toEqual({
+      port: 3000,
+      api_url: 'http://localhost:5173',
+      demo_mode: false,
+      database: {
+        host: 'localhost',
+        port: 5432,
+        database: 'test',
+        user: 'root',
+        password: 'root',
+      },
+    })
+  })
+
+  it('reads every value from its env var override', () => {
+    process.env.KUROSHIRO_PORT = '8080'
+    process.env.KUROSHIRO_API_URL = 'https://example.com'
+    process.env.KUROSHIRO_DEMO_MODE = 'true'
+    process.env.KUROSHIRO_DB_HOST = 'db.example.com'
+    process.env.KUROSHIRO_DB_PORT = '6543'
+    process.env.KUROSHIRO_DB_DB = 'kuroshiro'
+    process.env.KUROSHIRO_DB_USER = 'admin'
+    process.env.KUROSHIRO_DB_PASSWORD = 'hunter2'
+
+    expect(config()).toEqual({
+      port: 8080,
+      api_url: 'https://example.com',
+      demo_mode: true,
+      database: {
+        host: 'db.example.com',
+        port: 6543,
+        database: 'kuroshiro',
+        user: 'admin',
+        password: 'hunter2',
+      },
+    })
+  })
+
+  it('falls back to port 3000 when KUROSHIRO_PORT is non-numeric', () => {
+    process.env.KUROSHIRO_PORT = 'not-a-number'
+    expect(config().port).toBe(3000)
+  })
+
+  it('treats any value other than the literal string "true" as demo_mode disabled', () => {
+    process.env.KUROSHIRO_DEMO_MODE = 'false'
+    expect(config().demo_mode).toBe(false)
+    process.env.KUROSHIRO_DEMO_MODE = 'yes'
+    expect(config().demo_mode).toBe(false)
+  })
+})

--- a/packages/api/src/devices/devices.service.ts
+++ b/packages/api/src/devices/devices.service.ts
@@ -62,13 +62,21 @@ export class DevicesService {
   }
 
   private async applyModelChanges(device: Device, deviceModelName?: string, paletteId?: string): Promise<void> {
-    if (deviceModelName !== undefined && deviceModelName !== device.deviceModel?.name) {
-      const model = await this.deviceModels.findByName(deviceModelName)
-      if (!model)
-        throw new BadRequestException(`Unknown device model: ${deviceModelName}`)
-      device.deviceModel = model
-      device.palette = null
-    }
+    await this.applyModelChange(device, deviceModelName)
+    await this.applyPaletteChange(device, paletteId)
+  }
+
+  private async applyModelChange(device: Device, deviceModelName?: string): Promise<void> {
+    if (deviceModelName === undefined || deviceModelName === device.deviceModel?.name)
+      return
+    const model = await this.deviceModels.findByName(deviceModelName)
+    if (!model)
+      throw new BadRequestException(`Unknown device model: ${deviceModelName}`)
+    device.deviceModel = model
+    device.palette = null
+  }
+
+  private async applyPaletteChange(device: Device, paletteId?: string): Promise<void> {
     if (paletteId !== undefined) {
       if (!device.deviceModel)
         throw new BadRequestException('Cannot set a palette on a device with no assigned device model')
@@ -76,6 +84,7 @@ export class DevicesService {
       if (!palette || !(await this.paletteSupportedBy(palette, device.deviceModel)))
         throw new BadRequestException(`Palette ${paletteId} is not supported by device model ${device.deviceModel.name}`)
       device.palette = palette
+      return
     }
     if (device.deviceModel && !device.palette)
       device.palette = await this.deviceModels.defaultPaletteFor(device.deviceModel)

--- a/packages/api/src/plugins/plugin-data-source-mode.ts
+++ b/packages/api/src/plugins/plugin-data-source-mode.ts
@@ -31,30 +31,19 @@ export function dataSourceModeViolation(fields: DataSourceModeFields): string | 
     if (isPresent(method) && method !== 'GET') {
       return 'A literal-mode Data Source cannot have a Method'
     }
-    if (isPresent(url)) {
-      return 'A literal-mode Data Source cannot have a URL'
-    }
-    if (isPresent(headers)) {
-      return 'A literal-mode Data Source cannot have Headers'
-    }
-    if (isPresent(body)) {
-      return 'A literal-mode Data Source cannot have a Body'
-    }
-    if (isPresent(transformJs)) {
-      return 'A literal-mode Data Source cannot have a Transform'
-    }
-    if (!isPresent(literalValue)) {
-      return 'A literal-mode Data Source requires a Value'
-    }
-    return null
+    const literalModeViolations: Array<[fieldName: string, isViolation: boolean, message: string]> = [
+      ['url', isPresent(url), 'A literal-mode Data Source cannot have a URL'],
+      ['headers', isPresent(headers), 'A literal-mode Data Source cannot have Headers'],
+      ['body', isPresent(body), 'A literal-mode Data Source cannot have a Body'],
+      ['transformJs', isPresent(transformJs), 'A literal-mode Data Source cannot have a Transform'],
+      ['literalValue', !isPresent(literalValue), 'A literal-mode Data Source requires a Value'],
+    ]
+    return literalModeViolations.find(([, isViolation]) => isViolation)?.[2] ?? null
   }
 
-  if (isPresent(literalValue)) {
-    return 'A fetch-mode Data Source cannot have a Value'
-  }
-  if (!isPresent(url)) {
-    return 'A fetch-mode Data Source requires a URL'
-  }
-
-  return null
+  const fetchModeViolations: Array<[fieldName: string, isViolation: boolean, message: string]> = [
+    ['literalValue', isPresent(literalValue), 'A fetch-mode Data Source cannot have a Value'],
+    ['url', !isPresent(url), 'A fetch-mode Data Source requires a URL'],
+  ]
+  return fetchModeViolations.find(([, isViolation]) => isViolation)?.[2] ?? null
 }

--- a/packages/api/src/plugins/plugin-data-source-mode.ts
+++ b/packages/api/src/plugins/plugin-data-source-mode.ts
@@ -14,6 +14,8 @@ function isPresent(value: unknown): boolean {
   return value !== undefined && value !== null
 }
 
+type ModeViolation = [fieldName: string, isViolation: boolean, message: string]
+
 /**
  * fetch and literal Data Sources have disjoint required fields; a Data
  * Source carrying a field from the mode it isn't is rejected rather than
@@ -31,7 +33,7 @@ export function dataSourceModeViolation(fields: DataSourceModeFields): string | 
     if (isPresent(method) && method !== 'GET') {
       return 'A literal-mode Data Source cannot have a Method'
     }
-    const literalModeViolations: Array<[fieldName: string, isViolation: boolean, message: string]> = [
+    const literalModeViolations: ModeViolation[] = [
       ['url', isPresent(url), 'A literal-mode Data Source cannot have a URL'],
       ['headers', isPresent(headers), 'A literal-mode Data Source cannot have Headers'],
       ['body', isPresent(body), 'A literal-mode Data Source cannot have a Body'],
@@ -41,7 +43,7 @@ export function dataSourceModeViolation(fields: DataSourceModeFields): string | 
     return literalModeViolations.find(([, isViolation]) => isViolation)?.[2] ?? null
   }
 
-  const fetchModeViolations: Array<[fieldName: string, isViolation: boolean, message: string]> = [
+  const fetchModeViolations: ModeViolation[] = [
     ['literalValue', isPresent(literalValue), 'A fetch-mode Data Source cannot have a Value'],
     ['url', !isPresent(url), 'A fetch-mode Data Source requires a URL'],
   ]

--- a/packages/api/src/plugins/services/plugin-data-fetcher.service.ts
+++ b/packages/api/src/plugins/services/plugin-data-fetcher.service.ts
@@ -47,18 +47,30 @@ export class PluginDataFetcherService {
     body?: JsonObject,
     templateContext?: object,
   ): Promise<unknown> {
-    let resolvedUrl = url
-
-    // If URL contains Liquid template syntax, render it first
-    if (url.includes('{{') || url.includes('{%')) {
-      this.logger.debug(`Rendering URL template: ${url}`)
-      resolvedUrl = await this.renderer.render(url, templateContext || {})
-      this.logger.debug(`Resolved URL: ${resolvedUrl}`)
-    }
+    const resolvedUrl = await this.resolveUrl(url, templateContext)
 
     if (this.configService.get<boolean>('demo_mode'))
       assertPublicUrl(resolvedUrl)
 
+    const response = await fetch(resolvedUrl, this.buildRequestInit(method, headers, body))
+    return this.parseResponse(response)
+  }
+
+  /**
+   * A URL containing Liquid template syntax is rendered against the template
+   * context before use; a plain URL is returned unchanged so callers never
+   * pay for a render they don't need.
+   */
+  private async resolveUrl(url: string, templateContext?: object): Promise<string> {
+    if (!url.includes('{{') && !url.includes('{%'))
+      return url
+    this.logger.debug(`Rendering URL template: ${url}`)
+    const resolvedUrl = await this.renderer.render(url, templateContext || {})
+    this.logger.debug(`Resolved URL: ${resolvedUrl}`)
+    return resolvedUrl
+  }
+
+  private buildRequestInit(method: string, headers: Record<string, string>, body?: JsonObject): RequestInit {
     const options: RequestInit = {
       method,
       headers: method === 'POST' && body
@@ -70,8 +82,10 @@ export class PluginDataFetcherService {
       options.body = JSON.stringify(body)
     }
 
-    const response = await fetch(resolvedUrl, options)
+    return options
+  }
 
+  private async parseResponse(response: Response): Promise<unknown> {
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`)
     }

--- a/packages/api/src/utils/__test__/ssrfGuard.spec.ts
+++ b/packages/api/src/utils/__test__/ssrfGuard.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import { assertPublicUrl } from '../ssrfGuard'
+
+describe('assertPublicUrl', () => {
+  it('allows a public URL', () => {
+    expect(() => assertPublicUrl('https://example.com/data')).not.toThrow()
+  })
+
+  it('allows a public IPv4 address', () => {
+    expect(() => assertPublicUrl('http://8.8.8.8/')).not.toThrow()
+  })
+
+  describe('private IPv4 ranges', () => {
+    it('blocks the loopback range (127.0.0.0/8)', () => {
+      expect(() => assertPublicUrl('http://127.0.0.1/')).toThrow('private IP ranges')
+      expect(() => assertPublicUrl('http://127.255.255.255/')).toThrow('private IP ranges')
+    })
+
+    it('blocks the 10.0.0.0/8 range, including its upper boundary', () => {
+      expect(() => assertPublicUrl('http://10.0.0.0/')).toThrow('private IP ranges')
+      expect(() => assertPublicUrl('http://10.255.255.255/')).toThrow('private IP ranges')
+    })
+
+    it('blocks the 172.16.0.0/12 range but not addresses just outside it', () => {
+      expect(() => assertPublicUrl('http://172.16.0.0/')).toThrow('private IP ranges')
+      expect(() => assertPublicUrl('http://172.31.255.255/')).toThrow('private IP ranges')
+      expect(() => assertPublicUrl('http://172.15.255.255/')).not.toThrow()
+      expect(() => assertPublicUrl('http://172.32.0.0/')).not.toThrow()
+    })
+
+    it('blocks the 192.168.0.0/16 range but not addresses just outside it', () => {
+      expect(() => assertPublicUrl('http://192.168.0.0/')).toThrow('private IP ranges')
+      expect(() => assertPublicUrl('http://192.168.255.255/')).toThrow('private IP ranges')
+      expect(() => assertPublicUrl('http://192.167.255.255/')).not.toThrow()
+      expect(() => assertPublicUrl('http://192.169.0.0/')).not.toThrow()
+    })
+
+    it('blocks the link-local range (169.254.0.0/16), including the cloud metadata address', () => {
+      expect(() => assertPublicUrl('http://169.254.169.254/')).toThrow('private IP ranges')
+    })
+  })
+
+  it('blocks IPv6 loopback and unique local addresses', () => {
+    expect(() => assertPublicUrl('http://[::1]/')).toThrow('private IP ranges')
+    expect(() => assertPublicUrl('http://[fc00::1]/')).toThrow('private IP ranges')
+    expect(() => assertPublicUrl('http://[fd12:3456::1]/')).toThrow('private IP ranges')
+  })
+
+  it('blocks known-internal hostnames and suffixes', () => {
+    expect(() => assertPublicUrl('http://localhost/')).toThrow('internal hosts')
+    expect(() => assertPublicUrl('http://metadata.google.internal/')).toThrow('internal hosts')
+    expect(() => assertPublicUrl('http://foo.local/')).toThrow('internal hosts')
+    expect(() => assertPublicUrl('http://foo.internal/')).toThrow('internal hosts')
+    expect(() => assertPublicUrl('http://foo.localhost/')).toThrow('internal hosts')
+  })
+
+  it('rejects an invalid URL', () => {
+    expect(() => assertPublicUrl('not-a-url')).toThrow('Invalid URL')
+  })
+})

--- a/packages/api/src/utils/ssrfGuard.ts
+++ b/packages/api/src/utils/ssrfGuard.ts
@@ -3,18 +3,24 @@ import net from 'node:net'
 const PRIVATE_HOSTNAMES = new Set(['localhost', 'metadata.google.internal'])
 const PRIVATE_HOSTNAME_SUFFIXES = ['.local', '.internal', '.localhost']
 
+const PRIVATE_IPV4_RANGES: Array<[start: string, end: string]> = [
+  ['127.0.0.0', '127.255.255.255'],
+  ['10.0.0.0', '10.255.255.255'],
+  ['172.16.0.0', '172.31.255.255'],
+  ['192.168.0.0', '192.168.255.255'],
+  ['169.254.0.0', '169.254.255.255'],
+]
+
+function ipv4ToInt(ip: string): number {
+  return ip.split('.').reduce((acc, part) => acc * 256 + Number(part), 0)
+}
+
 function isPrivateIpv4(ip: string): boolean {
   const parts = ip.split('.').map(Number)
   if (parts.length !== 4 || parts.some(Number.isNaN))
     return false
-  const [a, b] = parts
-  return (
-    a === 127
-    || a === 10
-    || (a === 172 && b >= 16 && b <= 31)
-    || (a === 192 && b === 168)
-    || (a === 169 && b === 254)
-  )
+  const value = ipv4ToInt(ip)
+  return PRIVATE_IPV4_RANGES.some(([start, end]) => value >= ipv4ToInt(start) && value <= ipv4ToInt(end))
 }
 
 function isPrivateIpv6(ip: string): boolean {

--- a/packages/api/src/utils/ssrfGuard.ts
+++ b/packages/api/src/utils/ssrfGuard.ts
@@ -3,24 +3,24 @@ import net from 'node:net'
 const PRIVATE_HOSTNAMES = new Set(['localhost', 'metadata.google.internal'])
 const PRIVATE_HOSTNAME_SUFFIXES = ['.local', '.internal', '.localhost']
 
-const PRIVATE_IPV4_RANGES: Array<[start: string, end: string]> = [
+function ipv4ToInt(ip: string): number {
+  return ip.split('.').reduce((acc, part) => acc * 256 + Number(part), 0)
+}
+
+const PRIVATE_IPV4_RANGES: Array<[start: number, end: number]> = [
   ['127.0.0.0', '127.255.255.255'],
   ['10.0.0.0', '10.255.255.255'],
   ['172.16.0.0', '172.31.255.255'],
   ['192.168.0.0', '192.168.255.255'],
   ['169.254.0.0', '169.254.255.255'],
-]
-
-function ipv4ToInt(ip: string): number {
-  return ip.split('.').reduce((acc, part) => acc * 256 + Number(part), 0)
-}
+].map(([start, end]) => [ipv4ToInt(start), ipv4ToInt(end)])
 
 function isPrivateIpv4(ip: string): boolean {
   const parts = ip.split('.').map(Number)
   if (parts.length !== 4 || parts.some(Number.isNaN))
     return false
   const value = ipv4ToInt(ip)
-  return PRIVATE_IPV4_RANGES.some(([start, end]) => value >= ipv4ToInt(start) && value <= ipv4ToInt(end))
+  return PRIVATE_IPV4_RANGES.some(([start, end]) => value >= start && value <= end)
 }
 
 function isPrivateIpv6(ip: string): boolean {


### PR DESCRIPTION
## What

Fixes the 5 baselined moderate-complexity fallow findings tracked in #854:

- `devices.service.ts` `applyModelChanges` — split into `applyModelChange` and `applyPaletteChange` (firmware handling was already its own method), each with a single responsibility.
- `ssrfGuard.ts` `isPrivateIpv4` — replaced the boolean chain with a table of `[start, end]` IPv4 ranges checked with `.some()`.
- `plugin-data-source-mode.ts` `dataSourceModeViolation` — drives the per-field checks from `[fieldName, isViolation, message]` tuples and `find()`s the first hit, keeping the `method !== 'GET'` special case and its comment as instructed.
- `plugin-data-fetcher.service.ts` `fetchData` — split request building (`resolveUrl`, `buildRequestInit`) from execution/error mapping (`parseResponse`).
- `config.ts` — no refactor (as the issue specified); added `config.spec.ts` covering the defaults and every env-var override, including non-numeric `KUROSHIRO_PORT` → 3000 and `KUROSHIRO_DEMO_MODE`.

`pnpm fallow:baseline` was run in this PR — the 5 findings above are gone from `.fallow-baselines/health.baseline.json` and no new findings were added.

## Why

Fallow flagged these as moderate/critical complexity/CRAP hotspots on 2026-08-22; this closes out the last checkboxes in #854.

## Test plan

- [x] `pnpm lint` — clean (one pre-existing unrelated warning in `generateApikey.spec.ts`)
- [x] `pnpm type-check` — clean
- [x] `pnpm test` — 756 API tests + 285 UI tests pass, plus new coverage: `ssrfGuard.spec.ts` (boundary cases for every private range, including `10.255.255.255`, `172.32.0.0`, `192.169.0.0`) and `config.spec.ts` (defaults, overrides, non-numeric port, demo mode)
- [x] `pnpm fallow:ci` — complexity gate passes (0 functions above threshold vs. baseline)
- [x] Two-axis code review (Standards + Spec) run against the merge-base; the two smells it surfaced (a duplicated tuple type and IP ranges reparsed per call) were fixed in a follow-up commit

Closes #854

> Opened by Kongroo, karakuri's Projects agent — Stage: implement