### PR TITLE
fix(docker): stop the production stage choking on the workspace devDependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ COPY packages/shared ./packages/shared
 COPY pnpm-workspace.yaml package.json pnpm-lock.yaml ./
 RUN corepack enable && pnpm install --frozen-lockfile
 RUN pnpm --filter ./packages/ui build
-RUN pnpm --filter ./packages/ui build
 
 # Stage 2: Build api
 FROM node:24-alpine AS api-build
@@ -14,7 +13,6 @@ WORKDIR /app
 COPY packages/api ./packages/api
 COPY packages/shared ./packages/shared
 COPY pnpm-workspace.yaml package.json pnpm-lock.yaml ./
-# Copy built ui static files from previous stage
 RUN corepack enable && pnpm install --frozen-lockfile
 RUN pnpm --filter ./packages/api run build && pnpm --filter ./packages/api run build:migrations
 
@@ -47,9 +45,10 @@ COPY --from=ui-build /app/packages/ui/dist ./public
 COPY entrypoint.sh ./entrypoint.sh
 RUN chmod +x ./entrypoint.sh
 
-# Install only production dependencies
+# The api's workspace devDependencies are bundled into dist at build time and cannot
+# resolve here, since no workspace packages are copied into this stage
 COPY packages/api/package.json ./package.json
-RUN corepack enable && pnpm install --prod --ignore-scripts
+RUN corepack enable && pnpm pkg delete devDependencies && pnpm install --prod --ignore-scripts
 
 # Use tini as the entrypoint
 ENTRYPOINT ["/sbin/tini", "--"]


### PR DESCRIPTION
## What broke

`50ad0b7` (#875) added `"kuroshiro-shared": "workspace:*"` to `packages/api/package.json`. The `Dockerfile` production stage copies **only** that manifest into a bare image and installs from it — no workspace packages are present there, so pnpm resolves the workspace protocol *before* `--prod` filters devDependencies and dies:

```
[ERR_PNPM_WORKSPACE_PKG_NOT_FOUND] "kuroshiro-shared@workspace:*" is in the
dependencies but no package named "kuroshiro-shared" is present in the workspace
```

Blast radius:

- `docker-release` for **v0.12.0** failed → no `0.12.0` image, and `:latest` is still on `0.11.0`.
- `docker-next` has failed on **every push to main** since 2026-08-27, so `:next` is stale too.

## The fix

`tsup.config.ts` sets `noExternal: ['kuroshiro-shared']`, so shared is bundled into `dist/main.js`, and the `tsc` migration build only ever `import type`s it. Nothing needs it at runtime — the manifest just has to stop mentioning it, via `pnpm pkg delete devDependencies` before the install.

Drive-by tidies in the same file: stage 1 ran `pnpm --filter ./packages/ui build` twice, and stage 2 had a stale comment above an install line.

## Verification

Full `docker build` locally goes green. Booting the resulting image reaches `Starting Nest application...` and completes module init, stopping only at `ECONNREFUSED` on Postgres (expected with no DB). `kuroshiro-shared` survives in the image only inside a `.d.ts`.

## Follow-up (not in this PR)

The production stage installs **without** `pnpm-lock.yaml`, so runtime deps float — my local build resolved `js-yaml 5.4.1`, `liquidjs 10.29.0`, `vm2 3.12.0`, none of which match what the lockfile pins for the build stages. Shipped images aren't reproducible. Worth fixing separately (copy the lockfile + `--filter kuroshiro-api --prod --frozen-lockfile`).

## Getting 0.12.0 out

Re-running the failed release workflow won't help — it checks out the `kuroshiro-v0.12.0` tag, which still has the broken Dockerfile. Merging this unsticks `:next` immediately; release-please can then cut `0.12.1` to publish a release image and refresh `:latest`.

https://claude.ai/code/session_01MCDvXKqDUBxs6iM18BBSjJ
