### PR TITLE
refactor(api): split PluginsService create/update and share field/data-source persistence

### DIFF
--- a/.fallow-baselines/dupes.baseline.json
+++ b/.fallow-baselines/dupes.baseline.json
@@ -1,15 +1,13 @@
 {
   "clone_groups": [
     "packages/api/src/devices/display.service.ts:290-300|packages/api/src/devices/display.service.ts:84-94",
-    "packages/api/src/plugins/plugins.service.ts:232-243|packages/api/src/plugins/plugins.service.ts:348-359",
     "packages/api/src/devices/display.service.ts:521-533|packages/api/src/mashup/services/mashup-renderer.service.ts:60-71",
     "packages/api/src/devices/display.service.ts:532-540|packages/api/src/mashup/services/mashup-renderer.service.ts:70-78",
     "packages/api/src/plugins/services/plugin-importer.service.ts:253-261|packages/api/src/plugins/services/plugin-importer.service.ts:436-444",
-    "packages/api/src/test/fixtures.ts:88-107|packages/api/src/test/mockDeviceModelsService.ts:5-24"
+    "packages/api/src/test/fixtures.ts:88-107|packages/api/src/test/mockDeviceModelsService.ts:6-25"
   ],
   "clone_fingerprints": [
     "dup:04d1333c:2",
-    "dup:e767379f:2",
     "dup:0a6a4764:2",
     "dup:3219d03d:2",
     "dup:78a90f7a:2",
@@ -17,10 +15,9 @@
   ],
   "normalized_clone_fingerprints": [
     "dup:c61b2099:2",
-    "dup:c77b3abb6f87acd9-1:2",
-    "dup:c77b3abb6f87acd9-5:2",
     "dup:c77b3abb6f87acd9-4:2",
     "dup:c77b3abb6f87acd9-3:2",
-    "dup:c77b3abb6f87acd9-2:2"
+    "dup:c77b3abb6f87acd9-2:2",
+    "dup:c77b3abb6f87acd9-1:2"
   ]
 }

--- a/.fallow-baselines/health.baseline.json
+++ b/.fallow-baselines/health.baseline.json
@@ -38,11 +38,8 @@
       }
     },
     "packages/api/src/plugins/plugins.service.ts": {
-      "complexity_critical": {
-        "count": 2
-      },
-      "crap_critical": {
-        "count": 2
+      "crap_moderate": {
+        "count": 1
       }
     },
     "packages/api/src/plugins/services/plugin-data-fetcher.service.ts": {
@@ -103,6 +100,6 @@
   "runtime_coverage_findings": [],
   "target_keys": [
     "packages/api/src/devices/display.service.ts:complexity",
-    "packages/api/src/plugins/plugins.service.ts:complexity"
+    "packages/ui/src/utils/apiRequest.ts:high impact"
   ]
 }

--- a/packages/api/src/plugins/plugins.service.ts
+++ b/packages/api/src/plugins/plugins.service.ts
@@ -2,10 +2,12 @@ import type { MashupSlot } from '../mashup/entities/mashup-slot.entity.js'
 import type { AssignPluginToDeviceDto } from './dto/assign-plugin-to-device.dto.js'
 import type { CreatePluginDto } from './dto/create-plugin.dto.js'
 import type { PluginDataSourceDto } from './dto/plugin-data-source.dto.js'
+import type { PluginFieldDto } from './dto/plugin-field.dto.js'
+import type { PluginTemplateDto } from './dto/plugin-template.dto.js'
 import type { PreviewSourceDto } from './dto/preview-plugin.dto.js'
 import type { UpdateDeviceAssignmentDto } from './dto/update-device-assignment.dto.js'
 import type { UpdatePluginDto } from './dto/update-plugin.dto.js'
-import type { DevicePluginView } from './entities/plugin.entity.js'
+import type { DevicePluginView, MergeStrategy, PluginKind } from './entities/plugin.entity.js'
 import type { PluginKindFields } from './plugin-kind-fields.js'
 import { BadRequestException, Injectable, Logger, NotFoundException, OnModuleInit } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
@@ -170,10 +172,7 @@ export class PluginsService implements OnModuleInit {
 
     this.logger.debug(`Creating plugin with data: ${JSON.stringify({ dataSources, templates, fields, basicFields })}`)
 
-    if (dataSources && Array.isArray(dataSources) && dataSources.length > 0) {
-      this.validateDataSourceNames(dataSources, fields || [])
-      this.assertDataSourceModeFields(dataSources)
-    }
+    this.validateNewChildren(dataSources, fields)
 
     const kind = basicFields.kind || 'Poll'
 
@@ -185,7 +184,28 @@ export class PluginsService implements OnModuleInit {
       streamLimit: basicFields.streamLimit,
     })
 
-    const pluginToSave = {
+    const savedPlugin = await this.pluginRepository.save(this.buildPluginToSave(basicFields, kind))
+    this.logger.debug(`Saved plugin: ${savedPlugin.id}`)
+
+    await this.createDataSources(savedPlugin, dataSources)
+    await this.createTemplates(savedPlugin, templates)
+    await this.createFields(savedPlugin, fields)
+
+    const created = await this.reloadPlugin(savedPlugin.id, 'newly created')
+    this.scheduleIfReady(created, `Scheduled new plugin: ${created.name}`)
+
+    return created
+  }
+
+  private validateNewChildren(dataSources: PluginDataSourceDto[] | undefined, fields: PluginFieldDto[] | undefined): void {
+    if (dataSources && Array.isArray(dataSources) && dataSources.length > 0) {
+      this.validateDataSourceNames(dataSources, fields || [])
+      this.assertDataSourceModeFields(dataSources)
+    }
+  }
+
+  private buildPluginToSave(basicFields: Omit<CreatePluginDto, 'dataSources' | 'templates' | 'fields'>, kind: PluginKind) {
+    return {
       name: basicFields.name,
       description: basicFields.description,
       kind,
@@ -199,68 +219,84 @@ export class PluginsService implements OnModuleInit {
           }
         : {}),
     }
+  }
 
-    const savedPlugin = await this.pluginRepository.save(pluginToSave)
+  private async createDataSources(plugin: Plugin, dataSources: PluginDataSourceDto[] | undefined): Promise<void> {
+    if (!dataSources || !Array.isArray(dataSources) || dataSources.length === 0)
+      return
 
-    this.logger.debug(`Saved plugin: ${savedPlugin.id}`)
+    this.logger.debug(`Creating ${dataSources.length} data sources`)
+    await this.persistDataSources(plugin, dataSources)
+  }
 
-    if (dataSources && Array.isArray(dataSources) && dataSources.length > 0) {
-      this.logger.debug(`Creating ${dataSources.length} data sources`)
-      for (const [index, sourceData] of dataSources.entries()) {
-        const newDataSource = this.dataSourceRepository.create({
-          ...this.buildDataSourceFields(sourceData, index),
-          plugin: savedPlugin,
-        })
-        await this.dataSourceRepository.save(newDataSource)
-        this.logger.debug(`Saved data source: ${newDataSource.name}`)
-      }
+  private async createTemplates(plugin: Plugin, templates: PluginTemplateDto[] | undefined): Promise<void> {
+    if (!templates || !Array.isArray(templates) || templates.length === 0)
+      return
+
+    this.logger.debug(`Creating ${templates.length} templates`)
+    for (const templateData of templates) {
+      const newTemplate = this.templateRepository.create({
+        layout: templateData.layout || 'full',
+        liquidMarkup: templateData.liquidMarkup,
+        plugin,
+      })
+      await this.templateRepository.save(newTemplate)
+      this.logger.debug(`Saved template`)
     }
+  }
 
-    if (templates && Array.isArray(templates) && templates.length > 0) {
-      this.logger.debug(`Creating ${templates.length} templates`)
-      for (const templateData of templates) {
-        const newTemplate = this.templateRepository.create({
-          layout: templateData.layout || 'full',
-          liquidMarkup: templateData.liquidMarkup,
-          plugin: savedPlugin,
-        })
-        await this.templateRepository.save(newTemplate)
-        this.logger.debug(`Saved template`)
-      }
+  private async createFields(plugin: Plugin, fields: PluginFieldDto[] | undefined): Promise<void> {
+    if (!fields || !Array.isArray(fields) || fields.length === 0)
+      return
+
+    this.logger.debug(`Creating ${fields.length} fields`)
+    await this.persistFields(plugin, fields)
+  }
+
+  private buildFieldFields(fieldData: PluginFieldDto) {
+    return {
+      keyname: fieldData.keyname,
+      fieldType: fieldData.fieldType || 'string',
+      name: fieldData.name,
+      description: fieldData.description,
+      defaultValue: fieldData.defaultValue,
+      required: fieldData.required || false,
+      order: fieldData.order || 0,
     }
+  }
 
-    if (fields && Array.isArray(fields) && fields.length > 0) {
-      this.logger.debug(`Creating ${fields.length} fields`)
-      for (const fieldData of fields) {
-        const newField = this.fieldRepository.create({
-          keyname: fieldData.keyname,
-          fieldType: fieldData.fieldType || 'string',
-          name: fieldData.name,
-          description: fieldData.description,
-          defaultValue: fieldData.defaultValue,
-          required: fieldData.required || false,
-          order: fieldData.order || 0,
-          plugin: savedPlugin,
-        })
-        await this.fieldRepository.save(newField)
-        this.logger.debug(`Saved field: ${newField.keyname}`)
-      }
+  private async persistFields(plugin: Plugin, fields: PluginFieldDto[]): Promise<void> {
+    for (const fieldData of fields) {
+      const newField = this.fieldRepository.create({
+        ...this.buildFieldFields(fieldData),
+        plugin,
+      })
+      await this.fieldRepository.save(newField)
+      this.logger.debug(`Saved field: ${newField.keyname}`)
     }
+  }
 
-    const created = await this.pluginRepository.findOne({
-      where: { id: savedPlugin.id },
+  private async reloadPlugin(id: string, context: string): Promise<Plugin> {
+    const plugin = await this.pluginRepository.findOne({
+      where: { id },
       relations: { dataSources: true, templates: true, fields: true },
     })
 
-    if (!created)
-      throw new Error(`Failed to load newly created plugin: ${savedPlugin.id}`)
+    if (!plugin)
+      throw new Error(`Failed to load ${context} plugin: ${id}`)
 
-    if (created.dataSources && created.dataSources.length > 0 && created.templates && created.templates.length > 0) {
-      this.scheduler.schedulePlugin(created)
-      this.logger.log(`Scheduled new plugin: ${created.name}`)
+    return plugin
+  }
+
+  private isSchedulable(plugin: Plugin): boolean {
+    return !!(plugin.dataSources && plugin.dataSources.length > 0 && plugin.templates && plugin.templates.length > 0)
+  }
+
+  private scheduleIfReady(plugin: Plugin, message: string): void {
+    if (this.isSchedulable(plugin)) {
+      this.scheduler.schedulePlugin(plugin)
+      this.logger.log(message)
     }
-
-    return created
   }
 
   async update(id: string, pluginData: UpdatePluginDto): Promise<Plugin | null> {
@@ -272,19 +308,55 @@ export class PluginsService implements OnModuleInit {
       return null
 
     const { dataSources, templates, fields, webhookToken, ...rawBasicFields } = pluginData
+    const basicFields = this.dropUnsetFields(rawBasicFields)
 
-    // class-transformer's plainToInstance (the real ValidationPipe path) gives every declared
-    // UpdatePluginDto field an own property equal to `undefined` even when the caller never sent
-    // it, so unset fields must be dropped here before they reach the Object.assign below —
-    // otherwise a partial PATCH would blank out every field the caller omitted.
-    const basicFields = Object.fromEntries(
-      Object.entries(rawBasicFields).filter(([, value]) => value !== undefined),
-    ) as typeof rawBasicFields
+    this.assertKindUnchanged(basicFields, plugin)
+    this.validateUpdatedChildren(plugin, dataSources, fields)
 
+    const mergeFields = this.resolveMergeFields(basicFields, plugin)
+
+    this.assertKindFields({
+      kind: plugin.kind,
+      dataSources: dataSources ?? plugin.dataSources,
+      webhookToken: webhookToken === plugin.webhookToken ? undefined : webhookToken,
+      mergeStrategy: mergeFields.mergeStrategy,
+      streamLimit: mergeFields.streamLimit,
+    })
+
+    this.applyBasicFields(plugin, basicFields, mergeFields)
+
+    if (dataSources !== undefined) {
+      await this.replaceDataSources(plugin, dataSources)
+    }
+    await this.replaceTemplates(plugin, templates)
+    await this.replaceFields(plugin, fields)
+
+    const updated = await this.pluginRepository.save(plugin)
+
+    if (dataSources !== undefined || templates) {
+      await this.rescheduleAfterUpdate(id)
+    }
+
+    return updated
+  }
+
+  // class-transformer's plainToInstance (the real ValidationPipe path) gives every declared
+  // UpdatePluginDto field an own property equal to `undefined` even when the caller never sent
+  // it, so unset fields must be dropped here before they reach the Object.assign in
+  // applyBasicFields — otherwise a partial PATCH would blank out every field the caller omitted.
+  private dropUnsetFields<T extends object>(rawFields: T): T {
+    return Object.fromEntries(
+      Object.entries(rawFields).filter(([, value]) => value !== undefined),
+    ) as T
+  }
+
+  private assertKindUnchanged(basicFields: { kind?: PluginKind }, plugin: Plugin): void {
     if (basicFields.kind !== undefined && basicFields.kind !== plugin.kind) {
       throw new BadRequestException(`A Plugin's Kind is fixed at creation and cannot be changed`)
     }
+  }
 
+  private validateUpdatedChildren(plugin: Plugin, dataSources: PluginDataSourceDto[] | undefined, fields: PluginFieldDto[] | undefined): void {
     if (dataSources !== undefined || fields !== undefined) {
       const finalDataSources = dataSources !== undefined ? dataSources : (plugin.dataSources || [])
       const finalFields = fields !== undefined ? fields : (plugin.fields || [])
@@ -294,91 +366,79 @@ export class PluginsService implements OnModuleInit {
     if (dataSources !== undefined && Array.isArray(dataSources) && dataSources.length > 0) {
       this.assertDataSourceModeFields(dataSources)
     }
+  }
 
+  private resolveMergeFields(basicFields: { mergeStrategy?: MergeStrategy, streamLimit?: number }, plugin: Plugin): { mergeStrategy: MergeStrategy | null | undefined, streamLimit: number | null | undefined } {
     const mergeStrategy = basicFields.mergeStrategy !== undefined ? basicFields.mergeStrategy : plugin.mergeStrategy
     const streamLimit = mergeStrategy === 'stream' ? basicFields.streamLimit ?? plugin.streamLimit : basicFields.streamLimit
+    return { mergeStrategy, streamLimit }
+  }
 
-    this.assertKindFields({
-      kind: plugin.kind,
-      dataSources: dataSources ?? plugin.dataSources,
-      webhookToken: webhookToken === plugin.webhookToken ? undefined : webhookToken,
-      mergeStrategy,
-      streamLimit,
-    })
+  private applyBasicFields(plugin: Plugin, basicFields: object, mergeFields: { mergeStrategy: MergeStrategy | null | undefined, streamLimit: number | null | undefined }): void {
+    Object.assign(plugin, basicFields, plugin.kind === 'Webhook' ? { mergeStrategy: mergeFields.mergeStrategy, streamLimit: mergeFields.streamLimit ?? null } : {})
+  }
 
-    Object.assign(plugin, basicFields, plugin.kind === 'Webhook' ? { mergeStrategy, streamLimit: streamLimit ?? null } : {})
-
-    if (dataSources !== undefined) {
-      if (plugin.dataSources && plugin.dataSources.length > 0) {
-        await this.dataSourceRepository.remove(plugin.dataSources)
-      }
-      const newDataSources: PluginDataSource[] = []
-      if (Array.isArray(dataSources) && dataSources.length > 0) {
-        for (const [index, sourceData] of dataSources.entries()) {
-          const newDataSource = this.dataSourceRepository.create({
-            ...this.buildDataSourceFields(sourceData, index),
-            plugin,
-          })
-          newDataSources.push(await this.dataSourceRepository.save(newDataSource))
-        }
-      }
-      plugin.dataSources = newDataSources
+  private async replaceDataSources(plugin: Plugin, dataSources: PluginDataSourceDto[]): Promise<void> {
+    if (plugin.dataSources && plugin.dataSources.length > 0) {
+      await this.dataSourceRepository.remove(plugin.dataSources)
     }
+    plugin.dataSources = Array.isArray(dataSources) && dataSources.length > 0
+      ? await this.persistDataSources(plugin, dataSources)
+      : []
+  }
 
-    if (templates && Array.isArray(templates) && templates.length > 0) {
-      if (plugin.templates && plugin.templates.length > 0) {
-        Object.assign(plugin.templates[0], templates[0])
-        await this.templateRepository.save(plugin.templates[0])
-      }
-      else {
-        const newTemplate = this.templateRepository.create({
-          ...templates[0],
-          plugin,
-        })
-        await this.templateRepository.save(newTemplate)
-      }
-    }
-
-    if (fields && Array.isArray(fields)) {
-      // Delete existing fields
-      if (plugin.fields && plugin.fields.length > 0) {
-        await this.fieldRepository.remove(plugin.fields)
-      }
-      // Create new fields
-      if (fields.length > 0) {
-        this.logger.debug(`Updating ${fields.length} fields`)
-        for (const fieldData of fields) {
-          const newField = this.fieldRepository.create({
-            keyname: fieldData.keyname,
-            fieldType: fieldData.fieldType || 'string',
-            name: fieldData.name,
-            description: fieldData.description,
-            defaultValue: fieldData.defaultValue,
-            required: fieldData.required || false,
-            order: fieldData.order || 0,
-            plugin,
-          })
-          await this.fieldRepository.save(newField)
-        }
-      }
-    }
-
-    const updated = await this.pluginRepository.save(plugin)
-
-    // Reschedule if dataSources or templates changed
-    if (dataSources !== undefined || templates) {
-      this.scheduler.removeScheduledJob(id)
-      const fullPlugin = await this.pluginRepository.findOne({
-        where: { id },
-        relations: { dataSources: true, templates: true },
+  private async persistDataSources(plugin: Plugin, dataSources: PluginDataSourceDto[]): Promise<PluginDataSource[]> {
+    const saved: PluginDataSource[] = []
+    for (const [index, sourceData] of dataSources.entries()) {
+      const newDataSource = this.dataSourceRepository.create({
+        ...this.buildDataSourceFields(sourceData, index),
+        plugin,
       })
-      if (fullPlugin && fullPlugin.dataSources && fullPlugin.dataSources.length > 0 && fullPlugin.templates && fullPlugin.templates.length > 0) {
-        this.scheduler.schedulePlugin(fullPlugin)
-        this.logger.log(`Rescheduled plugin: ${fullPlugin.name}`)
-      }
+      saved.push(await this.dataSourceRepository.save(newDataSource))
+      this.logger.debug(`Saved data source: ${newDataSource.name}`)
     }
+    return saved
+  }
 
-    return updated
+  private async replaceTemplates(plugin: Plugin, templates: PluginTemplateDto[] | undefined): Promise<void> {
+    if (!templates || !Array.isArray(templates) || templates.length === 0)
+      return
+
+    if (plugin.templates && plugin.templates.length > 0) {
+      Object.assign(plugin.templates[0], templates[0])
+      await this.templateRepository.save(plugin.templates[0])
+    }
+    else {
+      const newTemplate = this.templateRepository.create({
+        ...templates[0],
+        plugin,
+      })
+      await this.templateRepository.save(newTemplate)
+    }
+  }
+
+  private async replaceFields(plugin: Plugin, fields: PluginFieldDto[] | undefined): Promise<void> {
+    if (!fields || !Array.isArray(fields))
+      return
+
+    if (plugin.fields && plugin.fields.length > 0) {
+      await this.fieldRepository.remove(plugin.fields)
+    }
+    if (fields.length > 0) {
+      this.logger.debug(`Updating ${fields.length} fields`)
+      await this.persistFields(plugin, fields)
+    }
+  }
+
+  private async rescheduleAfterUpdate(id: string): Promise<void> {
+    this.scheduler.removeScheduledJob(id)
+    const fullPlugin = await this.pluginRepository.findOne({
+      where: { id },
+      relations: { dataSources: true, templates: true },
+    })
+    if (fullPlugin) {
+      this.scheduleIfReady(fullPlugin, `Rescheduled plugin: ${fullPlugin.name}`)
+    }
   }
 
   private assertDataSourceModeFields(dataSources: PluginDataSourceDto[]): void {

--- a/packages/api/src/plugins/plugins.service.ts
+++ b/packages/api/src/plugins/plugins.service.ts
@@ -1,3 +1,4 @@
+import type { FindOptionsRelations } from 'typeorm'
 import type { MashupSlot } from '../mashup/entities/mashup-slot.entity.js'
 import type { AssignPluginToDeviceDto } from './dto/assign-plugin-to-device.dto.js'
 import type { CreatePluginDto } from './dto/create-plugin.dto.js'
@@ -26,6 +27,13 @@ import { PluginDataFetcherService } from './services/plugin-data-fetcher.service
 import { PluginRendererService } from './services/plugin-renderer.service.js'
 import { PluginSchedulerService } from './services/plugin-scheduler.service.js'
 import { PluginTransformService } from './services/plugin-transform.service.js'
+
+type UpdateBasicFields = Omit<UpdatePluginDto, 'dataSources' | 'templates' | 'fields' | 'webhookToken'>
+
+interface MergeFields {
+  mergeStrategy: MergeStrategy | null | undefined
+  streamLimit: number | null | undefined
+}
 
 @Injectable()
 export class PluginsService implements OnModuleInit {
@@ -191,7 +199,7 @@ export class PluginsService implements OnModuleInit {
     await this.createTemplates(savedPlugin, templates)
     await this.createFields(savedPlugin, fields)
 
-    const created = await this.reloadPlugin(savedPlugin.id, 'newly created')
+    const created = await this.reloadPlugin(savedPlugin.id)
     this.scheduleIfReady(created, `Scheduled new plugin: ${created.name}`)
 
     return created
@@ -276,14 +284,15 @@ export class PluginsService implements OnModuleInit {
     }
   }
 
-  private async reloadPlugin(id: string, context: string): Promise<Plugin> {
-    const plugin = await this.pluginRepository.findOne({
-      where: { id },
-      relations: { dataSources: true, templates: true, fields: true },
-    })
+  private async findPluginWithRelations(id: string, relations: FindOptionsRelations<Plugin>): Promise<Plugin | null> {
+    return this.pluginRepository.findOne({ where: { id }, relations })
+  }
+
+  private async reloadPlugin(id: string): Promise<Plugin> {
+    const plugin = await this.findPluginWithRelations(id, { dataSources: true, templates: true, fields: true })
 
     if (!plugin)
-      throw new Error(`Failed to load ${context} plugin: ${id}`)
+      throw new Error(`Failed to load newly created plugin: ${id}`)
 
     return plugin
   }
@@ -344,13 +353,13 @@ export class PluginsService implements OnModuleInit {
   // UpdatePluginDto field an own property equal to `undefined` even when the caller never sent
   // it, so unset fields must be dropped here before they reach the Object.assign in
   // applyBasicFields — otherwise a partial PATCH would blank out every field the caller omitted.
-  private dropUnsetFields<T extends object>(rawFields: T): T {
+  private dropUnsetFields(rawFields: UpdateBasicFields): UpdateBasicFields {
     return Object.fromEntries(
       Object.entries(rawFields).filter(([, value]) => value !== undefined),
-    ) as T
+    ) as UpdateBasicFields
   }
 
-  private assertKindUnchanged(basicFields: { kind?: PluginKind }, plugin: Plugin): void {
+  private assertKindUnchanged(basicFields: UpdateBasicFields, plugin: Plugin): void {
     if (basicFields.kind !== undefined && basicFields.kind !== plugin.kind) {
       throw new BadRequestException(`A Plugin's Kind is fixed at creation and cannot be changed`)
     }
@@ -368,13 +377,13 @@ export class PluginsService implements OnModuleInit {
     }
   }
 
-  private resolveMergeFields(basicFields: { mergeStrategy?: MergeStrategy, streamLimit?: number }, plugin: Plugin): { mergeStrategy: MergeStrategy | null | undefined, streamLimit: number | null | undefined } {
+  private resolveMergeFields(basicFields: UpdateBasicFields, plugin: Plugin): MergeFields {
     const mergeStrategy = basicFields.mergeStrategy !== undefined ? basicFields.mergeStrategy : plugin.mergeStrategy
     const streamLimit = mergeStrategy === 'stream' ? basicFields.streamLimit ?? plugin.streamLimit : basicFields.streamLimit
     return { mergeStrategy, streamLimit }
   }
 
-  private applyBasicFields(plugin: Plugin, basicFields: object, mergeFields: { mergeStrategy: MergeStrategy | null | undefined, streamLimit: number | null | undefined }): void {
+  private applyBasicFields(plugin: Plugin, basicFields: UpdateBasicFields, mergeFields: MergeFields): void {
     Object.assign(plugin, basicFields, plugin.kind === 'Webhook' ? { mergeStrategy: mergeFields.mergeStrategy, streamLimit: mergeFields.streamLimit ?? null } : {})
   }
 
@@ -432,10 +441,7 @@ export class PluginsService implements OnModuleInit {
 
   private async rescheduleAfterUpdate(id: string): Promise<void> {
     this.scheduler.removeScheduledJob(id)
-    const fullPlugin = await this.pluginRepository.findOne({
-      where: { id },
-      relations: { dataSources: true, templates: true },
-    })
+    const fullPlugin = await this.findPluginWithRelations(id, { dataSources: true, templates: true })
     if (fullPlugin) {
       this.scheduleIfReady(fullPlugin, `Rescheduled plugin: ${fullPlugin.name}`)
     }


### PR DESCRIPTION
## What / why

`PluginsService.create` (cyclomatic 35, cognitive 31, 102 lines, CRAP 300) and `PluginsService.update` (cyclomatic 49, cognitive 57, 111 lines, CRAP 567) were the worst complexity findings in the repo, and the field-creation logic in each was a near-exact clone (the data-source *object-building* was already deduplicated via a pre-existing `buildDataSourceFields` helper, but the two persistence loops around it were not).

This PR:
- Splits `create` into named steps: `validateNewChildren` → `buildPluginToSave` → save → `createDataSources`/`createTemplates`/`createFields` → `reloadPlugin` → `scheduleIfReady`.
- Splits `update` into named steps: `dropUnsetFields` → `assertKindUnchanged` → `validateUpdatedChildren` → `resolveMergeFields` → `assertKindFields` → `applyBasicFields` → `replaceDataSources`/`replaceTemplates`/`replaceFields` → save → `rescheduleAfterUpdate`.
- Extracts `buildFieldFields`/`persistFields` (shared field persistence) and `persistDataSources` (shared data-source persistence), used by both `create` and `update`, eliminating both the baselined field-creation clone and the previously-undetected data-source persistence-loop duplication.
- Bundles `mergeStrategy`/`streamLimit` into a single named `MergeFields` value instead of two positional params, and gives `update`'s basic-field object a precise `UpdateBasicFields` type instead of a bare `object`.
- Shares one `findPluginWithRelations` lookup between `reloadPlugin` (create path) and `rescheduleAfterUpdate` (update path) instead of two near-identical inline `findOne` calls.
- No behavior change: same validation order, same defaults, same reschedule/scheduling triggers. Issue #828 (the `kind`-guard bug the issue asked to fix first if not already done) was already fixed on `main` by #829 before this branch existed; `assertKindUnchanged` extracts that existing, unmodified guard rather than re-touching it.
- Re-ran `pnpm fallow:baseline`: `plugins.service.ts` no longer appears under `complexity_critical`/`crap_critical` in `.fallow-baselines/health.baseline.json` (now a single `crap_moderate: 1`, well under the issue's cyclomatic<20/cognitive<15 target), and its field-creation clone entry is gone from `dupes.baseline.json`.

## Test evidence

- `pnpm --filter kuroshiro-api exec vitest run src/plugins/__test__/plugins.service.spec.ts` — 55/55 passed, file unmodified (pins existing behavior through the refactor).
- `pnpm lint && pnpm type-check && pnpm test` — all green (7 shared + 752 API + 297 UI tests).
- `pnpm fallow:ci` — exits 0 against the re-saved baselines.
- Ran `/code-review` (standards + spec axes, two parallel sub-agents) against `origin/main`. Spec axis found no missing/extra requirements. Standards axis flagged only judgement-call smells (no hard violations): a bare `object` param type, a repeated inline type literal, and a duplicated `findOne` query shape — all fixed in the second commit (`MergeFields`/`UpdateBasicFields` named types, shared `findPluginWithRelations`).

Closes #840

---
*Opened by Kongroo, karakuri's Projects agent — Stage: implement*