### PR TITLE
Build multi-arch Docker images for amd64 and arm64

### DIFF
--- a/.github/workflows/docker-next.yml
+++ b/.github/workflows/docker-next.yml
@@ -22,6 +22,10 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v4
         with:
@@ -36,6 +40,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ghcr.io/${{ steps.repo.outputs.repository }}:next

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -22,6 +22,10 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v4
         with:
@@ -39,6 +43,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ghcr.io/${{ steps.repo.outputs.repository }}:latest


### PR DESCRIPTION
The published images are amd64 only. `docker/build-push-action` was called without a `platforms:` key in both the `next` and release workflows, so `ghcr.io/phyberapex/kuroshiro:latest` is a single-platform manifest and cannot be pulled on ARM — including Raspberry Pi, which is where most self-hosted Home Assistant installs run.

This adds `docker/setup-qemu-action` and `docker/setup-buildx-action` to both workflows and builds `linux/amd64,linux/arm64`. Tags are unchanged.

Prompted by packaging Kuroshiro as a Home Assistant add-on (PhyberApex/home-assistant-add-on-repo#14). That add-on works around the single-arch image today by taking only the architecture-independent bundles from an amd64 stage and reinstalling production dependencies for its own architecture; once multi-arch releases exist it can consume the release image directly.

## Caveats

**The arm64 leg builds under QEMU emulation and will be noticeably slower** — it runs `pnpm install`, the Vite build and swc under emulation. If that becomes painful, the next step is a two-runner matrix (`ubuntu-latest` + `ubuntu-24.04-arm`) pushing by digest and merging the manifest with `docker buildx imagetools create`, rather than dropping back to a single architecture.

**This change is not exercised by its own PR.** `docker-next.yml` triggers on push to `main` and `docker-release.yml` on `release: published`, so a PR only runs `checks.yml` (lint / type-check / test), which a workflow-only diff does not touch. The first proof that the arm64 leg builds at all comes after merge, on the `next` image. Worth watching that run, then confirming:

```
docker buildx imagetools inspect ghcr.io/phyberapex/kuroshiro:next
```

comes back as a multi-platform manifest rather than a single one.

Unrelated but noticed while checking the registry: `0.12.0` is in `package.json` and `.release-please-manifest.json`, but **no `0.12.0` image exists on ghcr** — `latest` still resolves to the same digest as `0.11.0`. That release's `docker-release` run may have failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H7K5gyc9HUaQUGLm8cYo87

---
_Generated by [Claude Code](https://claude.ai/code/session_01H7K5gyc9HUaQUGLm8cYo87)_