### PR TITLE
refactor(ui): extract shared apiRequest helper for Pinia stores

### DIFF
--- a/.fallow-baselines/dupes.baseline.json
+++ b/.fallow-baselines/dupes.baseline.json
@@ -1,32 +1,26 @@
 {
   "clone_groups": [
     "packages/api/src/devices/display.service.ts:290-300|packages/api/src/devices/display.service.ts:84-94",
-    "packages/ui/src/stores/deviceModels.ts:60-70|packages/ui/src/stores/firmware.ts:53-63",
     "packages/api/src/plugins/plugins.service.ts:232-243|packages/api/src/plugins/plugins.service.ts:348-359",
     "packages/api/src/devices/display.service.ts:521-533|packages/api/src/mashup/services/mashup-renderer.service.ts:60-71",
     "packages/api/src/devices/display.service.ts:532-540|packages/api/src/mashup/services/mashup-renderer.service.ts:70-78",
-    "packages/ui/src/stores/plugins.ts:18-23|packages/ui/src/stores/plugins.ts:35-40",
     "packages/api/src/plugins/services/plugin-importer.service.ts:253-261|packages/api/src/plugins/services/plugin-importer.service.ts:436-444",
     "packages/api/src/test/fixtures.ts:88-107|packages/api/src/test/mockDeviceModelsService.ts:5-24"
   ],
   "clone_fingerprints": [
     "dup:04d1333c:2",
-    "dup:b3dbc735:2",
     "dup:e767379f:2",
     "dup:0a6a4764:2",
     "dup:3219d03d:2",
-    "dup:a7daa5d0:2",
     "dup:78a90f7a:2",
     "dup:5304ed0c:2"
   ],
   "normalized_clone_fingerprints": [
     "dup:c61b2099:2",
-    "dup:c77b3abb6f87acd9-4:2",
     "dup:c77b3abb6f87acd9-1:2",
-    "dup:c77b3abb6f87acd9-7:2",
-    "dup:c77b3abb6f87acd9-6:2",
-    "dup:c77b3abb6f87acd9-3:2",
     "dup:c77b3abb6f87acd9-5:2",
+    "dup:c77b3abb6f87acd9-4:2",
+    "dup:c77b3abb6f87acd9-3:2",
     "dup:c77b3abb6f87acd9-2:2"
   ]
 }

--- a/.fallow-baselines/health.baseline.json
+++ b/.fallow-baselines/health.baseline.json
@@ -102,7 +102,6 @@
   },
   "runtime_coverage_findings": [],
   "target_keys": [
-    "packages/ui/src/stores/deviceModels.ts:high impact",
     "packages/api/src/devices/display.service.ts:complexity",
     "packages/api/src/plugins/plugins.service.ts:complexity"
   ]

--- a/packages/ui/src/stores/deviceModels.ts
+++ b/packages/ui/src/stores/deviceModels.ts
@@ -2,6 +2,7 @@ import type { DeviceModelSyncResult } from 'kuroshiro-shared'
 import type { DeviceModel, Palette } from '../types'
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
+import { apiRequest } from '../utils/apiRequest'
 
 export const useDeviceModelsStore = defineStore('deviceModels', () => {
   const models = ref<DeviceModel[]>([])
@@ -57,12 +58,7 @@ export const useDeviceModelsStore = defineStore('deviceModels', () => {
     syncing.value = true
     error.value = null
     try {
-      const res = await fetch('/api/device-models/sync', { method: 'POST' })
-      if (!res.ok) {
-        const body = await res.json().catch(() => null)
-        throw new Error(body?.message ?? `Sync failed: ${res.statusText}`)
-      }
-      const result: DeviceModelSyncResult = await res.json()
+      const result = await apiRequest<DeviceModelSyncResult>('/api/device-models/sync', { method: 'POST' }, res => `Sync failed: ${res.statusText}`)
       await fetchAll()
       return result
     }

--- a/packages/ui/src/stores/firmware.ts
+++ b/packages/ui/src/stores/firmware.ts
@@ -2,6 +2,7 @@ import type { FirmwareSyncResult } from 'kuroshiro-shared'
 import type { Firmware } from '../types'
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
+import { apiRequest } from '../utils/apiRequest'
 
 export const useFirmwareStore = defineStore('firmware', () => {
   const firmware = ref<Firmware[]>([])
@@ -50,12 +51,7 @@ export const useFirmwareStore = defineStore('firmware', () => {
     syncing.value = true
     error.value = null
     try {
-      const res = await fetch('/api/firmware/sync', { method: 'POST' })
-      if (!res.ok) {
-        const body = await res.json().catch(() => null)
-        throw new Error(body?.message ?? `Sync failed: ${res.statusText}`)
-      }
-      const result: FirmwareSyncResult = await res.json()
+      const result = await apiRequest<FirmwareSyncResult>('/api/firmware/sync', { method: 'POST' }, res => `Sync failed: ${res.statusText}`)
       await fetchAll()
       return result
     }

--- a/packages/ui/src/stores/plugins.ts
+++ b/packages/ui/src/stores/plugins.ts
@@ -1,6 +1,11 @@
 import type { CreatePluginPayload, Plugin } from '@/types/plugin'
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
+import { apiRequest } from '../utils/apiRequest'
+
+// The create/update endpoints echo back the device the plugin was assigned to,
+// which is not part of the client-side `Plugin` shape.
+type PluginWithDevice = Plugin & { device?: { id: string } }
 
 export const usePluginsStore = defineStore('plugins', () => {
   const plugins = ref<Plugin[]>([])
@@ -13,16 +18,11 @@ export const usePluginsStore = defineStore('plugins', () => {
   }
 
   const createPlugin = async (pluginData: CreatePluginPayload) => {
-    const res = await fetch('/api/plugins', {
+    const newPlugin = await apiRequest<PluginWithDevice>('/api/plugins', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(pluginData),
-    })
-    if (!res.ok) {
-      const errorData = await res.json().catch(() => ({}))
-      throw new Error(errorData.message || 'Failed to create plugin')
-    }
-    const newPlugin = await res.json()
+    }, 'Failed to create plugin')
     if (newPlugin.device?.id) {
       await fetchPluginsForDevice(newPlugin.device.id)
     }
@@ -30,16 +30,11 @@ export const usePluginsStore = defineStore('plugins', () => {
   }
 
   const updatePlugin = async (id: string, pluginData: Partial<CreatePluginPayload>) => {
-    const res = await fetch(`/api/plugins/${id}`, {
+    const updatedPlugin = await apiRequest<PluginWithDevice>(`/api/plugins/${id}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(pluginData),
-    })
-    if (!res.ok) {
-      const errorData = await res.json().catch(() => ({}))
-      throw new Error(errorData.message || 'Failed to update plugin')
-    }
-    const updatedPlugin = await res.json()
+    }, 'Failed to update plugin')
     if (updatedPlugin.device?.id) {
       await fetchPluginsForDevice(updatedPlugin.device.id)
     }

--- a/packages/ui/src/utils/__test__/apiRequest.spec.ts
+++ b/packages/ui/src/utils/__test__/apiRequest.spec.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import { jsonResponse, stubFetch } from '../../test/fetch'
+import { apiRequest } from '../apiRequest'
+
+describe('apiRequest', () => {
+  it('returns the parsed JSON body on success', async () => {
+    const mockFetch = stubFetch()
+    mockFetch.mockResolvedValue(jsonResponse({ id: 'plugin-1' }))
+
+    await expect(apiRequest('/api/plugins', undefined, 'Failed to create plugin')).resolves.toEqual({ id: 'plugin-1' })
+    expect(mockFetch).toHaveBeenCalledWith('/api/plugins', undefined)
+  })
+
+  it('passes the request init through to fetch', async () => {
+    const mockFetch = stubFetch()
+    mockFetch.mockResolvedValue(jsonResponse({ ok: true }))
+
+    await apiRequest('/api/plugins', { method: 'POST', body: '{}' }, 'Failed to create plugin')
+
+    expect(mockFetch).toHaveBeenCalledWith('/api/plugins', { method: 'POST', body: '{}' })
+  })
+
+  it('throws the server message from the error body', async () => {
+    const mockFetch = stubFetch()
+    mockFetch.mockResolvedValue(jsonResponse({ message: 'Data source name "trmnl" is reserved' }, false))
+
+    await expect(apiRequest('/api/plugins', undefined, 'Failed to create plugin'))
+      .rejects
+      .toThrow('Data source name "trmnl" is reserved')
+  })
+
+  it('falls back to the given message when the error body has no message', async () => {
+    const mockFetch = stubFetch()
+    mockFetch.mockResolvedValue(jsonResponse({}, false))
+
+    await expect(apiRequest('/api/plugins', undefined, 'Failed to create plugin'))
+      .rejects
+      .toThrow('Failed to create plugin')
+  })
+
+  it('falls back to the given message when the error body carries an empty message', async () => {
+    const mockFetch = stubFetch()
+    mockFetch.mockResolvedValue(jsonResponse({ message: '' }, false))
+
+    await expect(apiRequest('/api/plugins', undefined, 'Failed to create plugin'))
+      .rejects
+      .toThrow('Failed to create plugin')
+  })
+
+  it('falls back to the given message when the error body is not JSON', async () => {
+    const mockFetch = stubFetch()
+    mockFetch.mockResolvedValue(new Response('not json', { status: 500, statusText: 'Server Error' }))
+
+    await expect(apiRequest('/api/plugins', undefined, 'Failed to create plugin'))
+      .rejects
+      .toThrow('Failed to create plugin')
+  })
+
+  it('computes the fallback message from the response when given a function', async () => {
+    const mockFetch = stubFetch()
+    mockFetch.mockResolvedValue(jsonResponse({}, { ok: false, statusText: 'Service Unavailable' }))
+
+    await expect(apiRequest('/api/device-models/sync', { method: 'POST' }, res => `Sync failed: ${res.statusText}`))
+      .rejects
+      .toThrow('Sync failed: Service Unavailable')
+  })
+})

--- a/packages/ui/src/utils/apiRequest.ts
+++ b/packages/ui/src/utils/apiRequest.ts
@@ -1,0 +1,10 @@
+type Fallback = string | ((res: Response) => string)
+
+export async function apiRequest<T>(input: RequestInfo, init: RequestInit | undefined, fallback: Fallback): Promise<T> {
+  const res = await fetch(input, init)
+  if (!res.ok) {
+    const body = await res.json().catch(() => null)
+    throw new Error(body?.message || (typeof fallback === 'function' ? fallback(res) : fallback))
+  }
+  return res.json()
+}


### PR DESCRIPTION
## What / why

`pnpm fallow` flagged copy-pasted `fetch` plumbing across the Pinia stores. The same
`if (!res.ok) { const body = await res.json().catch(...); throw new Error(body?.message ?? fallback) }`
shape appeared in the `sync` actions of `deviceModels.ts` and `firmware.ts`, and in
`plugins.ts`'s `createPlugin` / `updatePlugin`.

This adds `packages/ui/src/utils/apiRequest.ts`: a small functional helper (no class, no side
effects) that performs the `fetch`, throws an `Error` carrying the API's `message` on a non-ok
response, and returns the parsed JSON typed through a generic `<T>`.

The fallback is `string | ((res: Response) => string)` — the function form exists because the two
sync call sites build their message from `res.statusText`, so they can keep their exact wording.

## Locations updated

1. `packages/ui/src/stores/deviceModels.ts` — `sync()` (was 59-69)
2. `packages/ui/src/stores/firmware.ts` — `sync()` (was 52-62)
3. `packages/ui/src/stores/plugins.ts` — `createPlugin()` (was 18-23)
4. `packages/ui/src/stores/plugins.ts` — `updatePlugin()` (was 35-40)

All four user-facing fallback strings are unchanged: `Sync failed: ${res.statusText}` (×2),
`Failed to create plugin`, `Failed to update plugin`.

Two notes on preserving behaviour exactly:

- The helper uses `body?.message || fallback` rather than `??`. `plugins.ts` originally used `||`,
  and truthiness also matches the existing `utils/errorMessage.ts` convention — so an API that
  returns `message: ""` still surfaces the useful fallback instead of a blank `Error("")`.
- `createPlugin` / `updatePlugin` read `.device?.id` off the response, which is not part of the
  client-side `Plugin` type, so they are typed through a local `PluginWithDevice` alias rather than
  loosening the shared type.

## Test evidence

- New unit tests in `packages/ui/src/utils/__test__/apiRequest.spec.ts` (6 cases): success, init
  pass-through, server-supplied message, missing message, empty message, non-JSON error body, and
  the function-fallback form.
- `pnpm lint` — exit 0
- `pnpm type-check` — exit 0
- UI suite: 54 files, 292 tests, all passing. The existing `deviceModels` / `firmware` / `plugins`
  store specs pass unchanged.
- `pnpm fallow:baseline` re-run in this PR: both flagged dupe pairs
  (`deviceModels.ts:60-70|firmware.ts:53-63` and `plugins.ts:18-23|35-40`) are gone from
  `.fallow-baselines/dupes.baseline.json`, plus the corresponding `health` target key. The baseline
  diff is removals only — no new findings were added.
- `pnpm fallow:ci` — exit 0 (`✓ No issues found`, `✓ No code duplication found`).

Note: `packages/api`'s two `plugin-renderer.service.spec.ts` date tests (`date_short`, `date_long`)
fail on a non-UTC local clock on `main` as well, unrelated to this change; they pass in CI.

Closes #844
