### PR TITLE
fix(docker): deploy pnpm-lock.yaml-pinned node_modules to the production image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,9 @@ RUN pnpm --filter ./packages/api run build && pnpm --filter ./packages/api run b
 # --no-optional: drops typeorm's optional peer on ts-node (otherwise pulled in because
 #   ts-node is a devDependency elsewhere in the workspace lockfile, dragging in
 #   ts-node/typescript/@swc-core for a CLI path this image never uses) and pg's optional
-#   pg-cloudflare (Cloudflare Workers transport, dead code on plain Node.js). Nothing
-#   else in the runtime tree declares an optionalDependency.
+#   pg-cloudflare (Cloudflare Workers transport, dead code on plain Node.js). typeorm also
+#   marks pg itself optional (one of many DB-driver peers), but pg stays installed since
+#   it's a direct runtime dependency of packages/api independent of that peer flag.
 RUN pnpm --filter ./packages/api deploy --legacy --prod --no-optional --ignore-scripts /prod/api
 
 # Stage 3: Production image

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,16 @@ COPY pnpm-workspace.yaml package.json pnpm-lock.yaml ./
 RUN corepack enable && pnpm install --frozen-lockfile
 RUN pnpm --filter ./packages/api run build && pnpm --filter ./packages/api run build:migrations
 
+# Deploy the api's production node_modules, pinned exactly to pnpm-lock.yaml.
+# --legacy: this workspace doesn't inject workspace packages (see the kuroshiro-shared
+#   note below), which pnpm's default deploy implementation requires.
+# --no-optional: drops typeorm's optional peer on ts-node (otherwise pulled in because
+#   ts-node is a devDependency elsewhere in the workspace lockfile, dragging in
+#   ts-node/typescript/@swc-core for a CLI path this image never uses) and pg's optional
+#   pg-cloudflare (Cloudflare Workers transport, dead code on plain Node.js). Nothing
+#   else in the runtime tree declares an optionalDependency.
+RUN pnpm --filter ./packages/api deploy --legacy --prod --no-optional --ignore-scripts /prod/api
+
 # Stage 3: Production image
 FROM node:24-alpine AS production
 WORKDIR /app
@@ -35,20 +45,18 @@ RUN apk add --no-cache \
     giflib-dev \
     tiff-dev
 
-# Copy api bundle and static files only
-COPY --from=api-build /app/pnpm-workspace.yaml ./
-COPY --from=api-build /app/package.json ./
+# Copy api bundle, its lockfile-pinned runtime node_modules, and static files only.
+# node_modules here comes straight from `pnpm deploy` in api-build, so it is not
+# reinstalled in this stage and cannot drift from pnpm-lock.yaml. The api's workspace
+# devDependencies (e.g. kuroshiro-shared) are bundled into dist at build time and must
+# not be reintroduced here.
+COPY --from=api-build /prod/api/node_modules ./node_modules
 COPY --from=api-build /app/packages/api/dist ./dist
 COPY --from=ui-build /app/packages/ui/dist ./public
 
 # Copy entrypoint
 COPY entrypoint.sh ./entrypoint.sh
 RUN chmod +x ./entrypoint.sh
-
-# The api's workspace devDependencies are bundled into dist at build time and cannot
-# resolve here, since no workspace packages are copied into this stage
-COPY packages/api/package.json ./package.json
-RUN corepack enable && pnpm pkg delete devDependencies && pnpm install --prod --ignore-scripts
 
 # Use tini as the entrypoint
 ENTRYPOINT ["/sbin/tini", "--"]


### PR DESCRIPTION
## What

The production Docker stage installed runtime deps with a fresh `pnpm install --prod`, never consulting `pnpm-lock.yaml`. Ranged catalog specs (`adm-zip`, `js-yaml`, `liquidjs`, `multer`, `node-cron`, `vm2`) could resolve to whatever the registry served at build time, independent of what CI locked/tested/type-checked.

## Why

`vm2` sandboxes user-authored plugin code, so a silent minor bump there — with no commit, PR, or changelog entry — is exactly the kind of change that should go through review before shipping. The issue reproduced this drift locally on 2026-09-02: `vm2` pinned to `3.11.8` in the lockfile, but `3.12.0` landed in the built image.

## How

- `api-build` now runs `pnpm --filter ./packages/api deploy --legacy --prod --no-optional --ignore-scripts /prod/api` after the build step, producing a `node_modules` resolved straight from the already-verified `pnpm-lock.yaml`.
  - `--legacy`: this workspace doesn't inject workspace packages, which pnpm's default deploy implementation requires.
  - `--no-optional`: drops `typeorm`'s optional peer on `ts-node` (otherwise pulled in because `ts-node` is a devDependency elsewhere in the workspace lockfile, dragging `ts-node`/`typescript`/`@swc-core` into the image for a CLI path it never exercises) and `pg`'s optional `pg-cloudflare` (Cloudflare Workers transport, dead code on plain Node.js — confirmed by reading `pg`'s `lib/stream.js`, which only requires it under a Cloudflare Workers runtime check). No other runtime dependency declares an `optionalDependency`.
- Stage 3 now copies that `node_modules` directly (`COPY --from=api-build /prod/api/node_modules ./node_modules`) instead of reinstalling, and no longer needs `pnpm`, `pnpm-workspace.yaml`, or `package.json` at all.
- Removes the dead `COPY --from=api-build /app/package.json ./` that stage 3 immediately overwrote ten lines later.

## Test evidence

No Docker daemon is available in this sandbox, so each `Dockerfile` `RUN`/`COPY` step was replayed by hand against scratch copies of the repo:

- `pnpm --filter ./packages/api deploy --legacy --prod --no-optional --ignore-scripts <dir>` produces a `node_modules` whose `adm-zip`/`js-yaml`/`liquidjs`/`multer`/`node-cron`/`pg`/`typeorm`/`vm2`/`puppeteer` versions match the `packages/api` importer in `pnpm-lock.yaml` **exactly** (`vm2` → `3.11.8`, reproducing and fixing the reported drift).
- No `kuroshiro-shared` and no `ts-node`/`typescript`/`@swc-core` end up in that `node_modules` (confirms the #910 regression stays fixed and the ts-node peer-drag is avoided).
- Size is on par with the previous `pnpm install --prod` output (~121MB either way) — no meaningful image regression.
- Assembling the stage-3 layout (`node_modules` + `dist` + `entrypoint.sh`) and running `node dist/main.js` reaches `Starting Nest application...` with all modules initialized, then retries with `ECONNREFUSED` as expected without a database.
- `npx typeorm migration:run -d dist/src/config/typeorm.config.js` resolves the local `typeorm` binary from `node_modules/.bin` and fails with the same `ECONNREFUSED`, confirming `typeorm`/`pg` are genuinely present at runtime.
- `pnpm run type-check` and `pnpm run -r type-check` pass (no application code changed).

Docker itself (multi-stage build, multi-arch via QEMU/buildx) should still be validated by CI on this PR since it isn't exercisable locally here.

Closes #912

> *Opened by Kongroo, karakuri's Projects agent — Stage: implement*