### PR TITLE
refactor(api): reduce complexity in devices/ssrfGuard/plugin-data-source-mode/plugin-data-fetcher, add config coverage

### DIFF
--- a/.fallow-baselines/health.baseline.json
+++ b/.fallow-baselines/health.baseline.json
@@ -1,15 +1,5 @@
 {
   "finding_counts": {
-    "packages/api/src/config/config.ts": {
-      "crap_critical": {
-        "count": 1
-      }
-    },
-    "packages/api/src/devices/devices.service.ts": {
-      "crap_moderate": {
-        "count": 1
-      }
-    },
     "packages/api/src/devices/display.service.ts": {
       "complexity_critical": {
         "count": 2
@@ -32,22 +22,7 @@
         "count": 1
       }
     },
-    "packages/api/src/plugins/plugin-data-source-mode.ts": {
-      "complexity_moderate": {
-        "count": 1
-      }
-    },
     "packages/api/src/plugins/plugins.service.ts": {
-      "crap_moderate": {
-        "count": 1
-      }
-    },
-    "packages/api/src/plugins/services/plugin-data-fetcher.service.ts": {
-      "crap_moderate": {
-        "count": 1
-      }
-    },
-    "packages/api/src/utils/ssrfGuard.ts": {
       "crap_moderate": {
         "count": 1
       }

--- a/packages/api/src/config/__test__/config.spec.ts
+++ b/packages/api/src/config/__test__/config.spec.ts
@@ -1,0 +1,91 @@
+import process from 'node:process'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import config from '../config.js'
+
+const ENV_KEYS = [
+  'KUROSHIRO_PORT',
+  'KUROSHIRO_API_URL',
+  'KUROSHIRO_DEMO_MODE',
+  'KUROSHIRO_DB_HOST',
+  'KUROSHIRO_DB_PORT',
+  'KUROSHIRO_DB_DB',
+  'KUROSHIRO_DB_USER',
+  'KUROSHIRO_DB_PASSWORD',
+] as const
+
+describe('config', () => {
+  let originalEnv: Record<string, string | undefined>
+
+  beforeEach(() => {
+    originalEnv = Object.fromEntries(ENV_KEYS.map(key => [key, process.env[key]]))
+    ENV_KEYS.forEach(key => delete process.env[key])
+  })
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (originalEnv[key] === undefined)
+        delete process.env[key]
+      else
+        process.env[key] = originalEnv[key]
+    }
+  })
+
+  it('falls back to defaults when no env vars are set', () => {
+    expect(config()).toEqual({
+      port: 3000,
+      api_url: 'http://localhost:5173',
+      demo_mode: false,
+      database: {
+        host: 'localhost',
+        port: 5432,
+        database: 'test',
+        user: 'root',
+        password: 'root',
+      },
+    })
+  })
+
+  it('reads every value from its env var override', () => {
+    process.env.KUROSHIRO_PORT = '8080'
+    process.env.KUROSHIRO_API_URL = 'https://app.example.com'
+    process.env.KUROSHIRO_DEMO_MODE = 'true'
+    process.env.KUROSHIRO_DB_HOST = 'db.example.com'
+    process.env.KUROSHIRO_DB_PORT = '5433'
+    process.env.KUROSHIRO_DB_DB = 'kuroshiro'
+    process.env.KUROSHIRO_DB_USER = 'kuroshiro_user'
+    process.env.KUROSHIRO_DB_PASSWORD = 'secret'
+
+    expect(config()).toEqual({
+      port: 8080,
+      api_url: 'https://app.example.com',
+      demo_mode: true,
+      database: {
+        host: 'db.example.com',
+        port: 5433,
+        database: 'kuroshiro',
+        user: 'kuroshiro_user',
+        password: 'secret',
+      },
+    })
+  })
+
+  it('falls back to port 3000 when KUROSHIRO_PORT is not set', () => {
+    expect(config().port).toBe(3000)
+  })
+
+  it('falls back to port 3000 when KUROSHIRO_PORT is non-numeric', () => {
+    process.env.KUROSHIRO_PORT = 'not-a-number'
+    expect(config().port).toBe(3000)
+  })
+
+  it('only enables demo mode for the literal string "true"', () => {
+    process.env.KUROSHIRO_DEMO_MODE = 'false'
+    expect(config().demo_mode).toBe(false)
+
+    process.env.KUROSHIRO_DEMO_MODE = 'yes'
+    expect(config().demo_mode).toBe(false)
+
+    process.env.KUROSHIRO_DEMO_MODE = 'true'
+    expect(config().demo_mode).toBe(true)
+  })
+})

--- a/packages/api/src/devices/devices.service.ts
+++ b/packages/api/src/devices/devices.service.ts
@@ -45,7 +45,8 @@ export class DevicesService {
     Object.assign(dbDevice, attributes)
     this.assertSleepWindowConfigured(dbDevice)
     const before = { model: dbDevice.deviceModel?.name, palette: dbDevice.palette?.id }
-    await this.applyModelChanges(dbDevice, deviceModelName, paletteId)
+    await this.applyModelChange(dbDevice, deviceModelName)
+    await this.applyPaletteChange(dbDevice, paletteId)
     await this.applyFirmwareChanges(dbDevice, targetFirmwareId)
     const saved = await this.deviceRepository.save(dbDevice)
     if (before.model !== saved.deviceModel?.name || before.palette !== saved.palette?.id)
@@ -61,14 +62,17 @@ export class DevicesService {
     return true
   }
 
-  private async applyModelChanges(device: Device, deviceModelName?: string, paletteId?: string): Promise<void> {
-    if (deviceModelName !== undefined && deviceModelName !== device.deviceModel?.name) {
-      const model = await this.deviceModels.findByName(deviceModelName)
-      if (!model)
-        throw new BadRequestException(`Unknown device model: ${deviceModelName}`)
-      device.deviceModel = model
-      device.palette = null
-    }
+  private async applyModelChange(device: Device, deviceModelName?: string): Promise<void> {
+    if (deviceModelName === undefined || deviceModelName === device.deviceModel?.name)
+      return
+    const model = await this.deviceModels.findByName(deviceModelName)
+    if (!model)
+      throw new BadRequestException(`Unknown device model: ${deviceModelName}`)
+    device.deviceModel = model
+    device.palette = null
+  }
+
+  private async applyPaletteChange(device: Device, paletteId?: string): Promise<void> {
     if (paletteId !== undefined) {
       if (!device.deviceModel)
         throw new BadRequestException('Cannot set a palette on a device with no assigned device model')

--- a/packages/api/src/plugins/plugin-data-source-mode.ts
+++ b/packages/api/src/plugins/plugin-data-source-mode.ts
@@ -14,6 +14,8 @@ function isPresent(value: unknown): boolean {
   return value !== undefined && value !== null
 }
 
+type ModeViolationCheck = [fieldName: string, isViolation: boolean, message: string]
+
 /**
  * fetch and literal Data Sources have disjoint required fields; a Data
  * Source carrying a field from the mode it isn't is rejected rather than
@@ -22,39 +24,25 @@ function isPresent(value: unknown): boolean {
 export function dataSourceModeViolation(fields: DataSourceModeFields): string | null {
   const { mode = 'fetch', method, url, headers, body, transformJs, literalValue } = fields
 
-  if (mode === 'literal') {
-    // PluginDataSource.method is a non-nullable column defaulting to 'GET'
-    // (shared with fetch mode, which needs a real default there) — a
-    // literal-mode row loaded back from storage always carries 'GET' even
-    // though nothing ever asked for it, so only a caller-supplied
-    // *non*-default method counts as a real fetch-field violation here.
-    if (isPresent(method) && method !== 'GET') {
-      return 'A literal-mode Data Source cannot have a Method'
-    }
-    if (isPresent(url)) {
-      return 'A literal-mode Data Source cannot have a URL'
-    }
-    if (isPresent(headers)) {
-      return 'A literal-mode Data Source cannot have Headers'
-    }
-    if (isPresent(body)) {
-      return 'A literal-mode Data Source cannot have a Body'
-    }
-    if (isPresent(transformJs)) {
-      return 'A literal-mode Data Source cannot have a Transform'
-    }
-    if (!isPresent(literalValue)) {
-      return 'A literal-mode Data Source requires a Value'
-    }
-    return null
-  }
+  const checks: ModeViolationCheck[] = mode === 'literal'
+    ? [
+        // PluginDataSource.method is a non-nullable column defaulting to
+        // 'GET' (shared with fetch mode, which needs a real default there)
+        // — a literal-mode row loaded back from storage always carries
+        // 'GET' even though nothing ever asked for it, so only a
+        // caller-supplied *non*-default method counts as a real
+        // fetch-field violation here.
+        ['method', isPresent(method) && method !== 'GET', 'A literal-mode Data Source cannot have a Method'],
+        ['url', isPresent(url), 'A literal-mode Data Source cannot have a URL'],
+        ['headers', isPresent(headers), 'A literal-mode Data Source cannot have Headers'],
+        ['body', isPresent(body), 'A literal-mode Data Source cannot have a Body'],
+        ['transformJs', isPresent(transformJs), 'A literal-mode Data Source cannot have a Transform'],
+        ['literalValue', !isPresent(literalValue), 'A literal-mode Data Source requires a Value'],
+      ]
+    : [
+        ['literalValue', isPresent(literalValue), 'A fetch-mode Data Source cannot have a Value'],
+        ['url', !isPresent(url), 'A fetch-mode Data Source requires a URL'],
+      ]
 
-  if (isPresent(literalValue)) {
-    return 'A fetch-mode Data Source cannot have a Value'
-  }
-  if (!isPresent(url)) {
-    return 'A fetch-mode Data Source requires a URL'
-  }
-
-  return null
+  return checks.find(([, isViolation]) => isViolation)?.[2] ?? null
 }

--- a/packages/api/src/plugins/services/plugin-data-fetcher.service.ts
+++ b/packages/api/src/plugins/services/plugin-data-fetcher.service.ts
@@ -47,35 +47,40 @@ export class PluginDataFetcherService {
     body?: JsonObject,
     templateContext?: object,
   ): Promise<unknown> {
-    let resolvedUrl = url
-
-    // If URL contains Liquid template syntax, render it first
-    if (url.includes('{{') || url.includes('{%')) {
-      this.logger.debug(`Rendering URL template: ${url}`)
-      resolvedUrl = await this.renderer.render(url, templateContext || {})
-      this.logger.debug(`Resolved URL: ${resolvedUrl}`)
-    }
+    const resolvedUrl = await this.resolveUrl(url, templateContext)
 
     if (this.configService.get<boolean>('demo_mode'))
       assertPublicUrl(resolvedUrl)
 
+    const response = await fetch(resolvedUrl, this.buildRequestInit(method, headers, body))
+    return this.parseResponse(response)
+  }
+
+  // If the URL contains Liquid template syntax, render it first.
+  private async resolveUrl(url: string, templateContext?: object): Promise<string> {
+    if (!url.includes('{{') && !url.includes('{%'))
+      return url
+    this.logger.debug(`Rendering URL template: ${url}`)
+    const resolvedUrl = await this.renderer.render(url, templateContext || {})
+    this.logger.debug(`Resolved URL: ${resolvedUrl}`)
+    return resolvedUrl
+  }
+
+  private buildRequestInit(method: string, headers: Record<string, string>, body?: JsonObject): RequestInit {
     const options: RequestInit = {
       method,
       headers: method === 'POST' && body
         ? { 'Content-Type': 'application/json', ...headers }
         : headers,
     }
-
-    if (method === 'POST' && body) {
+    if (method === 'POST' && body)
       options.body = JSON.stringify(body)
-    }
+    return options
+  }
 
-    const response = await fetch(resolvedUrl, options)
-
-    if (!response.ok) {
+  private async parseResponse(response: Response): Promise<unknown> {
+    if (!response.ok)
       throw new Error(`HTTP error! status: ${response.status}`)
-    }
-
     return response.json()
   }
 }

--- a/packages/api/src/utils/__test__/ssrfGuard.spec.ts
+++ b/packages/api/src/utils/__test__/ssrfGuard.spec.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import { assertPublicUrl } from '../ssrfGuard.js'
+
+describe('assertPublicUrl', () => {
+  it('allows a public URL', () => {
+    expect(() => assertPublicUrl('https://api.example.com/data')).not.toThrow()
+  })
+
+  it('rejects an invalid URL', () => {
+    expect(() => assertPublicUrl('not a url')).toThrow('Invalid URL')
+  })
+
+  it('rejects localhost and internal hostnames', () => {
+    expect(() => assertPublicUrl('http://localhost/data')).toThrow(/internal hosts/)
+    expect(() => assertPublicUrl('http://metadata.google.internal/data')).toThrow(/internal hosts/)
+    expect(() => assertPublicUrl('http://my-service.internal/data')).toThrow(/internal hosts/)
+    expect(() => assertPublicUrl('http://box.local/data')).toThrow(/internal hosts/)
+  })
+
+  describe('ipv4 loopback (127.0.0.0/8)', () => {
+    it('rejects the range', () => {
+      expect(() => assertPublicUrl('http://127.0.0.1/data')).toThrow(/private IP ranges/)
+      expect(() => assertPublicUrl('http://127.255.255.255/data')).toThrow(/private IP ranges/)
+    })
+  })
+
+  describe('ipv4 10.0.0.0/8', () => {
+    it('rejects the range, including its upper boundary', () => {
+      expect(() => assertPublicUrl('http://10.0.0.0/data')).toThrow(/private IP ranges/)
+      expect(() => assertPublicUrl('http://10.255.255.255/data')).toThrow(/private IP ranges/)
+    })
+  })
+
+  describe('ipv4 172.16.0.0/12', () => {
+    it('rejects the range', () => {
+      expect(() => assertPublicUrl('http://172.16.0.0/data')).toThrow(/private IP ranges/)
+      expect(() => assertPublicUrl('http://172.31.255.255/data')).toThrow(/private IP ranges/)
+    })
+
+    it('allows the address just past the upper boundary', () => {
+      expect(() => assertPublicUrl('http://172.32.0.0/data')).not.toThrow()
+    })
+
+    it('allows the address just before the lower boundary', () => {
+      expect(() => assertPublicUrl('http://172.15.255.255/data')).not.toThrow()
+    })
+  })
+
+  describe('ipv4 192.168.0.0/16', () => {
+    it('rejects the range', () => {
+      expect(() => assertPublicUrl('http://192.168.0.0/data')).toThrow(/private IP ranges/)
+      expect(() => assertPublicUrl('http://192.168.255.255/data')).toThrow(/private IP ranges/)
+    })
+
+    it('allows a neighboring /16 that is not the private range', () => {
+      expect(() => assertPublicUrl('http://192.169.0.0/data')).not.toThrow()
+    })
+  })
+
+  describe('ipv4 169.254.0.0/16 (link-local)', () => {
+    it('rejects the range', () => {
+      expect(() => assertPublicUrl('http://169.254.0.1/data')).toThrow(/private IP ranges/)
+    })
+  })
+
+  describe('ipv6', () => {
+    it('rejects loopback and unique local addresses', () => {
+      expect(() => assertPublicUrl('http://[::1]/data')).toThrow(/private IP ranges/)
+      expect(() => assertPublicUrl('http://[fc00::1]/data')).toThrow(/private IP ranges/)
+      expect(() => assertPublicUrl('http://[fd00::1]/data')).toThrow(/private IP ranges/)
+    })
+
+    it('allows a public IPv6 address', () => {
+      expect(() => assertPublicUrl('http://[2001:4860:4860::8888]/data')).not.toThrow()
+    })
+  })
+})

--- a/packages/api/src/utils/ssrfGuard.ts
+++ b/packages/api/src/utils/ssrfGuard.ts
@@ -3,18 +3,26 @@ import net from 'node:net'
 const PRIVATE_HOSTNAMES = new Set(['localhost', 'metadata.google.internal'])
 const PRIVATE_HOSTNAME_SUFFIXES = ['.local', '.internal', '.localhost']
 
+// Inclusive [start, end] IPv4 ranges reserved for loopback, private networks,
+// and link-local addressing (RFC 5735 / RFC 3927).
+const PRIVATE_IPV4_RANGES: [start: string, end: string][] = [
+  ['127.0.0.0', '127.255.255.255'],
+  ['10.0.0.0', '10.255.255.255'],
+  ['172.16.0.0', '172.31.255.255'],
+  ['192.168.0.0', '192.168.255.255'],
+  ['169.254.0.0', '169.254.255.255'],
+]
+
+function ipv4ToInt(ip: string): number {
+  return ip.split('.').map(Number).reduce((acc, octet) => acc * 256 + octet, 0)
+}
+
 function isPrivateIpv4(ip: string): boolean {
   const parts = ip.split('.').map(Number)
   if (parts.length !== 4 || parts.some(Number.isNaN))
     return false
-  const [a, b] = parts
-  return (
-    a === 127
-    || a === 10
-    || (a === 172 && b >= 16 && b <= 31)
-    || (a === 192 && b === 168)
-    || (a === 169 && b === 254)
-  )
+  const value = ipv4ToInt(ip)
+  return PRIVATE_IPV4_RANGES.some(([start, end]) => value >= ipv4ToInt(start) && value <= ipv4ToInt(end))
 }
 
 function isPrivateIpv6(ip: string): boolean {

--- a/packages/api/src/utils/ssrfGuard.ts
+++ b/packages/api/src/utils/ssrfGuard.ts
@@ -3,26 +3,26 @@ import net from 'node:net'
 const PRIVATE_HOSTNAMES = new Set(['localhost', 'metadata.google.internal'])
 const PRIVATE_HOSTNAME_SUFFIXES = ['.local', '.internal', '.localhost']
 
+function ipv4ToInt(ip: string): number {
+  return ip.split('.').map(Number).reduce((acc, octet) => acc * 256 + octet, 0)
+}
+
 // Inclusive [start, end] IPv4 ranges reserved for loopback, private networks,
 // and link-local addressing (RFC 5735 / RFC 3927).
-const PRIVATE_IPV4_RANGES: [start: string, end: string][] = [
+const PRIVATE_IPV4_RANGES: [start: number, end: number][] = [
   ['127.0.0.0', '127.255.255.255'],
   ['10.0.0.0', '10.255.255.255'],
   ['172.16.0.0', '172.31.255.255'],
   ['192.168.0.0', '192.168.255.255'],
   ['169.254.0.0', '169.254.255.255'],
-]
-
-function ipv4ToInt(ip: string): number {
-  return ip.split('.').map(Number).reduce((acc, octet) => acc * 256 + octet, 0)
-}
+].map(([start, end]) => [ipv4ToInt(start), ipv4ToInt(end)])
 
 function isPrivateIpv4(ip: string): boolean {
   const parts = ip.split('.').map(Number)
   if (parts.length !== 4 || parts.some(Number.isNaN))
     return false
   const value = ipv4ToInt(ip)
-  return PRIVATE_IPV4_RANGES.some(([start, end]) => value >= ipv4ToInt(start) && value <= ipv4ToInt(end))
+  return PRIVATE_IPV4_RANGES.some(([start, end]) => value >= start && value <= end)
 }
 
 function isPrivateIpv6(ip: string): boolean {


### PR DESCRIPTION
## What

Fixes the 5 baselined moderate/critical fallow findings tracked in #854:

- `devices.service.ts` `applyModelChanges` — split into `applyModelChange` and `applyPaletteChange` (firmware handling was already its own method), each with a single responsibility.
- `ssrfGuard.ts` `isPrivateIpv4` — replaced the boolean chain with a table of `[start, end]` IPv4 ranges (precomputed once at module load) checked with `.some()`.
- `plugin-data-source-mode.ts` `dataSourceModeViolation` — drives the per-field checks from `[fieldName, isViolation, message]` tuples and `find()`s the first hit, keeping the `method !== 'GET'` special case and its comment as instructed.
- `plugin-data-fetcher.service.ts` `fetchData` — split request building (`resolveUrl`, `buildRequestInit`) from execution/error mapping (`parseResponse`).
- `config.ts` — no refactor (as the issue specified); added `config.spec.ts` covering the defaults and every env-var override, including non-numeric `KUROSHIRO_PORT` → 3000 and `KUROSHIRO_DEMO_MODE`.

`pnpm fallow:baseline` was run in this PR — the 5 findings above are gone from `.fallow-baselines/health.baseline.json` and no new findings were added (verified the diff touches only those 5 entries; `display.service.ts`, `mashup.service.ts`, `plugins.service.ts`, `usePluginPreview.ts`, and `PluginEditView.vue`, tracked in other issues, are untouched).

## Why

Fallow flagged these as moderate/critical complexity/CRAP hotspots on 2026-08-22; this closes out the checkboxes in #854.

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm type-check` — clean
- [x] `pnpm test` — 775 API tests + 313 UI tests pass, plus new coverage: `ssrfGuard.spec.ts` (boundary cases for every private range, including `10.255.255.255`, `172.32.0.0`, `192.169.0.0`) and `config.spec.ts` (defaults, overrides, non-numeric port, demo mode)
- [x] `pnpm fallow:ci` — passes
- [x] Two-axis code review (Standards + Spec) run against the merge-base with `origin/main`; the Spec review found no gaps, and the one Standards-axis nit (ssrfGuard re-parsing static range strings on every call) was fixed in a follow-up commit

Closes #854

> *Opened by Kongroo, karakuri's Projects agent — Stage: implement*