### PR TITLE
refactor(api): split DisplayService and share plugin data-source fetch with MashupRendererService

### DIFF
--- a/.fallow-baselines/dupes.baseline.json
+++ b/.fallow-baselines/dupes.baseline.json
@@ -1,25 +1,16 @@
 {
   "clone_groups": [
-    "packages/api/src/devices/display.service.ts:290-300|packages/api/src/devices/display.service.ts:84-94",
     "packages/api/src/plugins/plugins.service.ts:232-243|packages/api/src/plugins/plugins.service.ts:348-359",
-    "packages/api/src/devices/display.service.ts:521-533|packages/api/src/mashup/services/mashup-renderer.service.ts:60-71",
-    "packages/api/src/devices/display.service.ts:532-540|packages/api/src/mashup/services/mashup-renderer.service.ts:70-78",
     "packages/api/src/plugins/services/plugin-importer.service.ts:253-261|packages/api/src/plugins/services/plugin-importer.service.ts:436-444",
     "packages/api/src/test/fixtures.ts:88-107|packages/api/src/test/mockDeviceModelsService.ts:5-24"
   ],
   "clone_fingerprints": [
-    "dup:04d1333c:2",
     "dup:e767379f:2",
-    "dup:0a6a4764:2",
-    "dup:3219d03d:2",
     "dup:78a90f7a:2",
     "dup:5304ed0c:2"
   ],
   "normalized_clone_fingerprints": [
-    "dup:c61b2099:2",
     "dup:c77b3abb6f87acd9-1:2",
-    "dup:c77b3abb6f87acd9-5:2",
-    "dup:c77b3abb6f87acd9-4:2",
     "dup:c77b3abb6f87acd9-3:2",
     "dup:c77b3abb6f87acd9-2:2"
   ]

--- a/.fallow-baselines/health.baseline.json
+++ b/.fallow-baselines/health.baseline.json
@@ -11,16 +11,7 @@
       }
     },
     "packages/api/src/devices/display.service.ts": {
-      "complexity_critical": {
-        "count": 2
-      },
-      "complexity_high": {
-        "count": 1
-      },
-      "crap_critical": {
-        "count": 2
-      },
-      "crap_high": {
+      "crap_moderate": {
         "count": 1
       }
     },
@@ -102,7 +93,6 @@
   },
   "runtime_coverage_findings": [],
   "target_keys": [
-    "packages/api/src/devices/display.service.ts:complexity",
     "packages/api/src/plugins/plugins.service.ts:complexity"
   ]
 }

--- a/packages/api/src/devices/__test__/display.service.spec.ts
+++ b/packages/api/src/devices/__test__/display.service.spec.ts
@@ -4,9 +4,8 @@ import type { FallbackScreensService } from '../../device-models/fallback-screen
 import type { MockDeviceSensorsService } from '../../device-sensors/__test__/mockDeviceSensorsService'
 import type { DeviceSensorsService } from '../../device-sensors/device-sensors.service'
 import type { FirmwareService } from '../../firmware/firmware.service'
-import type { PluginDataFetcherService } from '../../plugins/services/plugin-data-fetcher.service'
+import type { PluginDataResolverService } from '../../plugins/services/plugin-data-resolver.service'
 import type { PluginRendererService } from '../../plugins/services/plugin-renderer.service'
-import type { PluginTransformService } from '../../plugins/services/plugin-transform.service'
 import type { Schedule } from '../../schedule/schedule.entity'
 import type { Screen } from '../../screens/screens.entity'
 import type { MockDeviceModelsService, MockFallbackScreensService } from '../../test/mockDeviceModelsService'
@@ -92,9 +91,8 @@ describe('deviceDisplayService', () => {
       asService<DeviceModelsService>(deviceModels),
       asService<FallbackScreensService>(fallbackScreens),
       asService<FirmwareService>(firmwareService),
-      asService<PluginDataFetcherService>({}),
+      asService<PluginDataResolverService>({}),
       asService<PluginRendererService>({}),
-      asService<PluginTransformService>({}),
       asService<DeviceSensorsService>(deviceSensors),
       new PluginTemplateContextService(),
     )
@@ -242,7 +240,7 @@ describe('deviceDisplayService', () => {
         templates: [makePluginTemplate({ layout: 'full', liquidMarkup: '{{ v }}' })],
       })
       primeRotation({ id: 'screen2', type: 'plugin', order: 2, plugin, filename: 'x' }, device)
-      injectPrivate(service, 'pluginDataFetcher', { fetchOrLiteral: vi.fn().mockResolvedValue({ v: 1 }) })
+      injectPrivate(service, 'pluginDataResolver', { resolveDataSources: vi.fn().mockResolvedValue({ source: { v: 1 } }) })
       injectPrivate(service, 'pluginRenderer', { render: vi.fn().mockResolvedValue('<b>1</b>') })
 
       await service.getCurrentImage(headers)
@@ -831,9 +829,8 @@ describe('deviceDisplayService', () => {
 
   describe('mashup screen rendering', () => {
     beforeEach(() => {
-      injectPrivate(service, 'pluginDataFetcher', { fetchOrLiteral: vi.fn() })
+      injectPrivate(service, 'pluginDataResolver', { resolveDataSources: vi.fn() })
       injectPrivate(service, 'pluginRenderer', { render: vi.fn() })
-      injectPrivate(service, 'pluginTransformer', { transform: vi.fn() })
     })
 
     it('should detect mashup screen and call renderer', async () => {

--- a/packages/api/src/devices/display.service.ts
+++ b/packages/api/src/devices/display.service.ts
@@ -28,6 +28,17 @@ import { Display } from './display'
 import { DisplayScreen } from './displayScreen'
 import { isDeviceAsleep, secondsUntilSleepEnd } from './sleep-mode'
 
+// The fields getCurrentImage's response builders need out of applyHeaderReport,
+// bundled into one object rather than passed positionally — several of them
+// share a type (two booleans, two strings) and a transposed pair would compile
+// cleanly while silently flipping real-device behavior.
+export interface HeaderReport {
+  resetDevice: boolean
+  specialFunction: string
+  firmwareUrl: string
+  updateFirmware: boolean
+}
+
 export interface TrmnlScreenResponse {
   action?: string
   filename: string
@@ -81,11 +92,11 @@ export class DeviceDisplayService {
     this.logger.log(`Display request for MAC: ${headers.id}`)
     this.logger.debug(`Headers: ${JSON.stringify(headers)}`)
     const device = await this.authenticateDevice(headers)
-    const { resetDevice, specialFunction, firmwareUrl, updateFirmware } = await this.applyHeaderReport(device, headers)
+    const report = await this.applyHeaderReport(device, headers)
 
     return device.mirrorEnabled
-      ? this.buildMirrorResponse(device, headers, specialFunction, resetDevice)
-      : this.buildRotationResponse(device, specialFunction, firmwareUrl, resetDevice, updateFirmware)
+      ? this.buildMirrorResponse(device, headers, report)
+      : this.buildRotationResponse(device, report)
   }
 
   /**
@@ -114,7 +125,7 @@ export class DeviceDisplayService {
    * single save. Returns the fields the response builders need, since the
    * Device itself has already moved on (its one-shot flags are cleared).
    */
-  private async applyHeaderReport(device: Device, headers: DisplayRequestHeadersDto): Promise<{ resetDevice: boolean, specialFunction: string, firmwareUrl: string, updateFirmware: boolean }> {
+  private async applyHeaderReport(device: Device, headers: DisplayRequestHeadersDto): Promise<HeaderReport> {
     this.logger.log(`Updating device info for MAC: ${headers.id}`)
     device.batteryVoltage = headers['battery-voltage']
     device.fwVersion = headers['fw-version']
@@ -144,11 +155,11 @@ export class DeviceDisplayService {
    * otherwise advances to the next eligible Screen (or the no-screen
    * fallback) and generates its image.
    */
-  private async buildRotationResponse(device: Device, specialFunction: string, firmwareUrl: string, resetDevice: boolean, updateFirmware: boolean): Promise<Display> {
+  private async buildRotationResponse(device: Device, report: HeaderReport): Promise<Display> {
     const now = new Date()
     if (isDeviceAsleep(device, now)) {
       this.logger.log(`Device ${device.id} is asleep. Holding rotation.`)
-      return this.buildSleepResponse(device, now, specialFunction, firmwareUrl, resetDevice, updateFirmware)
+      return this.buildSleepResponse(device, now, report)
     }
     this.logger.log(`Device ${device.id} is not mirrored. Cycling screens.`)
     const screens = await this.screenRepository.find({
@@ -162,15 +173,15 @@ export class DeviceDisplayService {
     if (!nextScreen) {
       this.logger.log(`No eligible screen for device ${device.id} returning default no screen image`)
       return new Display({
-        action: specialFunction,
+        action: report.specialFunction,
         filename: 'noScreen.png',
-        firmware_url: firmwareUrl,
+        firmware_url: report.firmwareUrl,
         image_url: await this.fallbackImageUrl('noScreen', device),
         refresh_rate: device.refreshRate,
-        reset_firmware: resetDevice,
-        special_function: specialFunction,
+        reset_firmware: report.resetDevice,
+        special_function: report.specialFunction,
         temperature_profile: 'default',
-        update_firmware: updateFirmware,
+        update_firmware: report.updateFirmware,
       })
     }
     nextScreen.isActive = true
@@ -180,15 +191,15 @@ export class DeviceDisplayService {
     const imgUrl = await this.generateScreenImage(nextScreen, device)
 
     return new Display({
-      action: specialFunction,
+      action: report.specialFunction,
       filename: `${nextScreen.filename}_${nextScreen.generatedAt.toISOString()}`,
-      firmware_url: firmwareUrl,
+      firmware_url: report.firmwareUrl,
       image_url: imgUrl,
       refresh_rate: device.refreshRate,
-      reset_firmware: resetDevice,
-      special_function: specialFunction,
+      reset_firmware: report.resetDevice,
+      special_function: report.specialFunction,
       temperature_profile: 'default',
-      update_firmware: updateFirmware,
+      update_firmware: report.updateFirmware,
     })
   }
 
@@ -197,7 +208,7 @@ export class DeviceDisplayService {
    * (matching MACs), otherwise mirrors another Device's `current_screen` and
    * keeps this Device's own reset/special-function/firmware fields as-is.
    */
-  private async buildMirrorResponse(device: Device, headers: DisplayRequestHeadersDto, specialFunction: string, resetDevice: boolean): Promise<Display> {
+  private async buildMirrorResponse(device: Device, headers: DisplayRequestHeadersDto, report: Pick<HeaderReport, 'resetDevice' | 'specialFunction'>): Promise<Display> {
     this.logger.log(`Device ${device.id} is mirrored. Fetching from TRMNL.`)
     let proxy = false
     if (device.mac === device.mirrorMac) {
@@ -211,9 +222,9 @@ export class DeviceDisplayService {
     let filename = 'error.png'
     let localImageUrl = await this.fallbackImageUrl('error', device)
     let firmwareUrl: string | null = null
-    let resetFirmware = resetDevice
-    let mirrorSpecialFunction = specialFunction
-    let mirrorAction = specialFunction
+    let resetFirmware = report.resetDevice
+    let mirrorSpecialFunction = report.specialFunction
+    let mirrorAction = report.specialFunction
     let updateFirmware = false
     try {
       const { response, localImageUrl: localImage } = await this.fetchAndStoreMirrorImage(device, proxy ? headers : undefined)
@@ -291,21 +302,21 @@ export class DeviceDisplayService {
    * exactly on schedule, and the served image is either the dedicated Sleep
    * fallback screen or whatever was already showing.
    */
-  private async buildSleepResponse(device: Device, now: Date, specialFunction: string, firmwareUrl: string, resetDevice: boolean, updateFirmware: boolean): Promise<Display> {
+  private async buildSleepResponse(device: Device, now: Date, report: HeaderReport): Promise<Display> {
     const refreshRate = secondsUntilSleepEnd(device.sleepEndTime!, now)
     const { filename, imgUrl } = device.sleepScreenEnabled
       ? { filename: 'sleep.png', imgUrl: await this.fallbackImageUrl('sleep', device) }
       : await this.resolveFrozenImage(device)
     return new Display({
-      action: specialFunction,
+      action: report.specialFunction,
       filename,
-      firmware_url: firmwareUrl,
+      firmware_url: report.firmwareUrl,
       image_url: imgUrl,
       refresh_rate: refreshRate,
-      reset_firmware: resetDevice,
-      special_function: specialFunction,
+      reset_firmware: report.resetDevice,
+      special_function: report.specialFunction,
       temperature_profile: 'default',
-      update_firmware: updateFirmware,
+      update_firmware: report.updateFirmware,
     })
   }
 

--- a/packages/api/src/devices/display.service.ts
+++ b/packages/api/src/devices/display.service.ts
@@ -375,6 +375,7 @@ export class DeviceDisplayService {
   }
 
   private async resolveMirrorScreen(device: Device): Promise<{ filename: string, imgUrl: string, renderedAt: undefined }> {
+    const filename = `mirror_${new Date().toISOString()}`
     this.logger.log(`Mirroring enabled for device ${device.id}, checking for image...`)
     let imgUrl = await this.fallbackImageUrl('error', device)
     if (await fileExists(resolveAppPath('public', 'screens', 'devices', device.id, 'mirror.png'))) {
@@ -392,7 +393,7 @@ export class DeviceDisplayService {
         this.logger.error(`Failed to fetch mirror image on demand: ${message}`)
       }
     }
-    return { filename: `mirror_${new Date().toISOString()}`, imgUrl, renderedAt: undefined }
+    return { filename, imgUrl, renderedAt: undefined }
   }
 
   private async resolveActiveScreenImage(device: Device, activeScreen: Screen | null): Promise<{ filename: string, imgUrl: string, renderedAt: Date }> {

--- a/packages/api/src/devices/display.service.ts
+++ b/packages/api/src/devices/display.service.ts
@@ -13,10 +13,9 @@ import { FallbackScreensService } from '../device-models/fallback-screens.servic
 import { renderHtmlToPng } from '../device-models/render-html-to-png'
 import { DeviceSensorsService } from '../device-sensors/device-sensors.service'
 import { FirmwareService } from '../firmware/firmware.service'
-import { PluginDataFetcherService } from '../plugins/services/plugin-data-fetcher.service'
+import { PluginDataResolverService } from '../plugins/services/plugin-data-resolver.service'
 import { PluginRendererService } from '../plugins/services/plugin-renderer.service'
 import { PluginTemplateContextService } from '../plugins/services/plugin-template-context.service'
-import { PluginTransformService } from '../plugins/services/plugin-transform.service'
 import { isScheduleEligible } from '../schedule/schedule-eligibility'
 import { Screen } from '../screens/screens.entity'
 import { fileExists } from '../utils/fileExists'
@@ -54,9 +53,8 @@ export class DeviceDisplayService {
     private deviceModels: DeviceModelsService,
     private fallbackScreens: FallbackScreensService,
     private firmwareService: FirmwareService,
-    private pluginDataFetcher: PluginDataFetcherService,
+    private pluginDataResolver: PluginDataResolverService,
     private pluginRenderer: PluginRendererService,
-    private pluginTransformer: PluginTransformService,
     private deviceSensors: DeviceSensorsService,
     private pluginTemplateContext: PluginTemplateContextService,
   ) {
@@ -66,9 +64,8 @@ export class DeviceDisplayService {
         const { MashupRendererService } = await import('../mashup/services/mashup-renderer.service.js')
         // Get it from the module (this is a workaround for circular deps)
         this.mashupRenderer = new MashupRendererService(
-          this.pluginDataFetcher,
+          this.pluginDataResolver,
           this.pluginRenderer,
-          this.pluginTransformer,
           this.configService,
           this.deviceSensors,
           this.pluginTemplateContext,
@@ -83,6 +80,21 @@ export class DeviceDisplayService {
   async getCurrentImage(headers: DisplayRequestHeadersDto): Promise<Display> {
     this.logger.log(`Display request for MAC: ${headers.id}`)
     this.logger.debug(`Headers: ${JSON.stringify(headers)}`)
+    const device = await this.authenticateDevice(headers)
+    const { resetDevice, specialFunction, firmwareUrl, updateFirmware } = await this.applyHeaderReport(device, headers)
+
+    return device.mirrorEnabled
+      ? this.buildMirrorResponse(device, headers, specialFunction, resetDevice)
+      : this.buildRotationResponse(device, specialFunction, firmwareUrl, resetDevice, updateFirmware)
+  }
+
+  /**
+   * Looks up a Device by the MAC in `headers.id` and checks its API key —
+   * the entry check shared by both poll endpoints (`getCurrentImage` and
+   * `getCurrentImageWithoutProgressing`), each of which only needs a
+   * different subset of `DisplayRequestHeadersDto`.
+   */
+  private async authenticateDevice(headers: Pick<DisplayRequestHeadersDto, 'id' | 'access-token'>): Promise<Device> {
     const device = await this.deviceRepository.findOneBy({ mac: headers.id })
     if (!device) {
       this.logger.warn(`Device not found: ${headers.id}`)
@@ -92,6 +104,17 @@ export class DeviceDisplayService {
       this.logger.warn(`Invalid API key for device: ${headers.id}`)
       throw new UnauthorizedException('Invalid API key')
     }
+    return device
+  }
+
+  /**
+   * Records a polling Device's self-reported state (dimensions, firmware
+   * version, sensors, …), acknowledges any one-shot reset/special-function
+   * flags, and resolves a pending OTA push — then persists all of it in a
+   * single save. Returns the fields the response builders need, since the
+   * Device itself has already moved on (its one-shot flags are cleared).
+   */
+  private async applyHeaderReport(device: Device, headers: DisplayRequestHeadersDto): Promise<{ resetDevice: boolean, specialFunction: string, firmwareUrl: string, updateFirmware: boolean }> {
     this.logger.log(`Updating device info for MAC: ${headers.id}`)
     device.batteryVoltage = headers['battery-voltage']
     device.fwVersion = headers['fw-version']
@@ -109,104 +132,119 @@ export class DeviceDisplayService {
     // A Special Function fires once: this response acknowledges it, the next poll gets 'none'
     const specialFunction = device.specialFunction ?? 'none'
     device.specialFunction = 'none'
-    const { firmwareUrl: pushedFirmwareUrl, updateFirmware: pushedUpdateFirmware } = await this.resolveFirmwarePush(device)
+    const { firmwareUrl, updateFirmware } = await this.resolveFirmwarePush(device)
     device.lastSeen = new Date()
     await this.deviceRepository.save(device)
     this.logger.log(`Device info updated for MAC: ${headers.id}`)
-    if (!device.mirrorEnabled) {
-      const now = new Date()
-      if (isDeviceAsleep(device, now)) {
-        this.logger.log(`Device ${device.id} is asleep. Holding rotation.`)
-        return this.buildSleepResponse(device, now, specialFunction, pushedFirmwareUrl, resetDevice, pushedUpdateFirmware)
-      }
-      this.logger.log(`Device ${device.id} is not mirrored. Cycling screens.`)
-      const screens = await this.screenRepository.find({
-        where: { device: { id: device.id } },
-        relations: { schedule: true },
-        order: { order: 'ASC' },
-      })
-      const nextScreen = this.nextEligibleScreen(screens, new Date())
-      if (screens.length > 0)
-        await this.screenRepository.update({ device: { id: device.id } }, { isActive: false })
-      if (!nextScreen) {
-        this.logger.log(`No eligible screen for device ${device.id} returning default no screen image`)
-        return new Display({
-          action: specialFunction,
-          filename: 'noScreen.png',
-          firmware_url: pushedFirmwareUrl,
-          image_url: await this.fallbackImageUrl('noScreen', device),
-          refresh_rate: device.refreshRate,
-          reset_firmware: resetDevice,
-          special_function: specialFunction,
-          temperature_profile: 'default',
-          update_firmware: pushedUpdateFirmware,
-        })
-      }
-      nextScreen.isActive = true
-      await this.screenRepository.save(nextScreen)
-      this.logger.log(`Returning screen ${nextScreen.id} for device ${device.id}`)
+    return { resetDevice, specialFunction, firmwareUrl, updateFirmware }
+  }
 
-      const imgUrl = await this.generateScreenImage(nextScreen, device)
-
+  /**
+   * The non-mirrored path: holds the rotation while the Device sleeps,
+   * otherwise advances to the next eligible Screen (or the no-screen
+   * fallback) and generates its image.
+   */
+  private async buildRotationResponse(device: Device, specialFunction: string, firmwareUrl: string, resetDevice: boolean, updateFirmware: boolean): Promise<Display> {
+    const now = new Date()
+    if (isDeviceAsleep(device, now)) {
+      this.logger.log(`Device ${device.id} is asleep. Holding rotation.`)
+      return this.buildSleepResponse(device, now, specialFunction, firmwareUrl, resetDevice, updateFirmware)
+    }
+    this.logger.log(`Device ${device.id} is not mirrored. Cycling screens.`)
+    const screens = await this.screenRepository.find({
+      where: { device: { id: device.id } },
+      relations: { schedule: true },
+      order: { order: 'ASC' },
+    })
+    const nextScreen = this.nextEligibleScreen(screens, new Date())
+    if (screens.length > 0)
+      await this.screenRepository.update({ device: { id: device.id } }, { isActive: false })
+    if (!nextScreen) {
+      this.logger.log(`No eligible screen for device ${device.id} returning default no screen image`)
       return new Display({
         action: specialFunction,
-        filename: `${nextScreen.filename}_${nextScreen.generatedAt.toISOString()}`,
-        firmware_url: pushedFirmwareUrl,
-        image_url: imgUrl,
+        filename: 'noScreen.png',
+        firmware_url: firmwareUrl,
+        image_url: await this.fallbackImageUrl('noScreen', device),
         refresh_rate: device.refreshRate,
         reset_firmware: resetDevice,
         special_function: specialFunction,
         temperature_profile: 'default',
-        update_firmware: pushedUpdateFirmware,
-      })
-    }
-    else {
-      this.logger.log(`Device ${device.id} is mirrored. Fetching from TRMNL.`)
-      let proxy = false
-      if (device.mac === device.mirrorMac) {
-        this.logger.log(`MACs are identical we should proxy the device.`)
-        proxy = true
-      }
-      else {
-        this.logger.log(`MACs are different we should mirror with current_screen endpoint.`)
-      }
-      let refreshRate = device.refreshRate
-      let filename = 'error.png'
-      let localImageUrl = await this.fallbackImageUrl('error', device)
-      let firmwareUrl: string | null = null
-      let resetFirmware = resetDevice
-      let mirrorSpecialFunction = specialFunction
-      let mirrorAction = specialFunction
-      let updateFirmware = false
-      try {
-        const { response, localImageUrl: localImage } = await this.fetchAndStoreMirrorImage(device, proxy ? headers : undefined)
-
-        refreshRate = proxy ? (response.refresh_rate ?? refreshRate) : refreshRate
-        firmwareUrl = proxy ? (response.firmware_url ?? firmwareUrl) : firmwareUrl
-        resetFirmware = proxy ? (response.reset_firmware ?? resetFirmware) : resetFirmware
-        mirrorSpecialFunction = proxy ? (response.special_function ?? 'none') : mirrorSpecialFunction
-        mirrorAction = proxy ? (response.action ?? mirrorSpecialFunction) : mirrorAction
-        updateFirmware = proxy ? (response.update_firmware ?? updateFirmware) : updateFirmware
-        localImageUrl = localImage
-        filename = response.filename
-      }
-      catch (err) {
-        const message = getErrorMessage(err)
-        this.logger.error(`Failed to process image: ${message}`)
-      }
-      this.logger.log(`Returning mirrored screen for device ${device.id}`)
-      return new Display({
-        action: mirrorAction,
-        filename,
-        firmware_url: firmwareUrl,
-        image_url: localImageUrl,
-        refresh_rate: refreshRate,
-        reset_firmware: resetFirmware,
-        special_function: mirrorSpecialFunction,
-        temperature_profile: 'default',
         update_firmware: updateFirmware,
       })
     }
+    nextScreen.isActive = true
+    await this.screenRepository.save(nextScreen)
+    this.logger.log(`Returning screen ${nextScreen.id} for device ${device.id}`)
+
+    const imgUrl = await this.generateScreenImage(nextScreen, device)
+
+    return new Display({
+      action: specialFunction,
+      filename: `${nextScreen.filename}_${nextScreen.generatedAt.toISOString()}`,
+      firmware_url: firmwareUrl,
+      image_url: imgUrl,
+      refresh_rate: device.refreshRate,
+      reset_firmware: resetDevice,
+      special_function: specialFunction,
+      temperature_profile: 'default',
+      update_firmware: updateFirmware,
+    })
+  }
+
+  /**
+   * The mirrored path: proxies TRMNL's own response when mirroring itself
+   * (matching MACs), otherwise mirrors another Device's `current_screen` and
+   * keeps this Device's own reset/special-function/firmware fields as-is.
+   */
+  private async buildMirrorResponse(device: Device, headers: DisplayRequestHeadersDto, specialFunction: string, resetDevice: boolean): Promise<Display> {
+    this.logger.log(`Device ${device.id} is mirrored. Fetching from TRMNL.`)
+    let proxy = false
+    if (device.mac === device.mirrorMac) {
+      this.logger.log(`MACs are identical we should proxy the device.`)
+      proxy = true
+    }
+    else {
+      this.logger.log(`MACs are different we should mirror with current_screen endpoint.`)
+    }
+    let refreshRate = device.refreshRate
+    let filename = 'error.png'
+    let localImageUrl = await this.fallbackImageUrl('error', device)
+    let firmwareUrl: string | null = null
+    let resetFirmware = resetDevice
+    let mirrorSpecialFunction = specialFunction
+    let mirrorAction = specialFunction
+    let updateFirmware = false
+    try {
+      const { response, localImageUrl: localImage } = await this.fetchAndStoreMirrorImage(device, proxy ? headers : undefined)
+
+      if (proxy) {
+        refreshRate = response.refresh_rate ?? refreshRate
+        firmwareUrl = response.firmware_url ?? firmwareUrl
+        resetFirmware = response.reset_firmware ?? resetFirmware
+        mirrorSpecialFunction = response.special_function ?? 'none'
+        mirrorAction = response.action ?? mirrorSpecialFunction
+        updateFirmware = response.update_firmware ?? updateFirmware
+      }
+      localImageUrl = localImage
+      filename = response.filename
+    }
+    catch (err) {
+      const message = getErrorMessage(err)
+      this.logger.error(`Failed to process image: ${message}`)
+    }
+    this.logger.log(`Returning mirrored screen for device ${device.id}`)
+    return new Display({
+      action: mirrorAction,
+      filename,
+      firmware_url: firmwareUrl,
+      image_url: localImageUrl,
+      refresh_rate: refreshRate,
+      reset_firmware: resetFirmware,
+      special_function: mirrorSpecialFunction,
+      temperature_profile: 'default',
+      update_firmware: updateFirmware,
+    })
   }
 
   /**
@@ -289,15 +327,7 @@ export class DeviceDisplayService {
   async getCurrentImageWithoutProgressing(headers: Pick<DisplayRequestHeadersDto, 'id' | 'access-token'>): Promise<DisplayScreen> {
     this.logger.log(`Current Screen request for MAC: ${headers.id}`)
     this.logger.debug(`Headers: ${JSON.stringify(headers)}`)
-    const device = await this.deviceRepository.findOneBy({ mac: headers.id })
-    if (!device) {
-      this.logger.warn(`Device not found: ${headers.id}`)
-      throw new NotFoundException('Device not found')
-    }
-    if (device.apikey !== headers['access-token']) {
-      this.logger.warn(`Invalid API key for device: ${headers.id}`)
-      throw new UnauthorizedException('Invalid API key')
-    }
+    const device = await this.authenticateDevice(headers)
     const now = new Date()
     const asleep = !device.mirrorEnabled && isDeviceAsleep(device, now)
     const refreshRate = asleep ? secondsUntilSleepEnd(device.sleepEndTime!, now) : device.refreshRate
@@ -322,49 +352,51 @@ export class DeviceDisplayService {
         rendered_at: new Date(),
       })
     }
-    let imgUrl = await this.fallbackImageUrl('error', device)
-    let filename: string
-    let renderedAt: Date | undefined
-    if (device.mirrorEnabled) {
-      filename = `mirror_${new Date().toISOString()}`
-      renderedAt = undefined
-      this.logger.log(`Mirroring enabled for device ${device.id}, checking for image...`)
-      if (await fileExists(resolveAppPath('public', 'screens', 'devices', device.id, 'mirror.png'))) {
-        this.logger.log(`Image found returning`)
-        imgUrl = `${this.configService.get<string>('api_url')}/screens/devices/${device.id}/mirror.png`
-      }
-      else {
-        this.logger.log(`Mirror image missing on disk, fetching from TRMNL on demand`)
-        try {
-          const { localImageUrl } = await this.fetchAndStoreMirrorImage(device)
-          imgUrl = localImageUrl
-        }
-        catch (err) {
-          const message = getErrorMessage(err)
-          this.logger.error(`Failed to fetch mirror image on demand: ${message}`)
-        }
-      }
-    }
-    else {
-      if (!activeScreen)
-        throw new NotFoundException('No active screen found for device')
-      this.logger.log(`Returning screen ${activeScreen.id} for device ${device.id}`)
-      if (await fileExists(this.screenImagePath(device, activeScreen))) {
-        imgUrl = this.screenImageUrl(device, activeScreen)
-      }
-      else {
-        this.logger.log(`Screen image for ${activeScreen.id} missing on disk, generating on demand`)
-        imgUrl = await this.generateScreenImage(activeScreen, device)
-      }
-      filename = `${activeScreen.filename}_${activeScreen.generatedAt.toISOString()}`
-      renderedAt = activeScreen.generatedAt
-    }
+    const { filename, imgUrl, renderedAt } = device.mirrorEnabled
+      ? await this.resolveMirrorScreen(device)
+      : await this.resolveActiveScreenImage(device, activeScreen)
     return new DisplayScreen({
       filename,
       image_url: imgUrl,
       refresh_rate: refreshRate,
       rendered_at: renderedAt,
     })
+  }
+
+  private async resolveMirrorScreen(device: Device): Promise<{ filename: string, imgUrl: string, renderedAt: undefined }> {
+    this.logger.log(`Mirroring enabled for device ${device.id}, checking for image...`)
+    let imgUrl = await this.fallbackImageUrl('error', device)
+    if (await fileExists(resolveAppPath('public', 'screens', 'devices', device.id, 'mirror.png'))) {
+      this.logger.log(`Image found returning`)
+      imgUrl = `${this.configService.get<string>('api_url')}/screens/devices/${device.id}/mirror.png`
+    }
+    else {
+      this.logger.log(`Mirror image missing on disk, fetching from TRMNL on demand`)
+      try {
+        const { localImageUrl } = await this.fetchAndStoreMirrorImage(device)
+        imgUrl = localImageUrl
+      }
+      catch (err) {
+        const message = getErrorMessage(err)
+        this.logger.error(`Failed to fetch mirror image on demand: ${message}`)
+      }
+    }
+    return { filename: `mirror_${new Date().toISOString()}`, imgUrl, renderedAt: undefined }
+  }
+
+  private async resolveActiveScreenImage(device: Device, activeScreen: Screen | null): Promise<{ filename: string, imgUrl: string, renderedAt: Date }> {
+    if (!activeScreen)
+      throw new NotFoundException('No active screen found for device')
+    this.logger.log(`Returning screen ${activeScreen.id} for device ${device.id}`)
+    let imgUrl: string
+    if (await fileExists(this.screenImagePath(device, activeScreen))) {
+      imgUrl = this.screenImageUrl(device, activeScreen)
+    }
+    else {
+      this.logger.log(`Screen image for ${activeScreen.id} missing on disk, generating on demand`)
+      imgUrl = await this.generateScreenImage(activeScreen, device)
+    }
+    return { filename: `${activeScreen.filename}_${activeScreen.generatedAt.toISOString()}`, imgUrl, renderedAt: activeScreen.generatedAt }
   }
 
   private async fetchAndStoreMirrorImage(device: Device, proxyHeaders?: DisplayRequestHeadersDto): Promise<{ response: TrmnlScreenResponse, localImageUrl: string }> {
@@ -395,116 +427,13 @@ export class DeviceDisplayService {
   }
 
   private async generateScreenImage(screen: Screen, device: Device): Promise<string> {
-    let imgUrl: string | null = null
+    let imgUrl = screen.type === 'mashup'
+      ? await this.renderMashupScreen(screen, device)
+      : await this.renderPluginOrHtmlScreen(screen, device)
 
-    // Handle mashup screen
-    if (screen.type === 'mashup') {
-      try {
-        const screenWithMashup = await this.screenRepository.findOne({
-          where: { id: screen.id },
-          relations: {
-            mashupConfiguration: {
-              slots: {
-                plugin: {
-                  dataSources: true,
-                  templates: true,
-                },
-              },
-            },
-          },
-        })
+    if (screen.externalLink && !screen.fetchManual)
+      imgUrl = await this.renderExternalLinkScreen(screen, device)
 
-        if (screenWithMashup?.mashupConfiguration && this.mashupRenderer) {
-          let renderedHtml: string
-
-          // Use cached output if available
-          if (screenWithMashup.cachedPluginOutput) {
-            this.logger.log(`Using cached mashup output for screen ${screen.id}`)
-            renderedHtml = screenWithMashup.cachedPluginOutput
-          }
-          else {
-            this.logger.log(`Rendering mashup ${screenWithMashup.mashupConfiguration.id} for screen ${screen.id}`)
-            renderedHtml = await this.mashupRenderer.renderMashup(screenWithMashup.mashupConfiguration, device)
-            await this.cachePluginOutput(screen, renderedHtml)
-          }
-
-          imgUrl = await this.renderBodyToScreenPng(renderedHtml, screen, device)
-        }
-      }
-      catch (err) {
-        const message = getErrorMessage(err)
-        this.logger.error(`Failed to render mashup: ${message}`)
-        imgUrl = await this.fallbackImageUrl('error', device)
-      }
-    }
-    // Handle plugin screen
-    else {
-      // Load plugin relationship if needed
-      const screenWithPlugin = await this.screenRepository.findOne({
-        where: { id: screen.id },
-        relations: { plugin: { dataSources: true, templates: true } },
-      })
-
-      if (screenWithPlugin?.plugin) {
-        const plugin = screenWithPlugin.plugin
-
-        // Use cached output if available
-        if (screenWithPlugin.cachedPluginOutput) {
-          try {
-            this.logger.log(`Using cached plugin output for plugin ${plugin.id}, screen ${screen.id}`)
-            imgUrl = await this.renderBodyToScreenPng(viewFull(screenWithPlugin.cachedPluginOutput), screen, device)
-          }
-          catch (err) {
-            const message = getErrorMessage(err)
-            this.logger.error(`Failed to render cached plugin output: ${message}`)
-            imgUrl = await this.fallbackImageUrl('error', device)
-          }
-        }
-        // Fallback: fetch and render on-demand
-        else if (plugin.dataSources && plugin.dataSources.length > 0 && plugin.templates && plugin.templates.length > 0) {
-          try {
-            const renderedHtml = await this.renderPluginHtml(plugin, screen, device)
-            if (renderedHtml)
-              imgUrl = await this.renderBodyToScreenPng(viewFull(renderedHtml), screen, device)
-          }
-          catch (err) {
-            const message = getErrorMessage(err)
-            this.logger.error(`Failed to render plugin: ${message}`)
-            imgUrl = await this.fallbackImageUrl('error', device)
-          }
-        }
-      }
-      // Handle HTML screen
-      else if (screen.html) {
-        imgUrl = await this.renderBodyToScreenPng(viewFull(screen.html), screen, device)
-      }
-    }
-    // Handle external link screen
-    if (screen.externalLink && !screen.fetchManual) {
-      const inputPath = path.join(resolveAppPath('public', 'screens', 'devices', device.id), 'tmp-source')
-      try {
-        await downloadImage(screen.externalLink, inputPath, this.logger)
-        await convertToPng(inputPath, this.screenImagePath(device, screen), await this.deviceModels.renderTargetFor(device), this.logger)
-        this.logger.log('Updating generation date on screen')
-        screen.generatedAt = new Date()
-        await this.screenRepository.save(screen)
-        this.logger.log('Download and conversion successful')
-        imgUrl = this.screenImageUrl(device, screen)
-      }
-      catch (err) {
-        const message = getErrorMessage(err)
-        this.logger.error(`Failed to process image: ${message}`)
-        imgUrl = await this.fallbackImageUrl('error', device)
-      }
-      finally {
-        try {
-          await fs.promises.unlink(inputPath)
-        }
-        catch {
-          // best-effort cleanup
-        }
-      }
-    }
     if (imgUrl !== null)
       return imgUrl
 
@@ -514,38 +443,129 @@ export class DeviceDisplayService {
       : await this.fallbackImageUrl('error', device)
   }
 
+  private async renderMashupScreen(screen: Screen, device: Device): Promise<string | null> {
+    try {
+      const screenWithMashup = await this.screenRepository.findOne({
+        where: { id: screen.id },
+        relations: {
+          mashupConfiguration: {
+            slots: {
+              plugin: {
+                dataSources: true,
+                templates: true,
+              },
+            },
+          },
+        },
+      })
+
+      if (!screenWithMashup?.mashupConfiguration || !this.mashupRenderer)
+        return null
+
+      let renderedHtml: string
+      if (screenWithMashup.cachedPluginOutput) {
+        this.logger.log(`Using cached mashup output for screen ${screen.id}`)
+        renderedHtml = screenWithMashup.cachedPluginOutput
+      }
+      else {
+        renderedHtml = await this.renderMashupOnDemand(screen, screenWithMashup.mashupConfiguration, device)
+      }
+
+      return await this.renderBodyToScreenPng(renderedHtml, screen, device)
+    }
+    catch (err) {
+      const message = getErrorMessage(err)
+      this.logger.error(`Failed to render mashup: ${message}`)
+      return await this.fallbackImageUrl('error', device)
+    }
+  }
+
+  private async renderMashupOnDemand(screen: Screen, mashupConfiguration: NonNullable<Screen['mashupConfiguration']>, device: Device): Promise<string> {
+    this.logger.log(`Rendering mashup ${mashupConfiguration.id} for screen ${screen.id}`)
+    const renderedHtml = await this.mashupRenderer.renderMashup(mashupConfiguration, device)
+    await this.cachePluginOutput(screen, renderedHtml)
+    return renderedHtml
+  }
+
+  private async renderPluginOrHtmlScreen(screen: Screen, device: Device): Promise<string | null> {
+    // Load plugin relationship if needed
+    const screenWithPlugin = await this.screenRepository.findOne({
+      where: { id: screen.id },
+      relations: { plugin: { dataSources: true, templates: true } },
+    })
+
+    if (screenWithPlugin?.plugin)
+      return await this.renderPluginScreen(screenWithPlugin, screen, device)
+
+    return screen.html
+      ? await this.renderBodyToScreenPng(viewFull(screen.html), screen, device)
+      : null
+  }
+
+  private async renderPluginScreen(screenWithPlugin: Screen, screen: Screen, device: Device): Promise<string | null> {
+    const plugin = screenWithPlugin.plugin!
+
+    // Use cached output if available
+    if (screenWithPlugin.cachedPluginOutput) {
+      try {
+        this.logger.log(`Using cached plugin output for plugin ${plugin.id}, screen ${screen.id}`)
+        return await this.renderBodyToScreenPng(viewFull(screenWithPlugin.cachedPluginOutput), screen, device)
+      }
+      catch (err) {
+        const message = getErrorMessage(err)
+        this.logger.error(`Failed to render cached plugin output: ${message}`)
+        return await this.fallbackImageUrl('error', device)
+      }
+    }
+
+    // Fallback: fetch and render on-demand
+    if (plugin.dataSources && plugin.dataSources.length > 0 && plugin.templates && plugin.templates.length > 0) {
+      try {
+        const renderedHtml = await this.renderPluginHtml(plugin, screen, device)
+        return renderedHtml ? await this.renderBodyToScreenPng(viewFull(renderedHtml), screen, device) : null
+      }
+      catch (err) {
+        const message = getErrorMessage(err)
+        this.logger.error(`Failed to render plugin: ${message}`)
+        return await this.fallbackImageUrl('error', device)
+      }
+    }
+
+    return null
+  }
+
+  private async renderExternalLinkScreen(screen: Screen, device: Device): Promise<string> {
+    const inputPath = path.join(resolveAppPath('public', 'screens', 'devices', device.id), 'tmp-source')
+    try {
+      await downloadImage(screen.externalLink!, inputPath, this.logger)
+      await convertToPng(inputPath, this.screenImagePath(device, screen), await this.deviceModels.renderTargetFor(device), this.logger)
+      this.logger.log('Updating generation date on screen')
+      screen.generatedAt = new Date()
+      await this.screenRepository.save(screen)
+      this.logger.log('Download and conversion successful')
+      return this.screenImageUrl(device, screen)
+    }
+    catch (err) {
+      const message = getErrorMessage(err)
+      this.logger.error(`Failed to process image: ${message}`)
+      return await this.fallbackImageUrl('error', device)
+    }
+    finally {
+      try {
+        await fs.promises.unlink(inputPath)
+      }
+      catch {
+        // best-effort cleanup
+      }
+    }
+  }
+
   private async renderPluginHtml(plugin: Plugin, screen: Screen, device: Device): Promise<string | null> {
     this.logger.log(`No cache, rendering plugin ${plugin.id} on-demand for screen ${screen.id}`)
 
     const sensors = await this.deviceSensors.findForDevice(device.id)
     const templateContext = this.pluginTemplateContext.build(plugin, sensors)
-
-    // Fetch all of the plugin's data sources in parallel; a source that fails
-    // gets an error marker instead of aborting the whole render (ADR-0005).
-    // A literal-mode source has no fetch to make — it contributes its stored
-    // value directly, with no call to the data fetcher at all.
-    const results = await Promise.allSettled(
-      plugin.dataSources.map(async (source) => {
-        let rawData = await this.pluginDataFetcher.fetchOrLiteral(source, templateContext)
-        if (source.transformJs) {
-          this.logger.debug(`Applying transform.js to data source: ${source.name}`)
-          rawData = this.pluginTransformer.transform(source.transformJs, rawData)
-        }
-        return rawData
-      }),
-    )
-
-    const data: Record<string, unknown> = {}
-    results.forEach((result, index) => {
-      const name = plugin.dataSources[index].name
-      if (result.status === 'fulfilled') {
-        data[name] = result.value
-      }
-      else {
-        this.logger.warn(`Data source "${name}" failed for plugin ${plugin.id}: ${result.reason?.message || result.reason}`)
-        data[name] = { error: true, message: result.reason?.message || String(result.reason) }
-      }
-    })
+    const data = await this.pluginDataResolver.resolveDataSources(plugin, templateContext)
 
     const fullTemplate = plugin.templates.find(t => t.layout === 'full')
     if (!fullTemplate)

--- a/packages/api/src/mashup/__test__/mashup-renderer.service.spec.ts
+++ b/packages/api/src/mashup/__test__/mashup-renderer.service.spec.ts
@@ -8,6 +8,7 @@ import type { MockPluginDataFetcherService, MockPluginRendererService, MockPlugi
 import type { MashupConfiguration } from '../entities/mashup-configuration.entity'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createMockDeviceSensorsService, primeMockDeviceSensorsService } from '../../device-sensors/__test__/mockDeviceSensorsService'
+import { PluginDataResolverService } from '../../plugins/services/plugin-data-resolver.service'
 import { PluginTemplateContextService } from '../../plugins/services/plugin-template-context.service'
 import { makeDevice, makeMashupConfiguration, makeMashupSlot, makePlugin, makePluginDataSource, makePluginTemplate } from '../../test/fixtures'
 import { createMockPluginDataFetcherService, createMockPluginRendererService, createMockPluginTransformService } from '../../test/mockPluginCollaborators'
@@ -35,9 +36,8 @@ describe('mashupRendererService', () => {
     primeMockDeviceSensorsService(deviceSensors)
 
     service = new MashupRendererService(
-      asService<PluginDataFetcherService>(pluginDataFetcher),
+      new PluginDataResolverService(asService<PluginDataFetcherService>(pluginDataFetcher), asService<PluginTransformService>(pluginTransformer)),
       asService<PluginRendererService>(pluginRenderer),
-      asService<PluginTransformService>(pluginTransformer),
       asService<ConfigService>(configService),
       asService<DeviceSensorsService>(deviceSensors),
       new PluginTemplateContextService(),

--- a/packages/api/src/mashup/__test__/mashup.integration.spec.ts
+++ b/packages/api/src/mashup/__test__/mashup.integration.spec.ts
@@ -8,9 +8,8 @@ import { getRepositoryToken } from '@nestjs/typeorm'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { Device } from '../../devices/devices.entity'
 import { Plugin as PluginEntity } from '../../plugins/entities/plugin.entity'
-import { PluginDataFetcherService } from '../../plugins/services/plugin-data-fetcher.service'
+import { PluginDataResolverService } from '../../plugins/services/plugin-data-resolver.service'
 import { PluginRendererService } from '../../plugins/services/plugin-renderer.service'
-import { PluginTransformService } from '../../plugins/services/plugin-transform.service'
 import { Screen as ScreenEntity } from '../../screens/screens.entity'
 import { makeDevice, makeMashupConfiguration, makeMashupSlot, makePlugin, makePluginTemplate, makeScreen } from '../../test/fixtures'
 import { createMockRepository, whereId } from '../../test/mockRepository'
@@ -181,11 +180,7 @@ describe('mashup Integration Tests', () => {
           useValue: mockPluginRenderer,
         },
         {
-          provide: PluginDataFetcherService,
-          useValue: {},
-        },
-        {
-          provide: PluginTransformService,
+          provide: PluginDataResolverService,
           useValue: {},
         },
         {
@@ -262,11 +257,7 @@ describe('mashup Integration Tests', () => {
           useValue: mockPluginRenderer,
         },
         {
-          provide: PluginDataFetcherService,
-          useValue: {},
-        },
-        {
-          provide: PluginTransformService,
+          provide: PluginDataResolverService,
           useValue: {},
         },
         {

--- a/packages/api/src/mashup/services/mashup-renderer.service.ts
+++ b/packages/api/src/mashup/services/mashup-renderer.service.ts
@@ -5,10 +5,9 @@ import type { MashupSlot } from '../entities/mashup-slot.entity'
 import { Injectable, Logger } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
 import { DeviceSensorsService } from '../../device-sensors/device-sensors.service'
-import { PluginDataFetcherService } from '../../plugins/services/plugin-data-fetcher.service'
+import { PluginDataResolverService } from '../../plugins/services/plugin-data-resolver.service'
 import { PluginRendererService } from '../../plugins/services/plugin-renderer.service'
 import { PluginTemplateContextService } from '../../plugins/services/plugin-template-context.service'
-import { PluginTransformService } from '../../plugins/services/plugin-transform.service'
 import { getErrorMessage } from '../../utils/getErrorMessage'
 
 @Injectable()
@@ -16,9 +15,8 @@ export class MashupRendererService {
   private readonly logger = new Logger(MashupRendererService.name)
 
   constructor(
-    private readonly pluginDataFetcher: PluginDataFetcherService,
+    private readonly pluginDataResolver: PluginDataResolverService,
     private readonly pluginRenderer: PluginRendererService,
-    private readonly pluginTransformer: PluginTransformService,
     private readonly configService: ConfigService,
     private readonly deviceSensors: DeviceSensorsService,
     private readonly pluginTemplateContext: PluginTemplateContextService,
@@ -58,28 +56,7 @@ export class MashupRendererService {
     }
 
     const templateContext = this.pluginTemplateContext.build(plugin, sensors)
-
-    // Fetch all of the plugin's data sources in parallel; a source that fails
-    // gets an error marker instead of aborting the whole render (ADR-0005).
-    // A literal-mode source has no fetch to make — it contributes its stored
-    // value directly, with no call to the data fetcher at all.
-    const results = await Promise.allSettled(
-      plugin.dataSources.map(async (source) => {
-        let rawData = await this.pluginDataFetcher.fetchOrLiteral(source, templateContext)
-        if (source.transformJs) {
-          rawData = this.pluginTransformer.transform(source.transformJs, rawData)
-        }
-        return rawData
-      }),
-    )
-
-    const data: Record<string, unknown> = {}
-    results.forEach((result, index) => {
-      const name = plugin.dataSources[index].name
-      data[name] = result.status === 'fulfilled'
-        ? result.value
-        : { error: true, message: result.reason?.message || String(result.reason) }
-    })
+    const data = await this.pluginDataResolver.resolveDataSources(plugin, templateContext)
 
     // Find template (prefer 'full' layout for now, could support size variants later)
     const template = plugin.templates.find(t => t.layout === 'full') || plugin.templates[0]

--- a/packages/api/src/plugins/__test__/plugin-data-resolver.service.spec.ts
+++ b/packages/api/src/plugins/__test__/plugin-data-resolver.service.spec.ts
@@ -1,0 +1,67 @@
+import type { PluginDataFetcherService } from '../services/plugin-data-fetcher.service'
+import type { PluginTransformService } from '../services/plugin-transform.service'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { makePlugin, makePluginDataSource } from '../../test/fixtures'
+import { asService } from '../../test/mockService'
+import { PluginDataResolverService } from '../services/plugin-data-resolver.service'
+
+describe('pluginDataResolverService', () => {
+  let service: PluginDataResolverService
+  let pluginDataFetcher: { fetchOrLiteral: ReturnType<typeof vi.fn> }
+  let pluginTransformer: { transform: ReturnType<typeof vi.fn> }
+
+  beforeEach(() => {
+    pluginDataFetcher = { fetchOrLiteral: vi.fn() }
+    pluginTransformer = { transform: vi.fn() }
+    service = new PluginDataResolverService(
+      asService<PluginDataFetcherService>(pluginDataFetcher),
+      asService<PluginTransformService>(pluginTransformer),
+    )
+  })
+
+  it('collects every data source under its own name', async () => {
+    const plugin = makePlugin({
+      dataSources: [
+        makePluginDataSource({ name: 'weather', url: 'http://x/weather' }),
+        makePluginDataSource({ name: 'calendar', url: 'http://x/calendar' }),
+      ],
+    })
+    pluginDataFetcher.fetchOrLiteral
+      .mockResolvedValueOnce({ temp: 72 })
+      .mockResolvedValueOnce({ events: 3 })
+
+    const data = await service.resolveDataSources(plugin, { trmnl: {} })
+
+    expect(data).toEqual({ weather: { temp: 72 }, calendar: { events: 3 } })
+  })
+
+  it('applies transform.js to a source that declares it', async () => {
+    const plugin = makePlugin({
+      dataSources: [makePluginDataSource({ name: 'weather', transformJs: 'module.exports = (d) => d.temp' })],
+    })
+    pluginDataFetcher.fetchOrLiteral.mockResolvedValue({ temp: 72 })
+    pluginTransformer.transform.mockReturnValue(72)
+
+    const data = await service.resolveDataSources(plugin)
+
+    expect(pluginTransformer.transform).toHaveBeenCalledWith('module.exports = (d) => d.temp', { temp: 72 })
+    expect(data).toEqual({ weather: 72 })
+  })
+
+  it('gives a failing source an error marker instead of rejecting (ADR-0005)', async () => {
+    const plugin = makePlugin({
+      dataSources: [
+        makePluginDataSource({ name: 'working' }),
+        makePluginDataSource({ name: 'failing' }),
+      ],
+    })
+    pluginDataFetcher.fetchOrLiteral
+      .mockResolvedValueOnce({ ok: true })
+      .mockRejectedValueOnce(new Error('boom'))
+
+    const data = await service.resolveDataSources(plugin)
+
+    expect(data.working).toEqual({ ok: true })
+    expect(data.failing).toEqual({ error: true, message: 'boom' })
+  })
+})

--- a/packages/api/src/plugins/plugins.module.ts
+++ b/packages/api/src/plugins/plugins.module.ts
@@ -12,6 +12,7 @@ import { WebhookPluginGuard } from './guards/webhook-plugin.guard'
 import { PluginsController } from './plugins.controller'
 import { PluginsService } from './plugins.service'
 import { PluginDataFetcherService } from './services/plugin-data-fetcher.service'
+import { PluginDataResolverService } from './services/plugin-data-resolver.service'
 import { PluginExporterService } from './services/plugin-exporter.service'
 import { PluginImporterService } from './services/plugin-importer.service'
 import { PluginRenderCacheService } from './services/plugin-render-cache.service'
@@ -39,6 +40,7 @@ import { WebhookIngestController } from './webhook-ingest.controller'
   providers: [
     PluginsService,
     PluginDataFetcherService,
+    PluginDataResolverService,
     PluginRendererService,
     PluginSchedulerService,
     PluginImporterService,
@@ -49,6 +51,6 @@ import { WebhookIngestController } from './webhook-ingest.controller'
     WebhookIngestService,
     WebhookPluginGuard,
   ],
-  exports: [PluginsService, PluginSchedulerService, PluginDataFetcherService, PluginRendererService, PluginTransformService, PluginRenderCacheService, PluginTemplateContextService],
+  exports: [PluginsService, PluginSchedulerService, PluginDataFetcherService, PluginDataResolverService, PluginRendererService, PluginTransformService, PluginRenderCacheService, PluginTemplateContextService],
 })
 export class PluginsModule {}

--- a/packages/api/src/plugins/services/plugin-data-resolver.service.ts
+++ b/packages/api/src/plugins/services/plugin-data-resolver.service.ts
@@ -1,0 +1,48 @@
+import type { Plugin } from '../entities/plugin.entity'
+import { Injectable, Logger } from '@nestjs/common'
+import { PluginDataFetcherService } from './plugin-data-fetcher.service'
+import { PluginTransformService } from './plugin-transform.service'
+
+@Injectable()
+export class PluginDataResolverService {
+  private readonly logger = new Logger(PluginDataResolverService.name)
+
+  constructor(
+    private readonly pluginDataFetcher: PluginDataFetcherService,
+    private readonly pluginTransformer: PluginTransformService,
+  ) {}
+
+  /**
+   * Fetches every one of a Plugin's Data Sources in parallel and applies its
+   * transform.js, if any. A source that fails gets an error marker instead of
+   * aborting the whole render (ADR-0005); a literal-mode source has no fetch
+   * to make — it contributes its stored value directly, with no call to the
+   * data fetcher at all. Shared by every render path (device display, mashup
+   * slot) that turns a Plugin's Data Sources into template data.
+   */
+  async resolveDataSources(plugin: Plugin, templateContext?: object): Promise<Record<string, unknown>> {
+    const results = await Promise.allSettled(
+      plugin.dataSources.map(async (source) => {
+        let rawData = await this.pluginDataFetcher.fetchOrLiteral(source, templateContext)
+        if (source.transformJs) {
+          this.logger.debug(`Applying transform.js to data source: ${source.name}`)
+          rawData = this.pluginTransformer.transform(source.transformJs, rawData)
+        }
+        return rawData
+      }),
+    )
+
+    const data: Record<string, unknown> = {}
+    results.forEach((result, index) => {
+      const name = plugin.dataSources[index].name
+      if (result.status === 'fulfilled') {
+        data[name] = result.value
+      }
+      else {
+        this.logger.warn(`Data source "${name}" failed for plugin ${plugin.id}: ${result.reason?.message || result.reason}`)
+        data[name] = { error: true, message: result.reason?.message || String(result.reason) }
+      }
+    })
+    return data
+  }
+}


### PR DESCRIPTION
## What/why

`packages/api/src/devices/display.service.ts` carried the two worst
complexity findings in the API (`getCurrentImage`, `generateScreenImage`)
plus a copy-pasted device-auth check and a plugin data-source fetch block
duplicated with `MashupRendererService` (fallow finding, baselined on
2026-08-22).

- Extracted `authenticateDevice()` (device lookup + API-key check), reused by
  `getCurrentImage` and `getCurrentImageWithoutProgressing`.
- Added `PluginDataResolverService` (`packages/api/src/plugins/services`),
  wrapping `PluginDataFetcherService` + `PluginTransformService`, to fetch a
  Plugin's data sources in parallel and apply `transform.js` while preserving
  the ADR-0005 error-marker semantics. `DisplayService` and
  `MashupRendererService` both now delegate to it instead of each carrying
  their own copy of the fetch/transform/error-marker loop.
- Split `getCurrentImage`, `getCurrentImageWithoutProgressing` and
  `generateScreenImage` into intention-revealing private methods
  (`applyHeaderReport`, `buildRotationResponse`, `buildMirrorResponse`,
  `resolveMirrorScreen`, `resolveActiveScreenImage`, `renderMashupScreen`,
  `renderPluginOrHtmlScreen`, `renderPluginScreen`, `renderExternalLinkScreen`)
  so every function is now under fallow's cyclomatic/cognitive thresholds.
- Bundled the four fields `getCurrentImage`'s response builders need into one
  `HeaderReport` object instead of positional params, since two of them share
  a boolean type and two share a string type (transposition risk).
- Refreshed the fallow dupes/health baselines: both duplicate clone groups
  and all of `display.service.ts`'s complexity findings are gone.

Deliberately out of scope: `plugins.service.ts`'s `preview()` and
`plugin-scheduler.service.ts` still hand-roll their own (pre-existing, not
newly duplicated) fetch loop rather than using the new resolver — the issue
scoped the shared extraction to `DisplayService`/`MashupRendererService` only,
and folding those in is a separate, larger change.

## Test evidence

- `pnpm --filter kuroshiro-api test` — 745 passed, 38 skipped (pre-existing skips)
- `pnpm --filter kuroshiro-api type-check` — clean
- `pnpm --filter kuroshiro-api lint` — 0 errors (1 pre-existing, unrelated warning)
- `pnpm fallow:ci` — no new dead-code/dupes/health findings; `display.service.ts`'s complexity_critical/high findings and both targeted clone groups are gone from the baselines

Closes #838

> *Opened by Kongroo, karakuri's Projects agent — Stage: implement*