### PR TITLE
refactor(ui): split remaining moderate/high complexity hotspots

### DIFF
--- a/.fallow-baselines/dupes.baseline.json
+++ b/.fallow-baselines/dupes.baseline.json
@@ -13,8 +13,8 @@
   ],
   "normalized_clone_fingerprints": [
     "dup:c61b2099:2",
-    "dup:c77b3abb6f87acd9-4:2",
     "dup:c77b3abb6f87acd9-3:2",
-    "dup:c77b3abb6f87acd9-2:2"
+    "dup:c77b3abb6f87acd9-2:2",
+    "dup:c77b3abb6f87acd9-1:2"
   ]
 }

--- a/.fallow-baselines/health.baseline.json
+++ b/.fallow-baselines/health.baseline.json
@@ -52,24 +52,6 @@
         "count": 1
       }
     },
-    "packages/ui/src/components/PluginCard.vue": {
-      "complexity_moderate": {
-        "count": 1
-      }
-    },
-    "packages/ui/src/components/PluginImportDialog.vue": {
-      "complexity_high": {
-        "count": 1
-      },
-      "crap_high": {
-        "count": 1
-      }
-    },
-    "packages/ui/src/components/ScreenScheduleDialog.vue": {
-      "crap_high": {
-        "count": 1
-      }
-    },
     "packages/ui/src/composeables/usePluginPreview.ts": {
       "crap_moderate": {
         "count": 1
@@ -79,16 +61,10 @@
       "complexity_high": {
         "count": 1
       }
-    },
-    "packages/ui/src/views/VirtualDeviceView.vue": {
-      "crap_moderate": {
-        "count": 1
-      }
     }
   },
   "runtime_coverage_findings": [],
   "target_keys": [
-    "packages/api/src/plugins/plugins.service.ts:complexity",
     "packages/api/src/devices/display.service.ts:complexity",
     "packages/ui/src/utils/apiRequest.ts:high impact"
   ]

--- a/packages/ui/src/components/PluginCard.vue
+++ b/packages/ui/src/components/PluginCard.vue
@@ -1,12 +1,9 @@
 <script setup lang="ts">
 import type { Plugin } from '../types/plugin'
-import { mdiAccountMultiple, mdiDelete, mdiDownload, mdiPencil, mdiPower } from '@mdi/js'
-import { computed, ref } from 'vue'
-import { useRouter } from 'vue-router'
-import { VBtn, VCard, VCardActions, VCardText, VCardTitle, VChip, VDialog, VDivider, VSnackbar, VSpacer } from 'vuetify/components'
-import { usePluginsStore } from '../stores/plugins'
-import { withBasePath } from '../utils/basePath'
-import PluginAssignDialog from './PluginAssignDialog.vue'
+import { mdiAccountMultiple } from '@mdi/js'
+import { computed } from 'vue'
+import { VCard, VCardText, VCardTitle, VChip, VDivider } from 'vuetify/components'
+import PluginCardActions from './PluginCardActions.vue'
 
 const props = defineProps<{
   plugin: Plugin
@@ -18,74 +15,11 @@ const emit = defineEmits<{
   deleted: []
 }>()
 
-const router = useRouter()
-const pluginsStore = usePluginsStore()
-
-const showAssignDialog = ref(false)
-const showDeleteDialog = ref(false)
-const showExportSnackbar = ref(false)
-
 const assignedCount = computed(() => props.plugin.deviceAssignments?.length || 0)
-
-const loadingDelete = ref(false)
-async function confirmDelete() {
-  loadingDelete.value = true
-  try {
-    await pluginsStore.deletePlugin(props.plugin.id, props.deviceId)
-    showDeleteDialog.value = false
-    emit('deleted')
-  }
-  finally {
-    loadingDelete.value = false
-  }
-}
-
-function deletePlugin() {
-  showDeleteDialog.value = true
-}
-
-const loadingToggle = ref(false)
-async function toggleActive() {
-  loadingToggle.value = true
-  try {
-    // If we have deviceId and _devicePluginId, toggle assignment
-    if (props.deviceId && props.plugin._devicePluginId) {
-      await pluginsStore.updateDeviceAssignment(props.plugin._devicePluginId, {
-        isActive: !props.plugin._isActive,
-      })
-      if (props.deviceId) {
-        await pluginsStore.fetchPluginsForDevice(props.deviceId)
-      }
-    }
-  }
-  finally {
-    loadingToggle.value = false
-  }
-}
-
-function editPlugin() {
-  router.push({ name: 'pluginEdit', params: { id: props.plugin.id } })
-}
-
-function exportPlugin() {
-  window.location.href = withBasePath(`/api/plugins/${props.plugin.id}/export`)
-  showExportSnackbar.value = true
-}
-
-function openAssignDialog() {
-  showAssignDialog.value = true
-}
-
-function onAssigned() {
-  emit('assignmentsChanged')
-}
 </script>
 
 <template>
   <VCard elevation="1" class="h-100">
-    <VSnackbar v-model="showExportSnackbar" :timeout="3000" color="success">
-      Downloading plugin export...
-    </VSnackbar>
     <VCardTitle class="d-flex align-center justify-space-between flex-wrap ga-2">
       <span>{{ plugin.name }}</span>
       <div class="d-flex ga-2">
@@ -116,93 +50,11 @@ function onAssigned() {
         No description
       </div>
     </VCardText>
-    <VCardActions class="d-flex ga-2 flex-wrap">
-      <VBtn
-        variant="tonal"
-        size="small"
-        :prepend-icon="mdiPencil"
-        @click="editPlugin"
-      >
-        Edit
-      </VBtn>
-      <VBtn
-        v-if="!deviceId"
-        variant="tonal"
-        size="small"
-        :prepend-icon="mdiAccountMultiple"
-        @click="openAssignDialog"
-      >
-        Assign to Devices
-      </VBtn>
-      <VBtn
-        v-if="deviceId"
-        variant="tonal"
-        size="small"
-        :prepend-icon="mdiPower"
-        :color="plugin._isActive ? 'default' : 'success'"
-        :loading="loadingToggle"
-        @click="toggleActive"
-      >
-        {{ plugin._isActive ? 'Disable' : 'Enable' }}
-      </VBtn>
-      <VBtn
-        variant="tonal"
-        size="small"
-        :prepend-icon="mdiDownload"
-        @click="exportPlugin"
-      >
-        Export
-      </VBtn>
-      <VSpacer />
-      <VBtn
-        variant="tonal"
-        size="small"
-        color="error"
-        :prepend-icon="mdiDelete"
-        :loading="loadingDelete"
-        @click="deletePlugin"
-      >
-        Delete
-      </VBtn>
-    </VCardActions>
-
-    <PluginAssignDialog
-      v-model="showAssignDialog"
+    <PluginCardActions
       :plugin="plugin"
-      @assigned="onAssigned"
+      :device-id="deviceId"
+      @assignments-changed="emit('assignmentsChanged')"
+      @deleted="emit('deleted')"
     />
-
-    <VDialog v-model="showDeleteDialog" max-width="500">
-      <VCard>
-        <VCardTitle>Delete Plugin?</VCardTitle>
-        <VDivider />
-        <VCardText>
-          <p class="mb-2">
-            Are you sure you want to delete <strong>{{ plugin.name }}</strong>?
-          </p>
-          <p v-if="assignedCount > 0" class="text-error">
-            This plugin is assigned to {{ assignedCount }} device{{ assignedCount !== 1 ? 's' : '' }}. Deleting it will remove it from all devices.
-          </p>
-          <p class="text-medium-emphasis text-body-2">
-            This action cannot be undone.
-          </p>
-        </VCardText>
-        <VDivider />
-        <VCardActions>
-          <VSpacer />
-          <VBtn variant="text" @click="showDeleteDialog = false">
-            Cancel
-          </VBtn>
-          <VBtn
-            color="error"
-            variant="tonal"
-            :loading="loadingDelete"
-            @click="confirmDelete"
-          >
-            Delete
-          </VBtn>
-        </VCardActions>
-      </VCard>
-    </VDialog>
   </VCard>
 </template>

--- a/packages/ui/src/components/PluginCardActions.vue
+++ b/packages/ui/src/components/PluginCardActions.vue
@@ -1,0 +1,173 @@
+<script setup lang="ts">
+import type { Plugin } from '../types/plugin'
+import { mdiAccountMultiple, mdiDelete, mdiDownload, mdiPencil, mdiPower } from '@mdi/js'
+import { computed, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { VBtn, VCard, VCardActions, VCardText, VCardTitle, VDialog, VDivider, VSnackbar, VSpacer } from 'vuetify/components'
+import { usePluginsStore } from '../stores/plugins'
+import { withBasePath } from '../utils/basePath'
+import PluginAssignDialog from './PluginAssignDialog.vue'
+
+const props = defineProps<{
+  plugin: Plugin
+  deviceId?: string
+}>()
+
+const emit = defineEmits<{
+  assignmentsChanged: []
+  deleted: []
+}>()
+
+const router = useRouter()
+const pluginsStore = usePluginsStore()
+
+const showAssignDialog = ref(false)
+const showDeleteDialog = ref(false)
+const showExportSnackbar = ref(false)
+
+const assignedCount = computed(() => props.plugin.deviceAssignments?.length || 0)
+
+const loadingDelete = ref(false)
+async function confirmDelete() {
+  loadingDelete.value = true
+  try {
+    await pluginsStore.deletePlugin(props.plugin.id, props.deviceId)
+    showDeleteDialog.value = false
+    emit('deleted')
+  }
+  finally {
+    loadingDelete.value = false
+  }
+}
+
+function deletePlugin() {
+  showDeleteDialog.value = true
+}
+
+const loadingToggle = ref(false)
+async function toggleActive() {
+  loadingToggle.value = true
+  try {
+    if (props.deviceId && props.plugin._devicePluginId) {
+      await pluginsStore.updateDeviceAssignment(props.plugin._devicePluginId, {
+        isActive: !props.plugin._isActive,
+      })
+      await pluginsStore.fetchPluginsForDevice(props.deviceId)
+    }
+  }
+  finally {
+    loadingToggle.value = false
+  }
+}
+
+function editPlugin() {
+  router.push({ name: 'pluginEdit', params: { id: props.plugin.id } })
+}
+
+function exportPlugin() {
+  window.location.href = withBasePath(`/api/plugins/${props.plugin.id}/export`)
+  showExportSnackbar.value = true
+}
+
+function openAssignDialog() {
+  showAssignDialog.value = true
+}
+
+function onAssigned() {
+  emit('assignmentsChanged')
+}
+</script>
+
+<template>
+  <VSnackbar v-model="showExportSnackbar" :timeout="3000" color="success">
+    Downloading plugin export...
+  </VSnackbar>
+  <VCardActions class="d-flex ga-2 flex-wrap">
+    <VBtn
+      variant="tonal"
+      size="small"
+      :prepend-icon="mdiPencil"
+      @click="editPlugin"
+    >
+      Edit
+    </VBtn>
+    <VBtn
+      v-if="!deviceId"
+      variant="tonal"
+      size="small"
+      :prepend-icon="mdiAccountMultiple"
+      @click="openAssignDialog"
+    >
+      Assign to Devices
+    </VBtn>
+    <VBtn
+      v-if="deviceId"
+      variant="tonal"
+      size="small"
+      :prepend-icon="mdiPower"
+      :color="plugin._isActive ? 'default' : 'success'"
+      :loading="loadingToggle"
+      @click="toggleActive"
+    >
+      {{ plugin._isActive ? 'Disable' : 'Enable' }}
+    </VBtn>
+    <VBtn
+      variant="tonal"
+      size="small"
+      :prepend-icon="mdiDownload"
+      @click="exportPlugin"
+    >
+      Export
+    </VBtn>
+    <VSpacer />
+    <VBtn
+      variant="tonal"
+      size="small"
+      color="error"
+      :prepend-icon="mdiDelete"
+      :loading="loadingDelete"
+      @click="deletePlugin"
+    >
+      Delete
+    </VBtn>
+  </VCardActions>
+
+  <PluginAssignDialog
+    v-model="showAssignDialog"
+    :plugin="plugin"
+    @assigned="onAssigned"
+  />
+
+  <VDialog v-model="showDeleteDialog" max-width="500">
+    <VCard>
+      <VCardTitle>Delete Plugin?</VCardTitle>
+      <VDivider />
+      <VCardText>
+        <p class="mb-2">
+          Are you sure you want to delete <strong>{{ plugin.name }}</strong>?
+        </p>
+        <p v-if="assignedCount > 0" class="text-error">
+          This plugin is assigned to {{ assignedCount }} device{{ assignedCount !== 1 ? 's' : '' }}. Deleting it will remove it from all devices.
+        </p>
+        <p class="text-medium-emphasis text-body-2">
+          This action cannot be undone.
+        </p>
+      </VCardText>
+      <VDivider />
+      <VCardActions>
+        <VSpacer />
+        <VBtn variant="text" @click="showDeleteDialog = false">
+          Cancel
+        </VBtn>
+        <VBtn
+          color="error"
+          variant="tonal"
+          :loading="loadingDelete"
+          @click="confirmDelete"
+        >
+          Delete
+        </VBtn>
+      </VCardActions>
+    </VCard>
+  </VDialog>
+</template>

--- a/packages/ui/src/components/PluginImportDialog.vue
+++ b/packages/ui/src/components/PluginImportDialog.vue
@@ -3,7 +3,7 @@ import { mdiUpload } from '@mdi/js'
 import { ref } from 'vue'
 import { VAlert, VBtn, VCard, VCardActions, VCardText, VCardTitle, VDialog, VDivider, VFileInput, VSelect, VTab, VTabs, VTextField, VWindow, VWindowItem } from 'vuetify/components'
 import { useDeviceStore } from '../stores/device'
-import { apiFetch } from '../utils/apiRequest'
+import { apiRequest } from '../utils/apiRequest'
 import { errorMessage } from '../utils/errorMessage'
 
 defineProps<{
@@ -17,7 +17,7 @@ const emit = defineEmits<{
 
 const deviceStore = useDeviceStore()
 
-const importTab = ref('file')
+const importTab = ref<'file' | 'github' | 'recipe'>('file')
 const selectedFile = ref<File | null>(null)
 const githubUrl = ref('')
 const recipeId = ref('')
@@ -33,6 +33,44 @@ function onFileChange(files: File | File[]) {
   }
 }
 
+async function importFromFile(deviceId: string) {
+  if (!selectedFile.value) {
+    throw new Error('Please select a file')
+  }
+  const formData = new FormData()
+  formData.append('file', selectedFile.value)
+  formData.append('deviceId', deviceId)
+  await apiRequest('/api/plugins/import', { method: 'POST', body: formData }, 'Import failed')
+}
+
+async function importFromGithub(deviceId: string) {
+  if (!githubUrl.value) {
+    throw new Error('Please enter a GitHub URL')
+  }
+  await apiRequest('/api/plugins/import-github', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ githubUrl: githubUrl.value, deviceId }),
+  }, 'Import failed')
+}
+
+async function importFromRecipe(deviceId: string) {
+  if (!recipeId.value) {
+    throw new Error('Please enter a Recipe id or URL')
+  }
+  await apiRequest('/api/plugins/import-recipe', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ recipeId: recipeId.value, deviceId }),
+  }, 'Import failed')
+}
+
+const importBySource: Record<typeof importTab.value, (deviceId: string) => Promise<unknown>> = {
+  file: importFromFile,
+  github: importFromGithub,
+  recipe: importFromRecipe,
+}
+
 async function importPlugin() {
   if (!selectedDeviceId.value) {
     error.value = 'Please select a device'
@@ -43,67 +81,7 @@ async function importPlugin() {
   error.value = ''
 
   try {
-    if (importTab.value === 'file') {
-      if (!selectedFile.value) {
-        error.value = 'Please select a file'
-        return
-      }
-
-      const formData = new FormData()
-      formData.append('file', selectedFile.value)
-      formData.append('deviceId', selectedDeviceId.value)
-
-      const res = await apiFetch('/api/plugins/import', {
-        method: 'POST',
-        body: formData,
-      })
-
-      if (!res.ok) {
-        const errorData = await res.json()
-        throw new Error(errorData.message || 'Import failed')
-      }
-    }
-    else if (importTab.value === 'github') {
-      if (!githubUrl.value) {
-        error.value = 'Please enter a GitHub URL'
-        return
-      }
-
-      const res = await apiFetch('/api/plugins/import-github', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          githubUrl: githubUrl.value,
-          deviceId: selectedDeviceId.value,
-        }),
-      })
-
-      if (!res.ok) {
-        const errorData = await res.json()
-        throw new Error(errorData.message || 'Import failed')
-      }
-    }
-    else {
-      if (!recipeId.value) {
-        error.value = 'Please enter a Recipe id or URL'
-        return
-      }
-
-      const res = await apiFetch('/api/plugins/import-recipe', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          recipeId: recipeId.value,
-          deviceId: selectedDeviceId.value,
-        }),
-      })
-
-      if (!res.ok) {
-        const errorData = await res.json()
-        throw new Error(errorData.message || 'Import failed')
-      }
-    }
-
+    await importBySource[importTab.value](selectedDeviceId.value)
     emit('imported')
     close()
   }
@@ -135,7 +113,7 @@ function close() {
           <strong>Beta Feature:</strong> Terminus plugin import is experimental. Some plugins may not work correctly due to API authentication requirements or missing functionality.
         </VAlert>
 
-        <VAlert v-if="error" type="error" variant="tonal" class="mb-4">
+        <VAlert v-if="error" type="error" variant="tonal" class="mb-4" data-test-id="import-error">
           {{ error }}
         </VAlert>
 
@@ -169,6 +147,7 @@ function close() {
           <VWindowItem value="github">
             <VTextField
               v-model="githubUrl"
+              data-test-id="github-url"
               label="GitHub Repository URL"
               placeholder="https://github.com/owner/repo"
               hint="Enter the URL of a GitHub repository containing a Terminus plugin"
@@ -182,6 +161,7 @@ function close() {
           <VWindowItem value="recipe">
             <VTextField
               v-model="recipeId"
+              data-test-id="recipe-id"
               label="TRMNL Recipe id or URL"
               placeholder="150460 or https://trmnl.com/recipes/150460"
               hint="Enter a Recipe's numeric id or its trmnl.com/recipes/... page URL"
@@ -195,6 +175,7 @@ function close() {
 
         <VSelect
           v-model="selectedDeviceId"
+          data-test-id="import-device-select"
           label="Target Device"
           :items="deviceStore.devices"
           item-title="name"
@@ -213,6 +194,7 @@ function close() {
         <VBtn
           color="primary"
           variant="tonal"
+          data-test-id="import-submit"
           :loading="loading"
           :disabled="(!selectedFile && !githubUrl && !recipeId) || !selectedDeviceId"
           @click="importPlugin"

--- a/packages/ui/src/components/ScreenScheduleDialog.vue
+++ b/packages/ui/src/components/ScreenScheduleDialog.vue
@@ -32,16 +32,30 @@ const saving = ref(false)
 const hasSchedule = computed(() => Boolean(props.screen.schedule))
 const spansMidnight = computed(() => Boolean(startTime.value && endTime.value && startTime.value > endTime.value))
 
+function scheduleToForm(schedule: Screen['schedule']) {
+  if (!schedule) {
+    return { enabled: true, weekdays: [], startTime: '', endTime: '', startDate: '', endDate: '' }
+  }
+  return {
+    enabled: schedule.enabled,
+    weekdays: schedule.weekdays ? [...schedule.weekdays] : [],
+    startTime: schedule.startTime ? withoutSeconds(schedule.startTime) : '',
+    endTime: schedule.endTime ? withoutSeconds(schedule.endTime) : '',
+    startDate: schedule.startDate ?? '',
+    endDate: schedule.endDate ?? '',
+  }
+}
+
 watch(() => props.modelValue, (open) => {
   if (!open)
     return
-  const schedule = props.screen.schedule
-  enabled.value = schedule?.enabled ?? true
-  weekdays.value = schedule?.weekdays ? [...schedule.weekdays] : []
-  startTime.value = schedule?.startTime ? withoutSeconds(schedule.startTime) : ''
-  endTime.value = schedule?.endTime ? withoutSeconds(schedule.endTime) : ''
-  startDate.value = schedule?.startDate ?? ''
-  endDate.value = schedule?.endDate ?? ''
+  const form = scheduleToForm(props.screen.schedule)
+  enabled.value = form.enabled
+  weekdays.value = form.weekdays
+  startTime.value = form.startTime
+  endTime.value = form.endTime
+  startDate.value = form.startDate
+  endDate.value = form.endDate
   error.value = null
 }, { immediate: true })
 

--- a/packages/ui/src/components/__test__/PluginCard.spec.ts
+++ b/packages/ui/src/components/__test__/PluginCard.spec.ts
@@ -36,11 +36,8 @@ vi.mock('@/stores/plugins', () => ({
   usePluginsStore: () => pluginsStoreMock,
 }))
 
-const mockRouter = {
-  push: vi.fn(),
-}
 vi.mock('vue-router', () => ({
-  useRouter: () => mockRouter,
+  useRouter: () => ({ push: vi.fn() }),
 }))
 
 vi.mock('../PluginAssignDialog.vue', () => ({
@@ -57,7 +54,6 @@ describe('pluginCard', () => {
       updateDeviceAssignment: vi.fn(),
       fetchPluginsForDevice: vi.fn(),
     })
-    mockRouter.push.mockClear()
   })
 
   const basePlugin: Plugin = {
@@ -126,60 +122,6 @@ describe('pluginCard', () => {
     expect(wrapper.text()).toContain('Active')
   })
 
-  it('shows edit button and navigates on click', async () => {
-    const wrapper = mount(PluginCard, {
-      props: { plugin: basePlugin },
-      global: {
-        plugins: [createPinia(), vuetify],
-      },
-    })
-
-    const editBtn = wrapper.findAll('button').find(btn => btn.text().includes('Edit'))
-    expect(editBtn).toBeTruthy()
-    await editBtn!.trigger('click')
-
-    expect(mockRouter.push).toHaveBeenCalledWith({
-      name: 'pluginEdit',
-      params: { id: 'plugin-1' },
-    })
-  })
-
-  it('shows assign button when not on device page', () => {
-    const wrapper = mount(PluginCard, {
-      props: { plugin: basePlugin },
-      global: {
-        plugins: [createPinia(), vuetify],
-      },
-    })
-
-    expect(wrapper.text()).toContain('Assign to Devices')
-  })
-
-  it('shows enable/disable button when on device page', () => {
-    const plugin = {
-      ...basePlugin,
-      _isActive: true,
-      _devicePluginId: 'dp-1',
-    }
-    const wrapper = mount(PluginCard, {
-      props: { plugin, deviceId: 'device-1' },
-      global: {
-        plugins: [createPinia(), vuetify],
-      },
-    })
-
-    expect(wrapper.text()).toContain('Disable')
-  })
-
-  it('shows delete button', async () => {
-    const wrapper = mount(PluginCard, {
-      props: { plugin: basePlugin },
-      global: {
-        plugins: [createPinia(), vuetify],
-      },
-    })
-
-    const deleteBtn = wrapper.findAll('button').find(btn => btn.text().includes('Delete'))
-    expect(deleteBtn).toBeTruthy()
-  })
+  // Action-button behavior (edit/assign/toggle/export/delete) lives in PluginCardActions.vue
+  // now and is covered by PluginCardActions.spec.ts.
 })

--- a/packages/ui/src/components/__test__/PluginCardActions.spec.ts
+++ b/packages/ui/src/components/__test__/PluginCardActions.spec.ts
@@ -1,0 +1,201 @@
+import type { usePluginsStore } from '@/stores/plugins'
+import type { Plugin } from '@/types/plugin'
+import { flushPromises, mount } from '@vue/test-utils'
+import { createPinia } from 'pinia'
+import rop from 'resize-observer-polyfill'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import vuetify from '../../plugins/vuetify'
+import { asStore } from '../../test/mockStore'
+import PluginCardActions from '../PluginCardActions.vue'
+
+globalThis.ResizeObserver = rop
+
+globalThis.window.matchMedia = globalThis.window.matchMedia || function () {
+  return {
+    matches: false,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  }
+}
+
+Object.defineProperty(globalThis, 'visualViewport', {
+  value: {
+    width: 1024,
+    height: 768,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  },
+  writable: true,
+})
+
+let pluginsStoreMock: ReturnType<typeof usePluginsStore>
+vi.mock('@/stores/plugins', () => ({
+  usePluginsStore: () => pluginsStoreMock,
+}))
+
+const mockRouter = {
+  push: vi.fn(),
+}
+vi.mock('vue-router', () => ({
+  useRouter: () => mockRouter,
+}))
+
+vi.mock('../PluginAssignDialog.vue', () => ({
+  default: {
+    name: 'PluginAssignDialog',
+    props: ['modelValue', 'plugin'],
+    emits: ['update:modelValue', 'assigned'],
+    template: '<div data-test-id="assign-dialog-stub" />',
+  },
+}))
+
+const basePlugin: Plugin = {
+  id: 'plugin-1',
+  name: 'Test Plugin',
+  description: 'Test Description',
+  kind: 'Poll',
+  refreshInterval: 15,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+}
+
+function mountActions(props: { plugin: Plugin, deviceId?: string }) {
+  return mount(PluginCardActions, {
+    props,
+    global: { plugins: [createPinia(), vuetify] },
+    attachTo: document.body,
+  })
+}
+
+function findButton(wrapper: ReturnType<typeof mountActions>, text: string) {
+  return wrapper.findAll('button').find(btn => btn.text().includes(text))
+}
+
+describe('pluginCardActions', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    pluginsStoreMock = asStore<ReturnType<typeof usePluginsStore>>({
+      deletePlugin: vi.fn().mockResolvedValue(undefined),
+      updateDeviceAssignment: vi.fn().mockResolvedValue(undefined),
+      fetchPluginsForDevice: vi.fn().mockResolvedValue(undefined),
+    })
+    mockRouter.push.mockClear()
+  })
+
+  it('navigates to the edit route', async () => {
+    const wrapper = mountActions({ plugin: basePlugin })
+
+    await findButton(wrapper, 'Edit')!.trigger('click')
+
+    expect(mockRouter.push).toHaveBeenCalledWith({ name: 'pluginEdit', params: { id: 'plugin-1' } })
+  })
+
+  it('opens the assign dialog when not on a device page', async () => {
+    const wrapper = mountActions({ plugin: basePlugin })
+
+    await findButton(wrapper, 'Assign to Devices')!.trigger('click')
+
+    expect(wrapper.findComponent({ name: 'PluginAssignDialog' }).props('modelValue')).toBe(true)
+  })
+
+  it('forwards the assigned event from the dialog as assignmentsChanged', async () => {
+    const wrapper = mountActions({ plugin: basePlugin })
+
+    wrapper.findComponent({ name: 'PluginAssignDialog' }).vm.$emit('assigned')
+    await flushPromises()
+
+    expect(wrapper.emitted('assignmentsChanged')).toHaveLength(1)
+  })
+
+  it('toggles an active assignment off and refreshes the device plugin list', async () => {
+    const plugin = { ...basePlugin, _isActive: true, _devicePluginId: 'dp-1' }
+    const wrapper = mountActions({ plugin, deviceId: 'device-1' })
+
+    await findButton(wrapper, 'Disable')!.trigger('click')
+
+    expect(pluginsStoreMock.updateDeviceAssignment).toHaveBeenCalledWith('dp-1', { isActive: false })
+    expect(pluginsStoreMock.fetchPluginsForDevice).toHaveBeenCalledWith('device-1')
+  })
+
+  it('toggles an inactive assignment on', async () => {
+    const plugin = { ...basePlugin, _isActive: false, _devicePluginId: 'dp-1' }
+    const wrapper = mountActions({ plugin, deviceId: 'device-1' })
+
+    await findButton(wrapper, 'Enable')!.trigger('click')
+
+    expect(pluginsStoreMock.updateDeviceAssignment).toHaveBeenCalledWith('dp-1', { isActive: true })
+  })
+
+  it('does not toggle when there is no device-plugin assignment yet', async () => {
+    const plugin = { ...basePlugin, _isActive: false }
+    const wrapper = mountActions({ plugin, deviceId: 'device-1' })
+
+    await findButton(wrapper, 'Enable')!.trigger('click')
+
+    expect(pluginsStoreMock.updateDeviceAssignment).not.toHaveBeenCalled()
+    expect(pluginsStoreMock.fetchPluginsForDevice).not.toHaveBeenCalled()
+  })
+
+  it('shows a snackbar and triggers a browser download on export', async () => {
+    const wrapper = mountActions({ plugin: basePlugin })
+    const originalLocation = window.location
+    Object.defineProperty(window, 'location', { value: { ...originalLocation, href: '' }, writable: true })
+
+    await findButton(wrapper, 'Export')!.trigger('click')
+
+    expect(window.location.href).toBe('/api/plugins/plugin-1/export')
+    expect(document.body.textContent).toContain('Downloading plugin export...')
+
+    Object.defineProperty(window, 'location', { value: originalLocation, writable: true })
+  })
+
+  it('asks for confirmation before deleting, and deletes on confirm', async () => {
+    const wrapper = mountActions({ plugin: basePlugin })
+
+    await findButton(wrapper, 'Delete')!.trigger('click')
+    expect(document.body.textContent).toContain('Delete Plugin?')
+    expect(pluginsStoreMock.deletePlugin).not.toHaveBeenCalled()
+
+    const confirmBtn = Array.from(document.querySelectorAll('button')).find(btn => btn.textContent?.trim() === 'Delete' && btn.closest('.v-overlay')) as HTMLElement
+    confirmBtn.click()
+    await flushPromises()
+
+    expect(pluginsStoreMock.deletePlugin).toHaveBeenCalledWith('plugin-1', undefined)
+    expect(wrapper.emitted('deleted')).toHaveLength(1)
+  })
+
+  it('warns about assigned devices in the delete confirmation', async () => {
+    const plugin = { ...basePlugin, deviceAssignments: [{ id: '1', isActive: true, order: 0, device: { id: '1', name: 'Device 1' } }] }
+    const wrapper = mountActions({ plugin })
+
+    await findButton(wrapper, 'Delete')!.trigger('click')
+
+    expect(document.body.textContent).toContain('This plugin is assigned to 1 device')
+  })
+
+  it('cancels the delete confirmation without deleting', async () => {
+    const wrapper = mountActions({ plugin: basePlugin })
+
+    await findButton(wrapper, 'Delete')!.trigger('click')
+    const cancelBtn = Array.from(document.querySelectorAll('button')).find(btn => btn.textContent?.trim() === 'Cancel') as HTMLElement
+    cancelBtn.click()
+    await flushPromises()
+
+    expect(pluginsStoreMock.deletePlugin).not.toHaveBeenCalled()
+    expect(document.querySelector('.v-overlay--active')).toBeNull()
+  })
+
+  it('passes the deviceId through to deletePlugin so devices can scope the delete', async () => {
+    const wrapper = mountActions({ plugin: basePlugin, deviceId: 'device-1' })
+
+    await findButton(wrapper, 'Delete')!.trigger('click')
+    const confirmBtn = Array.from(document.querySelectorAll('button')).find(btn => btn.textContent?.trim() === 'Delete' && btn.closest('.v-overlay')) as HTMLElement
+    confirmBtn.click()
+    await flushPromises()
+
+    expect(pluginsStoreMock.deletePlugin).toHaveBeenCalledWith('plugin-1', 'device-1')
+  })
+})

--- a/packages/ui/src/components/__test__/PluginCardActions.spec.ts
+++ b/packages/ui/src/components/__test__/PluginCardActions.spec.ts
@@ -5,6 +5,7 @@ import { createPinia } from 'pinia'
 import rop from 'resize-observer-polyfill'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import vuetify from '../../plugins/vuetify'
+import { stubVisualViewport } from '../../test/browser'
 import { asStore } from '../../test/mockStore'
 import PluginCardActions from '../PluginCardActions.vue'
 
@@ -21,15 +22,7 @@ globalThis.window.matchMedia = globalThis.window.matchMedia || function () {
   }
 }
 
-Object.defineProperty(globalThis, 'visualViewport', {
-  value: {
-    width: 1024,
-    height: 768,
-    addEventListener: () => {},
-    removeEventListener: () => {},
-  },
-  writable: true,
-})
+globalThis.visualViewport = globalThis.visualViewport || stubVisualViewport()
 
 let pluginsStoreMock: ReturnType<typeof usePluginsStore>
 vi.mock('@/stores/plugins', () => ({

--- a/packages/ui/src/components/__test__/PluginImportDialog.spec.ts
+++ b/packages/ui/src/components/__test__/PluginImportDialog.spec.ts
@@ -1,0 +1,184 @@
+import type { Mock } from 'vitest'
+import type { useDeviceStore } from '@/stores/device'
+import { flushPromises, mount } from '@vue/test-utils'
+import { createPinia } from 'pinia'
+import rop from 'resize-observer-polyfill'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { VFileInput, VSelect } from 'vuetify/components'
+import vuetify from '../../plugins/vuetify'
+import { stubVisualViewport } from '../../test/browser'
+import { jsonResponse, stubFetch } from '../../test/fetch'
+import { asStore } from '../../test/mockStore'
+import PluginImportDialog from '../PluginImportDialog.vue'
+
+globalThis.ResizeObserver = rop
+
+globalThis.window.matchMedia = globalThis.window.matchMedia || function () {
+  return {
+    matches: false,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  }
+}
+
+globalThis.visualViewport = globalThis.visualViewport || stubVisualViewport()
+
+let deviceStoreMock: ReturnType<typeof useDeviceStore>
+vi.mock('@/stores/device', () => ({
+  useDeviceStore: () => deviceStoreMock,
+}))
+
+function mountDialog() {
+  return mount(PluginImportDialog, {
+    props: { modelValue: true },
+    global: { plugins: [createPinia(), vuetify] },
+    attachTo: document.body,
+  })
+}
+
+function setInput(testId: string, value: string) {
+  const input = document.querySelector(`[data-test-id="${testId}"] input`) as HTMLInputElement
+  input.value = value
+  input.dispatchEvent(new Event('input'))
+  return flushPromises()
+}
+
+async function selectDevice(wrapper: ReturnType<typeof mountDialog>, deviceId: string) {
+  await wrapper.findComponent(VSelect).vm.$emit('update:modelValue', deviceId)
+}
+
+function clickImport() {
+  const button = document.querySelector('[data-test-id="import-submit"]') as HTMLElement
+  button.click()
+  return flushPromises()
+}
+
+function clickTab(value: string) {
+  const tab = document.querySelector(`[value="${value}"]`) as HTMLElement
+  tab.click()
+  return flushPromises()
+}
+
+describe('pluginImportDialog', () => {
+  let mockFetch: Mock<typeof fetch>
+
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    deviceStoreMock = asStore<ReturnType<typeof useDeviceStore>>({
+      devices: [{ id: 'device-1', name: 'Device 1' }],
+    })
+    mockFetch = stubFetch()
+  })
+
+  it('imports from a GitHub URL for the selected device', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({}))
+    const wrapper = mountDialog()
+    await flushPromises()
+
+    await clickTab('github')
+    await flushPromises()
+    await setInput('github-url', 'https://github.com/owner/repo')
+    await selectDevice(wrapper, 'device-1')
+
+    await clickImport()
+
+    expect(globalThis.fetch).toHaveBeenCalledWith('/api/plugins/import-github', expect.objectContaining({
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ githubUrl: 'https://github.com/owner/repo', deviceId: 'device-1' }),
+    }))
+    expect(wrapper.emitted('imported')).toHaveLength(1)
+    expect(wrapper.emitted('update:modelValue')).toContainEqual([false])
+  })
+
+  it('imports from a TRMNL recipe id for the selected device', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({}))
+    const wrapper = mountDialog()
+    await flushPromises()
+
+    await clickTab('recipe')
+    await flushPromises()
+    await setInput('recipe-id', '150460')
+    await selectDevice(wrapper, 'device-1')
+
+    await clickImport()
+
+    expect(globalThis.fetch).toHaveBeenCalledWith('/api/plugins/import-recipe', expect.objectContaining({
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ recipeId: '150460', deviceId: 'device-1' }),
+    }))
+    expect(wrapper.emitted('imported')).toHaveLength(1)
+  })
+
+  it('imports a file for the selected device', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({}))
+    const wrapper = mountDialog()
+    await flushPromises()
+
+    await selectDevice(wrapper, 'device-1')
+    await wrapper.findComponent(VFileInput).vm.$emit('update:model-value', [new File(['content'], 'plugin.zip')])
+
+    await clickImport()
+
+    expect(globalThis.fetch).toHaveBeenCalledWith('/api/plugins/import', expect.objectContaining({ method: 'POST' }))
+    const [, init] = mockFetch.mock.calls[0]
+    expect(init?.body).toBeInstanceOf(FormData)
+    expect(wrapper.emitted('imported')).toHaveLength(1)
+  })
+
+  it('requires the active tab\'s own field even if a leftover value from another tab enabled the button', async () => {
+    // The recipe tab was filled in first, which enables Import; switching to the (still
+    // empty) github tab must still fail with a github-specific message, not silently
+    // import the leftover recipe.
+    const wrapper = mountDialog()
+    await flushPromises()
+
+    await clickTab('recipe')
+    await flushPromises()
+    await setInput('recipe-id', '150460')
+    await clickTab('github')
+    await flushPromises()
+    await selectDevice(wrapper, 'device-1')
+
+    await clickImport()
+
+    expect(globalThis.fetch).not.toHaveBeenCalled()
+    expect(document.querySelector('[data-test-id="import-error"]')?.textContent).toContain('Please enter a GitHub URL')
+    expect(wrapper.emitted('imported')).toBeUndefined()
+  })
+
+  it('shows the error the API rejected the import with', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ message: 'Repository not found' }, false))
+    const wrapper = mountDialog()
+    await flushPromises()
+
+    await clickTab('github')
+    await flushPromises()
+    await setInput('github-url', 'https://github.com/owner/repo')
+    await selectDevice(wrapper, 'device-1')
+
+    await clickImport()
+
+    expect(document.querySelector('[data-test-id="import-error"]')?.textContent).toContain('Repository not found')
+    expect(wrapper.emitted('imported')).toBeUndefined()
+  })
+
+  it('resets its fields when cancelled', async () => {
+    const wrapper = mountDialog()
+    await flushPromises()
+
+    await clickTab('github')
+    await flushPromises()
+    await setInput('github-url', 'https://github.com/owner/repo')
+
+    const cancelBtn = Array.from(document.querySelectorAll('button')).find(btn => btn.textContent?.trim() === 'Cancel') as HTMLElement
+    cancelBtn.click()
+    await flushPromises()
+
+    expect(wrapper.emitted('update:modelValue')).toContainEqual([false])
+  })
+})

--- a/packages/ui/src/views/VirtualDeviceView.vue
+++ b/packages/ui/src/views/VirtualDeviceView.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { Device } from '@/types'
 import { mdiClipboardArrowRight, mdiSend, mdiSync } from '@mdi/js'
 import { computed, ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
@@ -148,21 +149,29 @@ watch(macInputTab, () => {
   }
 })
 
-watch(mac, () => {
+const deviceHeaderSources: { [K in keyof typeof customHeaders.value]: (device: Device) => string | undefined } = {
+  'battery-voltage': device => device.batteryVoltage,
+  'fw-version': device => device.fwVersion,
+  'refresh-rate': device => device.refreshRate?.toString(),
+  'rssi': device => device.rssi,
+  'user-agent': device => device.userAgent,
+  'width': device => device.width?.toString(),
+  'height': device => device.height?.toString(),
+  'model': device => device.reportedModel ?? undefined,
+}
+
+function syncHeadersFromSelectedDevice() {
   if (macInputTab.value !== 'device')
     return
   const device = deviceStore.devices.find(d => d.mac === mac.value)
   if (!device)
     return
-  customHeaders.value['battery-voltage'] = device.batteryVoltage || customHeaders.value['battery-voltage']
-  customHeaders.value['fw-version'] = device.fwVersion || customHeaders.value['fw-version']
-  customHeaders.value['refresh-rate'] = device.refreshRate?.toString() || customHeaders.value['refresh-rate']
-  customHeaders.value.rssi = device.rssi || customHeaders.value.rssi
-  customHeaders.value['user-agent'] = device.userAgent || customHeaders.value['user-agent']
-  customHeaders.value.width = device.width?.toString() || customHeaders.value.width
-  customHeaders.value.height = device.height?.toString() || customHeaders.value.height
-  customHeaders.value.model = device.reportedModel || customHeaders.value.model
-})
+  for (const key of Object.keys(deviceHeaderSources) as (keyof typeof customHeaders.value)[]) {
+    customHeaders.value[key] = deviceHeaderSources[key](device) || customHeaders.value[key]
+  }
+}
+
+watch(mac, syncHeadersFromSelectedDevice)
 </script>
 
 <template>

--- a/packages/ui/src/views/__test__/VirtualDeviceView.spec.ts
+++ b/packages/ui/src/views/__test__/VirtualDeviceView.spec.ts
@@ -1,0 +1,119 @@
+import type { useDeviceStore } from '@/stores/device'
+import type { Device } from '@/types'
+import { flushPromises, mount } from '@vue/test-utils'
+import rop from 'resize-observer-polyfill'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { VAutocomplete, VTextField } from 'vuetify/components'
+import vuetify from '@/plugins/vuetify'
+import { stubVisualViewport } from '@/test/browser'
+import { asStore } from '@/test/mockStore'
+import VirtualDeviceView from '../VirtualDeviceView.vue'
+
+globalThis.ResizeObserver = rop
+globalThis.visualViewport = globalThis.visualViewport || stubVisualViewport()
+
+globalThis.window.matchMedia = globalThis.window.matchMedia || function () {
+  return {
+    matches: false,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  }
+}
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ name: 'virtualDevice', params: {} }),
+}))
+
+let deviceStoreMock: ReturnType<typeof useDeviceStore>
+vi.mock('@/stores/device', () => ({
+  useDeviceStore: () => deviceStoreMock,
+}))
+
+const device: Device = {
+  id: 'device-1',
+  name: 'Kitchen',
+  friendlyId: 'kitchen',
+  mac: 'AA:BB:CC:DD:EE:FF',
+  apikey: 'key',
+  batteryVoltage: '3.9V',
+  fwVersion: '1.2.3',
+  refreshRate: 900,
+  rssi: '-50',
+  userAgent: 'device-agent',
+  width: 600,
+  height: 400,
+  reportedModel: 'v2',
+  mirrorEnabled: false,
+  mirrorMac: '',
+  mirrorApikey: '',
+  specialFunction: '',
+  sleepModeEnabled: false,
+  sleepScreenEnabled: false,
+  resetDevice: false,
+  updateFirmware: false,
+  lastSeen: '2026-01-01T00:00:00.000Z',
+}
+
+function mountView() {
+  return mount(VirtualDeviceView, {
+    attachTo: document.body,
+    global: { plugins: [vuetify] },
+  })
+}
+
+function headerValue(wrapper: ReturnType<typeof mountView>, label: string) {
+  return wrapper.findAllComponents(VTextField).find(c => c.props('label') === label)?.props('modelValue')
+}
+
+describe('virtualDeviceView', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    deviceStoreMock = asStore<ReturnType<typeof useDeviceStore>>({
+      devices: [device],
+      getById: vi.fn().mockReturnValue(undefined),
+    })
+  })
+
+  it('fills the device-derived headers when a device is picked from the device tab', async () => {
+    const wrapper = mountView()
+
+    await wrapper.get('[value="device"]').trigger('click')
+    await flushPromises()
+    await wrapper.findComponent(VAutocomplete).vm.$emit('update:modelValue', device.mac)
+    await flushPromises()
+
+    expect(headerValue(wrapper, 'battery-voltage')).toBe('3.9V')
+    expect(headerValue(wrapper, 'fw-version')).toBe('1.2.3')
+    expect(headerValue(wrapper, 'refresh-rate')).toBe('900')
+    expect(headerValue(wrapper, 'rssi')).toBe('-50')
+    expect(headerValue(wrapper, 'user-agent')).toBe('device-agent')
+    expect(headerValue(wrapper, 'width')).toBe('600')
+    expect(headerValue(wrapper, 'height')).toBe('400')
+    expect(headerValue(wrapper, 'model')).toBe('v2')
+  })
+
+  it('keeps the previous header value when the device does not report one', async () => {
+    const partialDevice: Device = { ...device, mac: 'FF:EE:DD:CC:BB:AA', batteryVoltage: undefined }
+    deviceStoreMock.devices = [partialDevice]
+    const wrapper = mountView()
+
+    await wrapper.get('[value="device"]').trigger('click')
+    await flushPromises()
+    await wrapper.findComponent(VAutocomplete).vm.$emit('update:modelValue', partialDevice.mac)
+    await flushPromises()
+
+    expect(headerValue(wrapper, 'battery-voltage')).toBe('4.2V')
+  })
+
+  it('does not sync headers while the mac tab is active', async () => {
+    const wrapper = mountView()
+
+    await wrapper.findComponent(VTextField).vm.$emit('update:modelValue', device.mac)
+    await flushPromises()
+
+    expect(headerValue(wrapper, 'battery-voltage')).toBe('4.2V')
+  })
+})


### PR DESCRIPTION
## What

Resolves the four fallow complexity findings baselined in #853:

- **PluginImportDialog.vue** (`importPlugin`, cyclomatic 14 → split): extracts `importFromFile`/`importFromGithub`/`importFromRecipe` (using the existing `apiRequest()` helper), dispatched from an `importBySource` lookup keyed by the active tab; `importPlugin` now just validates the device selection and dispatches.
- **ScreenScheduleDialog.vue** (`modelValue` watcher, cyclomatic 14 → split): extracts `scheduleToForm(schedule)`, with an early-return null guard (not `?.` chains, which fallow still counts as branches) so the helper itself stays under cyclomatic 10; the watcher just assigns from it.
- **PluginCard.vue** (`<template>`, cyclomatic 14/cognitive 18/207 lines → split): moves the action buttons, the assign dialog, the delete-confirm dialog, and the export snackbar into a new `PluginCardActions.vue` child; `PluginCard.vue` keeps only the title/description display.
- **VirtualDeviceView.vue** (`mac` watcher arrow, cyclomatic 11 → split): extracts a named `syncHeadersFromSelectedDevice` function backed by a `deviceHeaderSources` lookup table instead of eight chained `||` assignments.

Re-saved `.fallow-baselines/health.baseline.json` (`pnpm fallow:baseline`) — all four findings are gone, nothing new added. `dupes.baseline.json` also picked up an unrelated fingerprint-numbering refresh for a pre-existing `packages/api` test-fixture duplicate (same underlying clone, no new duplication) — it was already drifting out of sync with the live scan before this PR.

## Why

Smaller UI complexity findings flagged by the initial fallow scan; each file now sits under the cyclomatic/cognitive targets set in the issue.

## Test evidence

- `pnpm lint && pnpm type-check && pnpm test` — pass (313 tests, 58 files).
- `pnpm fallow:ci` — exit 0; the four targeted findings are gone from `.fallow-baselines/health.baseline.json`, and `npx fallow health` no longer lists any of the four target functions/templates.
- Added component-level Vitest coverage for the two files that previously had thin or no coverage: `PluginCardActions.spec.ts` (new, 11 tests covering edit/assign/toggle/export/delete) and `PluginImportDialog.spec.ts` (new, 6 tests covering all three import sources plus validation/error paths). `VirtualDeviceView.spec.ts` (new, 3 tests) covers the extracted header-sync function. `ScreenScheduleDialog.spec.ts` (pre-existing) stayed green unmodified through the refactor.
- `pnpm --filter ./packages/ui test:e2e` was attempted for the two files with template changes per the issue's verification note, but the suite cannot launch Chromium in this sandbox (`Target.setAutoAttach: Target closed` from puppeteer-core) — confirmed this is a pre-existing environment limitation, not caused by this change, by running the same suite against the unmodified base commit and getting an identical failure.

Closes #853

> *Opened by Kongroo, karakuri's Projects agent — Stage: implement*