### PR TITLE
refactor(api): reduce complexity and dedupe layout detection in PluginImporterService

### DIFF
--- a/.fallow-baselines/dupes.baseline.json
+++ b/.fallow-baselines/dupes.baseline.json
@@ -4,21 +4,18 @@
     "packages/api/src/plugins/plugins.service.ts:232-243|packages/api/src/plugins/plugins.service.ts:348-359",
     "packages/api/src/devices/display.service.ts:521-533|packages/api/src/mashup/services/mashup-renderer.service.ts:60-71",
     "packages/api/src/devices/display.service.ts:532-540|packages/api/src/mashup/services/mashup-renderer.service.ts:70-78",
-    "packages/api/src/plugins/services/plugin-importer.service.ts:253-261|packages/api/src/plugins/services/plugin-importer.service.ts:436-444",
-    "packages/api/src/test/fixtures.ts:88-107|packages/api/src/test/mockDeviceModelsService.ts:5-24"
+    "packages/api/src/test/fixtures.ts:88-107|packages/api/src/test/mockDeviceModelsService.ts:6-25"
   ],
   "clone_fingerprints": [
     "dup:04d1333c:2",
     "dup:e767379f:2",
     "dup:0a6a4764:2",
     "dup:3219d03d:2",
-    "dup:78a90f7a:2",
     "dup:5304ed0c:2"
   ],
   "normalized_clone_fingerprints": [
     "dup:c61b2099:2",
     "dup:c77b3abb6f87acd9-1:2",
-    "dup:c77b3abb6f87acd9-5:2",
     "dup:c77b3abb6f87acd9-4:2",
     "dup:c77b3abb6f87acd9-3:2",
     "dup:c77b3abb6f87acd9-2:2"

--- a/.fallow-baselines/health.baseline.json
+++ b/.fallow-baselines/health.baseline.json
@@ -50,17 +50,6 @@
         "count": 1
       }
     },
-    "packages/api/src/plugins/services/plugin-importer.service.ts": {
-      "complexity_high": {
-        "count": 2
-      },
-      "crap_high": {
-        "count": 2
-      },
-      "crap_moderate": {
-        "count": 2
-      }
-    },
     "packages/api/src/utils/ssrfGuard.ts": {
       "crap_moderate": {
         "count": 1
@@ -102,7 +91,8 @@
   },
   "runtime_coverage_findings": [],
   "target_keys": [
+    "packages/api/src/plugins/plugins.service.ts:complexity",
     "packages/api/src/devices/display.service.ts:complexity",
-    "packages/api/src/plugins/plugins.service.ts:complexity"
+    "packages/ui/src/utils/apiRequest.ts:high impact"
   ]
 }

--- a/packages/api/src/plugins/__test__/plugin-importer.service.spec.ts
+++ b/packages/api/src/plugins/__test__/plugin-importer.service.spec.ts
@@ -4,7 +4,30 @@ import * as path from 'node:path'
 import AdmZip from 'adm-zip'
 import * as yaml from 'js-yaml'
 import { beforeEach, describe, expect, it } from 'vitest'
-import { PluginImporterService } from '../services/plugin-importer.service.js'
+import { layoutFromTemplateFilename, PluginImporterService } from '../services/plugin-importer.service.js'
+
+describe('layoutFromTemplateFilename', () => {
+  it('detects half_horizontal', () => {
+    expect(layoutFromTemplateFilename('half_horizontal')).toBe('half_horizontal')
+  })
+
+  it('detects half_vertical', () => {
+    expect(layoutFromTemplateFilename('half_vertical')).toBe('half_vertical')
+  })
+
+  it('detects quadrant', () => {
+    expect(layoutFromTemplateFilename('quadrant')).toBe('quadrant')
+  })
+
+  it('falls back to full for an unrecognized filename', () => {
+    expect(layoutFromTemplateFilename('full')).toBe('full')
+    expect(layoutFromTemplateFilename('anything-else')).toBe('full')
+  })
+
+  it('matches a substring anywhere in the filename', () => {
+    expect(layoutFromTemplateFilename('my-quadrant-view')).toBe('quadrant')
+  })
+})
 
 describe('pluginImporterService', () => {
   let service: PluginImporterService

--- a/packages/api/src/plugins/services/plugin-importer.service.ts
+++ b/packages/api/src/plugins/services/plugin-importer.service.ts
@@ -17,6 +17,20 @@ function parseYamlObject<T>(content: string, invalidMessage: string): T {
   return parsed as T
 }
 
+export type TemplateLayout = 'full' | 'half_horizontal' | 'half_vertical' | 'quadrant'
+
+// Checked in order against the template filename; the first substring match wins.
+const TEMPLATE_LAYOUTS: Array<[substring: string, layout: TemplateLayout]> = [
+  ['half_horizontal', 'half_horizontal'],
+  ['half_vertical', 'half_vertical'],
+  ['quadrant', 'quadrant'],
+]
+
+export function layoutFromTemplateFilename(filename: string): TemplateLayout {
+  const match = TEMPLATE_LAYOUTS.find(([substring]) => filename.includes(substring))
+  return match ? match[1] : 'full'
+}
+
 interface TerminusManifest {
   name?: string
   description?: string
@@ -251,14 +265,7 @@ export class PluginImporterService {
     const templates = layoutEntries.map((entry) => {
       const filename = path.basename(entry.entryName, '.liquid')
       const content = entry.getData().toString('utf8')
-
-      let layout = 'full'
-      if (filename.includes('half_horizontal'))
-        layout = 'half_horizontal'
-      else if (filename.includes('half_vertical'))
-        layout = 'half_vertical'
-      else if (filename.includes('quadrant'))
-        layout = 'quadrant'
+      const layout = layoutFromTemplateFilename(filename)
 
       // If template uses {% render "main" %} and we have shared.liquid, inline it
       let liquidMarkup = content
@@ -434,14 +441,7 @@ export class PluginImporterService {
         const filePath = path.join(srcDir, file)
         const content = await fs.promises.readFile(filePath, 'utf8')
         const filename = path.basename(file, '.liquid')
-
-        let layout = 'full'
-        if (filename.includes('half_horizontal'))
-          layout = 'half_horizontal'
-        else if (filename.includes('half_vertical'))
-          layout = 'half_vertical'
-        else if (filename.includes('quadrant'))
-          layout = 'quadrant'
+        const layout = layoutFromTemplateFilename(filename)
 
         templates.push({
           layout,
@@ -465,14 +465,7 @@ export class PluginImporterService {
     this.logger.debug(`Parsed settings: ${JSON.stringify(settings)}`)
     this.logger.debug(`Found ${templates.length} templates`)
 
-    // Name can be in manifest, settings, or use filename fallback
-    const pluginName = (manifest.name && manifest.name.trim() !== '')
-      ? manifest.name.trim()
-      : (settings.name && settings.name.trim() !== '')
-          ? settings.name.trim()
-          : fallbackName.replace(/[_-]/g, ' ').replace(/\.trmnlp$/, '')
-
-    const nameSource = manifest.name ? 'manifest' : settings.name ? 'settings' : 'filename'
+    const { name: pluginName, source: nameSource } = this.resolvePluginName(manifest, settings, fallbackName)
     this.logger.log(`Using plugin name: ${pluginName} (from ${nameSource})`)
 
     if (settings.data_source) {
@@ -483,32 +476,8 @@ export class PluginImporterService {
       throw new Error('At least one .liquid template file is required in src/ directory (e.g., src/full.liquid)')
     }
 
-    const hasDataSourcesArray = Array.isArray(settings.data_sources) && settings.data_sources.length > 0
-
-    if (hasDataSourcesArray && transformJs) {
-      this.logger.warn('Ignoring src/transform.js: settings.yml uses the "data_sources" array format, where each entry carries its own "transform_js" instead')
-    }
-
-    const dataSources = forcedDataSources
-      ?? (hasDataSourcesArray
-        ? this.parseDataSourcesArray(settings.data_sources!)
-        : [this.parseLegacySingleDataSource(settings, transformJs)])
-
-    // custom_fields can be in manifest or settings, can be empty object {}, missing, or an array
-    const customFieldsSource = Array.isArray(manifest.custom_fields)
-      ? manifest.custom_fields
-      : Array.isArray(settings.custom_fields)
-        ? settings.custom_fields
-        : []
-    const fields = customFieldsSource.map((field, index) => ({
-      keyname: field.keyname,
-      fieldType: field.field_type,
-      name: field.name,
-      description: field.description,
-      defaultValue: field.default_value,
-      required: !field.optional,
-      order: index + 1,
-    }))
+    const dataSources = forcedDataSources ?? this.resolveDataSources(settings, transformJs)
+    const fields = this.resolveFields(manifest, settings)
 
     return {
       name: pluginName,
@@ -521,73 +490,119 @@ export class PluginImporterService {
     }
   }
 
+  // Name can be in manifest, settings, or use filename fallback
+  private resolvePluginName(
+    manifest: TerminusManifest,
+    settings: TerminusSettings,
+    fallbackName: string,
+  ): { name: string, source: 'manifest' | 'settings' | 'filename' } {
+    const name = (manifest.name && manifest.name.trim() !== '')
+      ? manifest.name.trim()
+      : (settings.name && settings.name.trim() !== '')
+          ? settings.name.trim()
+          : fallbackName.replace(/[_-]/g, ' ').replace(/\.trmnlp$/, '')
+
+    const source = manifest.name ? 'manifest' : settings.name ? 'settings' : 'filename'
+
+    return { name, source }
+  }
+
+  private resolveDataSources(settings: TerminusSettings, transformJs?: string): ParsedDataSource[] {
+    const hasDataSourcesArray = Array.isArray(settings.data_sources) && settings.data_sources.length > 0
+
+    if (hasDataSourcesArray && transformJs) {
+      this.logger.warn('Ignoring src/transform.js: settings.yml uses the "data_sources" array format, where each entry carries its own "transform_js" instead')
+    }
+
+    return hasDataSourcesArray
+      ? this.parseDataSourcesArray(settings.data_sources!)
+      : [this.parseLegacySingleDataSource(settings, transformJs)]
+  }
+
+  // custom_fields can be in manifest or settings, can be empty object {}, missing, or an array
+  private resolveFields(manifest: TerminusManifest, settings: TerminusSettings): ParsedPlugin['fields'] {
+    const customFieldsSource = Array.isArray(manifest.custom_fields)
+      ? manifest.custom_fields
+      : Array.isArray(settings.custom_fields)
+        ? settings.custom_fields
+        : []
+
+    return customFieldsSource.map((field, index) => ({
+      keyname: field.keyname,
+      fieldType: field.field_type,
+      name: field.name,
+      description: field.description,
+      defaultValue: field.default_value,
+      required: !field.optional,
+      order: index + 1,
+    }))
+  }
+
   private parseDataSourcesArray(entries: DataSourceEntry[]): ParsedDataSource[] {
     return entries.map((entry, index) => {
       const name = entry.name && entry.name.trim() !== '' ? entry.name.trim() : `source_${index + 1}`
 
-      if (entry.mode === 'literal') {
-        return {
-          name,
-          mode: 'literal' as const,
-          literalValue: entry.literal_value ?? {},
-        }
-      }
-
-      if (!entry.endpoint || entry.endpoint.trim() === '') {
-        throw new Error(`Data source at index ${index} is missing an "endpoint"`)
-      }
-
-      return {
-        name,
-        mode: 'fetch' as const,
-        method: (entry.method || 'GET').toUpperCase(),
-        url: entry.endpoint.trim(),
-        headers: entry.headers || {},
-        body: entry.body || {},
-        transformJs: entry.transform_js || null,
-      }
+      return entry.mode === 'literal'
+        ? this.parseLiteralEntry(entry, name)
+        : this.parseFetchEntry(entry, name, index)
     })
+  }
+
+  private parseLiteralEntry(entry: DataSourceEntry, name: string): ParsedDataSource {
+    return {
+      name,
+      mode: 'literal',
+      literalValue: entry.literal_value ?? {},
+    }
+  }
+
+  private parseFetchEntry(entry: DataSourceEntry, name: string, index: number): ParsedDataSource {
+    if (!entry.endpoint || entry.endpoint.trim() === '') {
+      throw new Error(`Data source at index ${index} is missing an "endpoint"`)
+    }
+
+    return {
+      name,
+      mode: 'fetch',
+      method: (entry.method || 'GET').toUpperCase(),
+      url: entry.endpoint.trim(),
+      headers: entry.headers || {},
+      body: entry.body || {},
+      transformJs: entry.transform_js || null,
+    }
   }
 
   private parseLegacySingleDataSource(settings: TerminusSettings, transformJs?: string): ParsedDataSource {
     // Support both our previous format (endpoint/method) and Terminus's own format (polling_url/polling_verb)
     const endpoint = settings.endpoint || settings.polling_url
-    const method = settings.method || settings.polling_verb
 
     if (!endpoint || endpoint.trim() === '') {
       throw new Error('Data source endpoint is required in src/settings.yml. Expected format:\npolling_url: https://api.example.com/data\npolling_verb: get')
     }
 
-    // Parse headers if they're a string (Terminus format)
-    let headers = settings.headers || {}
-    if (typeof settings.polling_headers === 'string' && settings.polling_headers.trim()) {
-      try {
-        headers = JSON.parse(settings.polling_headers)
-      }
-      catch {
-        this.logger.warn('Failed to parse polling_headers as JSON, using empty object')
-      }
-    }
-
-    // Parse body if it's a string (Terminus format)
-    let body = settings.body || {}
-    if (typeof settings.polling_body === 'string' && settings.polling_body.trim()) {
-      try {
-        body = JSON.parse(settings.polling_body)
-      }
-      catch {
-        this.logger.warn('Failed to parse polling_body as JSON, using empty object')
-      }
-    }
-
     return {
       name: 'source',
       mode: 'fetch',
-      method: method?.toUpperCase() || 'GET',
+      method: (settings.method || settings.polling_verb)?.toUpperCase() || 'GET',
       url: endpoint.trim(),
-      headers,
-      body,
+      headers: this.parseLegacyJsonField(settings.headers, settings.polling_headers, 'polling_headers'),
+      body: this.parseLegacyJsonField(settings.body, settings.polling_body, 'polling_body'),
       transformJs: transformJs || null,
     }
+  }
+
+  // Terminus ships headers/body as JSON-encoded strings (polling_headers/polling_body);
+  // our own format carries them as plain objects. Falls back to the plain-object value
+  // (or {}) if the string isn't valid JSON.
+  private parseLegacyJsonField<T>(fallback: T | undefined, raw: string | undefined, fieldName: string): T {
+    if (typeof raw === 'string' && raw.trim()) {
+      try {
+        return JSON.parse(raw) as T
+      }
+      catch {
+        this.logger.warn(`Failed to parse ${fieldName} as JSON, using empty object`)
+      }
+    }
+    return (fallback ?? {}) as T
   }
 }

--- a/packages/api/src/plugins/services/plugin-importer.service.ts
+++ b/packages/api/src/plugins/services/plugin-importer.service.ts
@@ -31,6 +31,8 @@ export function layoutFromTemplateFilename(filename: string): TemplateLayout {
   return match ? match[1] : 'full'
 }
 
+const KNOWN_TEMPLATE_LAYOUT_NAMES: string[] = ['full', ...TEMPLATE_LAYOUTS.map(([substring]) => substring)]
+
 interface TerminusManifest {
   name?: string
   description?: string
@@ -259,7 +261,7 @@ export class PluginImporterService {
     // Process layout templates (skip shared.liquid, transform.js, etc.)
     const layoutEntries = templateEntries.filter((entry) => {
       const filename = path.basename(entry.entryName, '.liquid')
-      return ['full', 'half_horizontal', 'half_vertical', 'quadrant'].some(layout => filename.includes(layout))
+      return KNOWN_TEMPLATE_LAYOUT_NAMES.some(layout => filename.includes(layout))
     })
 
     const templates = layoutEntries.map((entry) => {


### PR DESCRIPTION
## What

Reduces cyclomatic/cognitive complexity in `PluginImporterService` and removes a duplicated layout-detection code path, per the fallow health finding baselined in #851.

- Extracted `layoutFromTemplateFilename(filename): TemplateLayout`, a lookup over an ordered `TEMPLATE_LAYOUTS` list, and used it in both the ZIP import path and the directory/YAML import path, replacing two copies of an `if`/`else if` chain. The `layoutEntries` filter (which used its own separate hardcoded layout-name list) now derives its list from the same `TEMPLATE_LAYOUTS` constant, so there's a single source of truth for known layout names.
- Split `buildParsedPlugin` into `resolvePluginName`, `resolveDataSources`, and `resolveFields`, each handling one concern instead of one function doing all three. The original throw order (legacy `data_source` check before the empty-templates check) and name/data-source resolution logic are preserved exactly.
- Split `parseDataSourcesArray`'s map callback into `parseLiteralEntry` / `parseFetchEntry`, chosen by `entry.mode`.
- Flattened `parseLegacySingleDataSource`'s duplicated header/body JSON-parsing logic into a shared `parseLegacyJsonField` helper.
- Added unit tests for the new `layoutFromTemplateFilename` helper.

No behavior changes — this is a pure refactor; the existing 26-case import/export test suite pins behavior and passes unmodified (only extended with the new helper's tests).

## Why

`plugin-importer.service.ts` was flagged by `fallow health` as a churn hotspot with four functions exceeding complexity thresholds (`buildParsedPlugin`: cyclomatic 17, `parseLegacySingleDataSource`: cyclomatic 15, `importFromYaml`: cyclomatic 10, `parseDataSourcesArray`'s map callback: cyclomatic 11) plus a duplicated layout-detection code path (`half_horizontal`/`half_vertical`/`quadrant`/default `full`) between the ZIP and directory/YAML import paths.

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm type-check` passes
- [x] `pnpm test` passes (757 passed, 38 skipped in `packages/api`; 297 passed in `packages/ui`)
- [x] `pnpm fallow:baseline` re-run — the plugin-importer.service.ts complexity and duplication findings are gone from `.fallow-baselines/`
- [x] `pnpm fallow:ci` passes
- [x] `/code-review` run against merge-base with `origin/main`; one finding (a leftover hardcoded layout-name list duplicating the new `TEMPLATE_LAYOUTS` constant) fixed in a follow-up commit

Closes #851

---
*Opened by Kongroo, karakuri's Projects agent — Stage: implement*